### PR TITLE
Improve CSS only HMR by applying scoping class to every element

### DIFF
--- a/packages/vite-plugin-svelte/package.json
+++ b/packages/vite-plugin-svelte/package.json
@@ -40,7 +40,7 @@
     "require-relative": "^0.8.7",
     "slash": "^3.0.0",
     "source-map": "^0.7.3",
-    "svelte-hmr": "^0.13.0"
+    "svelte-hmr": "^0.14.0"
   },
   "peerDependencies": {
     "svelte": "^3.35.0",

--- a/packages/vite-plugin-svelte/src/utils/compile.ts
+++ b/packages/vite-plugin-svelte/src/utils/compile.ts
@@ -1,5 +1,5 @@
 import { CompileOptions, PreprocessorGroup, Processed, ResolvedOptions } from './options';
-import { compile, preprocess, walk, parse } from 'svelte/compiler';
+import { compile, preprocess, walk } from 'svelte/compiler';
 // @ts-ignore
 import { createMakeHot } from 'svelte-hmr';
 import { SvelteRequest } from './id';
@@ -46,12 +46,7 @@ const _createCompileSvelte = (makeHot: Function, extraPreprocessors: Preprocesso
 			if (preprocessed.map) finalCompilerOptions.sourcemap = preprocessed.map;
 		}
 
-		let codeToCompile = preprocessed ? preprocessed.code : code;
-		if (!options.disableCssHmr) {
-			codeToCompile = injectScopeEverythingCssRule(codeToCompile);
-		}
-
-		const compiled = compile(codeToCompile, finalCompilerOptions);
+		const compiled = compile(preprocessed ? preprocessed.code : code, finalCompilerOptions);
 
 		(compiled.warnings || []).forEach((warning) => {
 			if (!emitCss && warning.code === 'css-unused-selector') return;
@@ -104,12 +99,6 @@ function buildMakeHot(options: ResolvedOptions) {
 		const adapter = options?.hot?.adapter;
 		return createMakeHot({ walk, hotApi, adapter, hotOptions: options.hot });
 	}
-}
-
-function injectScopeEverythingCssRule(code: string) {
-	const { css } = parse(code);
-	if (!css || !css.content) return code;
-	return code.slice(0, css.content.end) + '*{}' + code.slice(css.content.end);
 }
 
 export function createCompileSvelte(options: ResolvedOptions, config: ResolvedConfig) {

--- a/packages/vite-plugin-svelte/src/utils/preprocess.ts
+++ b/packages/vite-plugin-svelte/src/utils/preprocess.ts
@@ -109,6 +109,12 @@ export function buildExtraPreprocessors(options: ResolvedOptions, config: Resolv
 	if (options.useVitePreprocess) {
 		extraPreprocessors.push(createVitePreprocessorGroup(config, options));
 	}
+	if (options.hot && !options.disableCssHmr) {
+		const scopeEverythingPreprocessor: PreprocessorGroup = {
+			style: ({ content }) => ({ code: content + ' *{}' })
+		};
+		extraPreprocessors.push(scopeEverythingPreprocessor);
+	}
 	// TODO
 	/*
   const windiCssPlugin = config.plugins.find(p => p.name === 'vite-plugin-windicss:css');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -223,7 +223,7 @@ importers:
       require-relative: 0.8.7
       slash: 3.0.0
       source-map: 0.7.3
-      svelte-hmr: 0.13.0_svelte@3.35.0
+      svelte-hmr: 0.14.0_svelte@3.35.0
     devDependencies:
       '@types/debug': 4.1.5
       '@types/es-module-lexer': 0.3.0
@@ -254,7 +254,7 @@ importers:
       slash: ^3.0.0
       source-map: ^0.7.3
       svelte: ^3.35.0
-      svelte-hmr: ^0.13.0
+      svelte-hmr: ^0.14.0
       vite: ^2.1.0
 lockfileVersion: 5.2
 packages:
@@ -8662,10 +8662,19 @@ packages:
   /svelte-hmr/0.13.0_svelte@3.35.0:
     dependencies:
       svelte: 3.35.0
+    dev: true
     peerDependencies:
       svelte: '>=3.19.0'
     resolution:
       integrity: sha512-P7oHUgV9k87ZegcomUwMzkQ/JkeUTOMJ4tXPkyEdgHozEQEraYHkpJuPtVlN8fNY+gVAlRUaohsD3Ipiql5lDw==
+  /svelte-hmr/0.14.0_svelte@3.35.0:
+    dependencies:
+      svelte: 3.35.0
+    dev: false
+    peerDependencies:
+      svelte: '>=3.19.0'
+    resolution:
+      integrity: sha512-Rc4w11U+U30m/cHqOJ/xioFSEAY5fd5muiQC7FL6XJuJAuB2OIJoEZl3KEJR2uO1/f4Bw0PdrugtbxcngSsOtQ==
   /svelte-preprocess/4.6.9_svelte@3.35.0+typescript@4.2.3:
     dependencies:
       '@types/pug': 2.0.4


### PR DESCRIPTION
Also bumps svelte-hmr to 0.14.0, to guarantee stable HMR transform code with `injectCss: false` (and `injectCss` has been changed to `false` in this version).