### PR TITLE
fix: do not preserve type imports (WIP)

### DIFF
--- a/.changeset/dry-cameras-press.md
+++ b/.changeset/dry-cameras-press.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+fix: do not preserve types unless useVitePreprocess option is true

--- a/packages/playground/ts-type-import/__tests__/ts-type-import.spec.ts
+++ b/packages/playground/ts-type-import/__tests__/ts-type-import.spec.ts
@@ -1,0 +1,17 @@
+import { isBuild, getText, editFileAndWaitForHmrComplete } from '../../testUtils';
+
+test('should render App', async () => {
+	expect(await getText('#hello')).toBe('Hello world');
+});
+
+if (!isBuild) {
+	describe('hmr', () => {
+		const updateApp = editFileAndWaitForHmrComplete.bind(null, 'src/App.svelte');
+
+		test('should update App', async () => {
+			expect(await getText('#hello')).toBe('Hello world');
+			await updateApp((content) => content.replace('world', 'foo'));
+			expect(await getText('#hello')).toBe('Hello foo');
+		});
+	});
+}

--- a/packages/playground/ts-type-import/index.html
+++ b/packages/playground/ts-type-import/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Test</title>
+	</head>
+	<body>
+		<script src="/src/index.ts" type="module"></script>
+	</body>
+</html>

--- a/packages/playground/ts-type-import/package.json
+++ b/packages/playground/ts-type-import/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "playground-ts-type-import",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "serve": "vite preview"
+  },
+  "devDependencies": {
+    "@sveltejs/vite-plugin-svelte": "workspace:*",
+    "@tsconfig/svelte": "^1.0.10",
+    "@types/node": "^14.14.35",
+    "svelte-preprocess": "^4.6.9",
+    "vite": "^2.1.2"
+  }
+}

--- a/packages/playground/ts-type-import/src/App.svelte
+++ b/packages/playground/ts-type-import/src/App.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	let s: string = 'world';
+</script>
+
+<div id="hello">Hello {s}</div>

--- a/packages/playground/ts-type-import/src/index.ts
+++ b/packages/playground/ts-type-import/src/index.ts
@@ -1,7 +1,13 @@
 import { test, Test } from './lib';
+import App from './App.svelte';
 
 main();
 
 export function main({ arg = true }: Test = {}): void {
-	if (arg) test();
+	if (arg && test()) {
+		// only create app when test worked
+		const app = new App({
+			target: document.body
+		});
+	}
 }

--- a/packages/playground/ts-type-import/src/index.ts
+++ b/packages/playground/ts-type-import/src/index.ts
@@ -1,0 +1,7 @@
+import { test, Test } from './lib';
+
+main();
+
+export function main({ arg = true }: Test = {}): void {
+	if (arg) test();
+}

--- a/packages/playground/ts-type-import/src/lib.ts
+++ b/packages/playground/ts-type-import/src/lib.ts
@@ -2,6 +2,6 @@ export interface Test {
 	arg?: boolean;
 }
 
-export function test(): void {
-	console.log('la');
+export function test(): boolean {
+	return Date.now() > 1;
 }

--- a/packages/playground/ts-type-import/src/lib.ts
+++ b/packages/playground/ts-type-import/src/lib.ts
@@ -1,0 +1,7 @@
+export interface Test {
+	arg?: boolean;
+}
+
+export function test(): void {
+	console.log('la');
+}

--- a/packages/playground/ts-type-import/svelte.config.js
+++ b/packages/playground/ts-type-import/svelte.config.js
@@ -1,0 +1,7 @@
+const sveltePreprocess = require('svelte-preprocess');
+
+module.exports = {
+	// Consult https://github.com/sveltejs/svelte-preprocess
+	// for more information about preprocessors
+	preprocess: sveltePreprocess()
+};

--- a/packages/playground/ts-type-import/tsconfig.json
+++ b/packages/playground/ts-type-import/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@tsconfig/svelte/tsconfig.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+}

--- a/packages/playground/ts-type-import/vite.config.js
+++ b/packages/playground/ts-type-import/vite.config.js
@@ -2,8 +2,7 @@ const svelte = require('@sveltejs/vite-plugin-svelte');
 const { defineConfig } = require('vite');
 
 module.exports = defineConfig(() => {
-	const { preprocess } = require('./svelte.config');
 	return {
-		plugins: [svelte({ preprocess })]
+		plugins: [svelte()]
 	};
 });

--- a/packages/playground/ts-type-import/vite.config.js
+++ b/packages/playground/ts-type-import/vite.config.js
@@ -1,0 +1,9 @@
+const svelte = require('@sveltejs/vite-plugin-svelte');
+const { defineConfig } = require('vite');
+
+module.exports = defineConfig(() => {
+	const { preprocess } = require('./svelte.config');
+	return {
+		plugins: [svelte({ preprocess })]
+	};
+});

--- a/packages/vite-plugin-svelte/src/index.ts
+++ b/packages/vite-plugin-svelte/src/index.ts
@@ -62,13 +62,6 @@ export default function vitePluginSvelte(inlineOptions?: Partial<Options>): Plug
 
 			// extra vite config
 			const extraViteConfig = {
-				esbuild: {
-					tsconfigRaw: {
-						compilerOptions: {
-							importsNotUsedAsValues: 'preserve'
-						}
-					}
-				},
 				optimizeDeps: {
 					exclude: [...SVELTE_IMPORTS]
 				},

--- a/packages/vite-plugin-svelte/src/index.ts
+++ b/packages/vite-plugin-svelte/src/index.ts
@@ -8,7 +8,13 @@ import { handleHotUpdate } from './handleHotUpdate';
 import { log } from './utils/log';
 import { createCompileSvelte } from './utils/compile';
 import { buildIdParser, IdParser } from './utils/id';
-import { validateInlineOptions, Options, ResolvedOptions, resolveOptions, PreprocessorGroup } from './utils/options';
+import {
+	validateInlineOptions,
+	Options,
+	ResolvedOptions,
+	resolveOptions,
+	PreprocessorGroup
+} from './utils/options';
 import { VitePluginSvelteCache } from './utils/VitePluginSvelteCache';
 
 import { SVELTE_IMPORTS, SVELTE_RESOLVE_MAIN_FIELDS } from './utils/constants';
@@ -29,7 +35,7 @@ export {
 declare module 'vite' {
 	// eslint-disable-next-line no-unused-vars
 	interface Plugin {
-		sveltePreprocess?: PreprocessorGroup
+		sveltePreprocess?: PreprocessorGroup;
 	}
 }
 
@@ -61,7 +67,7 @@ export default function vitePluginSvelte(inlineOptions?: Partial<Options>): Plug
 			}
 
 			// extra vite config
-			const extraViteConfig = {
+			const extraViteConfig: Partial<UserConfig> = {
 				optimizeDeps: {
 					exclude: [...SVELTE_IMPORTS]
 				},
@@ -70,6 +76,17 @@ export default function vitePluginSvelte(inlineOptions?: Partial<Options>): Plug
 					dedupe: [...SVELTE_IMPORTS]
 				}
 			};
+			// needed to transform svelte files with component imports
+			// can cause issues with other typescript files, see https://github.com/sveltejs/vite-plugin-svelte/pull/20
+			if (inlineOptions?.useVitePreprocess) {
+				extraViteConfig.esbuild = {
+					tsconfigRaw: {
+						compilerOptions: {
+							importsNotUsedAsValues: 'preserve'
+						}
+					}
+				};
+			}
 			log.debug('additional vite config', extraViteConfig);
 			return extraViteConfig as Partial<UserConfig>;
 		},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,6 +175,19 @@ importers:
       svelte: ^3.35.0
       svelte-hmr: ^0.13.0
       vite: ^2.1.2
+  packages/playground/ts-type-import:
+    devDependencies:
+      '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte
+      '@tsconfig/svelte': 1.0.10
+      '@types/node': 14.14.35
+      svelte-preprocess: 4.6.9_svelte@3.35.0+typescript@4.2.3
+      vite: 2.1.2
+    specifiers:
+      '@sveltejs/vite-plugin-svelte': workspace:*
+      '@tsconfig/svelte': ^1.0.10
+      '@types/node': ^14.14.35
+      svelte-preprocess: ^4.6.9
+      vite: ^2.1.2
   packages/playground/vite-ssr:
     devDependencies:
       '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte


### PR DESCRIPTION
Hello,

I'm trying this plugin on a real-world project and the first thing to say is, it works very well, what a developer experience!

I noticed something that when I enable this plugin on a vite project (even without any svelte files): it breaks a lot of TypeScript modules because it preserve type imports.

Here is a little reproductible scenario:

```typescript
// lib.ts
export interface Test {
    arg?: boolean;
}

export function test(): void {
    console.log('la');
}

// index.ts
import { test, Test } from './lib';

main();

export function main({ arg = true }: Test = {}): void {
    if (arg) test();
}
```

If you compile this app with vite without `@sveltejs/vite-plugin-svelte`, it works as expected, the result would be:

```javascript
function test() {
    console.log('la');
}

main();

function main({ arg = true } = {}) {
    if (arg) test();
}
```

If you enable `@sveltejs/vite-plugin-svelte`, this will break with one of the following Error:
```
- runtime (dev): Uncaught SyntaxError: The requested module '/lib.ts' does not provide an export named 'Test'
- compile-time (build): Non-existent export 'Test' is imported from /lib.ts
```

**You can reproduce this error by installing the playground I embedded in this PR**

----

After a first inspection, I noticed that this plugin enforce the `importsNotUsedAsValues` Typescript compiler option with value `preserve`. This force TypeScript users to separate `type imports` from `value imports` using the strict syntax: `import type`. It can be a real problem on large TypeScript codebases because it force the developer to import its modules twice.

I'm not sure if there is a good reason about this but when I comment this line, it does not impact my project and it resolves this issue on all `.ts` files of my project (read below about `.svelte` files).

### Important Note

I also noticed that the same issue occured on `.svelte` files using this plugin. This is not the case using the rollup plugin. So when I switch a project (with a lot of TypeScript) from `rollup-plugin-svelte` to `vite-plugin-svelte`, the project breaks because of type imports.

This fix does not resolve the issue inside `.svelte` files. I'm not sure if this plugin is responsible of this or if the issue comes from `svelte-preprocess`.

Any idea?

*I will investigate on this and give you more feedbacks*.

Thanks again