### PR TITLE
disable svelte-hmr overlay

### DIFF
--- a/.changeset/lemon-toes-relax.md
+++ b/.changeset/lemon-toes-relax.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+disable svelte-hmr overlay by default

--- a/packages/vite-plugin-svelte/src/utils/compile.ts
+++ b/packages/vite-plugin-svelte/src/utils/compile.ts
@@ -97,7 +97,12 @@ function buildMakeHot(options: ResolvedOptions) {
 		const hotApi = options?.hot?.hotApi;
 		// @ts-ignore
 		const adapter = options?.hot?.adapter;
-		return createMakeHot({ walk, hotApi, adapter, hotOptions: options.hot });
+		return createMakeHot({
+			walk,
+			hotApi,
+			adapter,
+			hotOptions: { noOverlay: true, ...(options.hot as object) }
+		});
 	}
 }
 


### PR DESCRIPTION
`svelte-hmr` overlay has to go, because it's not visually aligned with Vite's one and, also, it risks creating confusion as to what is happening for end users.

From what I have seen, the two overlays don't really conflict (as in being stacked one over the other), because they don't catch the same type of errors. So, maybe we can reflect on feeding HMR runtime errors to Vite's overlay but, to be honest, that's not something I'm sure about. Mixing build and runtime errors in the same overlay might create even more confusion.

On the opposite, I would be inclined to rework svelte-hmr to reduce the number of try/catch in there, so that errors flow more "normally" (that is, the same way as when there's no HMR machinery) -- at least when overlay is turned off by option. That seems more ecological, since that's what the user would get without HMR. (This overlay had been added to work around HMR limitations of some tools initially, but Vite seems to have huge error recuperation capabilities, and doesn't seem to suffer those limitations.)

Ah! And, regarding the PR, I've implemented it so that the overlay disabled by default can be enabled back as an opt-in by a user who know what they do, and really want it. That's because, again, they're not the same type of errors, and flashing runtime errors to the browser might actually be desirable to someone who understands the situation.