### PR TITLE
Add docs on importing third-party Svelte libraries

### DIFF
--- a/packages/vite-plugin-svelte/README.md
+++ b/packages/vite-plugin-svelte/README.md
@@ -38,6 +38,24 @@ It supports all options from rollup-plugin-svelte and some additional options to
 
 For more Information check [options.ts](src/utils/options.ts)
 
+## Importing third-party Svelte libraries
+
+When importing any third-party libraries that uses Svelte's lifecycle API, e.g. `onMount`, `setContext`, and others, they need to be excluded from Vite's dependency pre-bundling process:
+
+```js
+// vite.config.js
+{
+	plugins: [svelte()],
+	optimizeDeps: {
+		exclude: ['svelte-library']
+	}
+}
+```
+
+This is needed because Vite's dependency pre-bundling doesn't deduplicate the Svelte instance, resulting in multiple Svelte instance running at once, causing errors like `Function called outside component initialization`.
+
+If you're unsure whether a library uses the lifecycle API, place it in `optimizeDeps.exclude` and you'll be fine. The team is working on removing this limitation soon.
+
 ## Integrations for other vite plugins
 
 ### Add an extra preprocessor


### PR DESCRIPTION
Am guilty of knowing this trick, and not announcing this sooner. Alas I pulled the plug :smile: 

Added a section about using `optimizeDeps.exclude`. I know there are plans to remove this caveat soon, but I'm not sure when. In the mean time, it would be great to document this so people don't get frustrated by Svelte's ecosystem.

Feel free to edit the docs!

Note: We could have this info in SvelteKit's FAQ too.