### PR TITLE
fix: update svelte-hmr to ^0.14.5 

### DIFF
--- a/.changeset/cuddly-maps-dance.md
+++ b/.changeset/cuddly-maps-dance.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+update svelte-hmr to ^0.14.5 to fix hmr reordering issue introduced by a change in svelte 3.38.3

--- a/packages/vite-plugin-svelte/package.json
+++ b/packages/vite-plugin-svelte/package.json
@@ -49,7 +49,7 @@
     "kleur": "^4.1.4",
     "magic-string": "^0.25.7",
     "require-relative": "^0.8.7",
-    "svelte-hmr": "^0.14.5-0"
+    "svelte-hmr": "^0.14.5"
   },
   "peerDependencies": {
     "svelte": "^3.34.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -331,7 +331,7 @@ importers:
       require-relative: ^0.8.7
       rollup: ^2.53.0
       svelte: ^3.38.3
-      svelte-hmr: ^0.14.5-0
+      svelte-hmr: ^0.14.5
       tsup: ^4.12.5
       vite: ^2.4.1
     dependencies:
@@ -340,7 +340,7 @@ importers:
       kleur: 4.1.4
       magic-string: 0.25.7
       require-relative: 0.8.7
-      svelte-hmr: 0.14.5-0_svelte@3.38.3
+      svelte-hmr: 0.14.5_svelte@3.38.3
     devDependencies:
       '@types/debug': 4.1.6
       esbuild: 0.12.15
@@ -7118,8 +7118,8 @@ packages:
       supports-color: 7.2.0
     dev: true
 
-  /svelte-hmr/0.14.5-0_svelte@3.38.3:
-    resolution: {integrity: sha512-shoJ+CoL9m3+qx9miVJ8J7cf9I8a0NQuyXccUXjy7DExfNmhAu0Cg+ob5cHfVCiRjRtQzW2LrmOGl7lgy/XL5w==}
+  /svelte-hmr/0.14.5_svelte@3.38.3:
+    resolution: {integrity: sha512-3O+kkbT1XKAomKB0LRcdY8JUTzONoNZ8rSH4iEdG7piIYsw+KkXpTkbbU1Sc1yPY4onfXkmCrHElYsxr0V1Snw==}
     peerDependencies:
       svelte: '>=3.19.0'
     dependencies:


### PR DESCRIPTION
to fix dom reordering issue on hmr introduced in svelte 3.38.3