### PR TITLE
feat: import svelte types

### DIFF
--- a/.changeset/famous-lemons-draw.md
+++ b/.changeset/famous-lemons-draw.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+import svelte types instead of duplicating them

--- a/packages/vite-plugin-svelte/package.json
+++ b/packages/vite-plugin-svelte/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "dev": "pnpm run build:ci -- --watch src",
     "build:ci": "rimraf dist && tsup-node src/index.ts --format esm,cjs --no-splitting",
-    "build": "pnpm run build:ci -- --dts --dts-resolve --sourcemap"
+    "build": "pnpm run build:ci -- --dts --sourcemap"
   },
   "engines": {
     "node": "^12.20 || ^14.13.1 || >= 16"

--- a/packages/vite-plugin-svelte/src/utils/options.ts
+++ b/packages/vite-plugin-svelte/src/utils/options.ts
@@ -429,7 +429,7 @@ export interface ResolvedOptions extends Options {
 	server?: ViteDevServer;
 }
 
-export { CompileOptions, Processed, MarkupPreprocessor, Preprocessor, PreprocessorGroup };
+export type { CompileOptions, Processed, MarkupPreprocessor, Preprocessor, PreprocessorGroup };
 
 export type ModuleFormat = NonNullable<CompileOptions['format']>;
 

--- a/packages/vite-plugin-svelte/src/utils/options.ts
+++ b/packages/vite-plugin-svelte/src/utils/options.ts
@@ -3,6 +3,15 @@ import { ConfigEnv, UserConfig, ViteDevServer } from 'vite';
 import { log } from './log';
 import { loadSvelteConfig } from './load-svelte-config';
 import { SVELTE_HMR_IMPORTS, SVELTE_IMPORTS, SVELTE_RESOLVE_MAIN_FIELDS } from './constants';
+// eslint-disable-next-line node/no-missing-import
+import { CompileOptions } from 'svelte/types/compiler/interfaces';
+import {
+	MarkupPreprocessor,
+	Preprocessor,
+	PreprocessorGroup,
+	Processed
+	// eslint-disable-next-line node/no-missing-import
+} from 'svelte/types/compiler/preprocess';
 
 const knownOptions = new Set([
 	'configFile',
@@ -420,63 +429,11 @@ export interface ResolvedOptions extends Options {
 	server?: ViteDevServer;
 }
 
-// TODO import from appropriate places
-export declare type ModuleFormat = 'esm' | 'cjs';
+export { CompileOptions, Processed, MarkupPreprocessor, Preprocessor, PreprocessorGroup };
 
-export interface CompileOptions {
-	format?: ModuleFormat;
-	name?: string;
-	filename?: string;
-	generate?: 'dom' | 'ssr' | false;
-	sourcemap?: object | string;
-	outputFilename?: string;
-	cssOutputFilename?: string;
-	sveltePath?: string;
-	dev?: boolean;
-	accessors?: boolean;
-	immutable?: boolean;
-	hydratable?: boolean;
-	legacy?: boolean;
-	customElement?: boolean;
-	tag?: string;
-	css?: boolean;
-	loopGuardTimeout?: number;
-	namespace?: string;
-	preserveComments?: boolean;
-	preserveWhitespace?: boolean;
-	cssHash?: CssHashGetter;
-}
+export type ModuleFormat = NonNullable<CompileOptions['format']>;
 
-export interface Processed {
-	code: string;
-	map?: string | object;
-	dependencies?: string[];
-	toString?: () => string;
-}
-
-export declare type CssHashGetter = (args: {
-	name: string;
-	filename: string | undefined;
-	css: string;
-	hash: (input: string) => string;
-}) => string;
-
-export declare type MarkupPreprocessor = (options: {
-	content: string;
-	filename: string;
-}) => Processed | Promise<Processed>;
-
-export declare type Preprocessor = (options: {
-	content: string;
-	attributes: Record<string, string | boolean>;
-	filename?: string;
-}) => Processed | Promise<Processed>;
-
-export interface PreprocessorGroup {
-	markup?: MarkupPreprocessor;
-	style?: Preprocessor;
-	script?: Preprocessor;
-}
+export type CssHashGetter = NonNullable<CompileOptions['cssHash']>;
 
 export type Arrayable<T> = T | T[];
 


### PR DESCRIPTION
Fixes #10

I initially wanted to import the types from svelte directly for every other files, but eslint keeps complaining of `node/no-missing-import`, and the imports are *ugly* :D So I've only modified the `option.ts` file, which re-exports the types needed. Though, let me know if we do want to import from svelte directly, and we could try that path.

I also removed `--dts-resolve` from `tsup`. It was unable to resolve `estree`, likely from Svelte compiler's dependencies. Removing that doesn't change the final dts however, so it looks safe.

