### PR TITLE
fix: resolve vite root before using it (fixes #113)

### DIFF
--- a/.changeset/fuzzy-bottles-teach.md
+++ b/.changeset/fuzzy-bottles-teach.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+resolve vite.root option correctly (fixes #113)

--- a/packages/e2e-tests/configfile-custom/__tests__/configfile-custom.spec.ts
+++ b/packages/e2e-tests/configfile-custom/__tests__/configfile-custom.spec.ts
@@ -1,3 +1,5 @@
 it('should load config and work', async () => {
 	expect(await page.textContent('h1')).toMatch('Hello world!');
+	expect(await page.textContent('#test-child')).toBe('test-child');
+	expect(await page.textContent('#dependency-import')).toBe('dependency-import');
 });

--- a/packages/e2e-tests/configfile-custom/src/App.svelte
+++ b/packages/e2e-tests/configfile-custom/src/App.svelte
@@ -1,9 +1,11 @@
 <script>
 	import Dependency from 'e2e-tests-hmr-test-dependency';
+	import Child from './lib/Child.svelte';
 </script>
 
 <h1>Hello world!</h1>
 <Dependency />
+<Child />
 
 <style>
 	h1 {

--- a/packages/e2e-tests/configfile-custom/src/lib/Child.svelte
+++ b/packages/e2e-tests/configfile-custom/src/lib/Child.svelte
@@ -1,0 +1,1 @@
+<h2 id="test-child">test-child</h2>

--- a/packages/e2e-tests/configfile-custom/vite.config.js
+++ b/packages/e2e-tests/configfile-custom/vite.config.js
@@ -3,6 +3,7 @@ const { defineConfig } = require('vite');
 
 module.exports = defineConfig(() => {
 	return {
+		root: './', // ensure custom root works, see https://github.com/sveltejs/vite-plugin-svelte/issues/113
 		plugins: [svelte({ configFile: 'svelte.config.custom.cjs' })],
 		build: {
 			// make build faster by skipping transforms and minification

--- a/packages/e2e-tests/configfile-esm/__tests__/configfile-esm.spec.ts
+++ b/packages/e2e-tests/configfile-esm/__tests__/configfile-esm.spec.ts
@@ -1,5 +1,5 @@
-// unfortunately this test does not work as jest is not fully compatible with esm
-// wait for jest 27 and see https://github.com/facebook/jest/issues/9430
 it('should load config and work', async () => {
 	expect(await page.textContent('h1')).toMatch('Hello world!');
+	expect(await page.textContent('#test-child')).toBe('test-child');
+	expect(await page.textContent('#dependency-import')).toBe('dependency-import');
 });

--- a/packages/e2e-tests/configfile-esm/src/App.svelte
+++ b/packages/e2e-tests/configfile-esm/src/App.svelte
@@ -1,9 +1,11 @@
 <script>
 	import Dependency from 'e2e-tests-hmr-test-dependency';
+	import Child from './lib/Child.svelte';
 </script>
 
 <h1>Hello world!</h1>
 <Dependency />
+<Child />
 
 <style>
 	h1 {

--- a/packages/e2e-tests/configfile-esm/src/lib/Child.svelte
+++ b/packages/e2e-tests/configfile-esm/src/lib/Child.svelte
@@ -1,0 +1,1 @@
+<h2 id="test-child">test-child</h2>

--- a/packages/e2e-tests/configfile-esm/vite.config.js
+++ b/packages/e2e-tests/configfile-esm/vite.config.js
@@ -3,6 +3,7 @@ import { defineConfig } from 'vite';
 
 export default defineConfig(({ command, mode }) => {
 	return {
+		root: './', // ensure custom root works, see https://github.com/sveltejs/vite-plugin-svelte/issues/113
 		plugins: [svelte()],
 		build: {
 			// make build faster by skipping transforms and minification


### PR DESCRIPTION
fixes #113 

maybe vite should resolve root before calling config hook, that information is pretty crucial for plugins to read their own config files.