### PR TITLE
Fix/tsconfig vite25

### DIFF
--- a/packages/e2e-tests/ts-type-import/src/index.ts
+++ b/packages/e2e-tests/ts-type-import/src/index.ts
@@ -1,4 +1,5 @@
-import { test, Test } from './lib';
+import type { Test } from './lib';
+import { test } from './lib';
 import App from './App.svelte';
 
 main();

--- a/packages/e2e-tests/ts-type-import/tsconfig.json
+++ b/packages/e2e-tests/ts-type-import/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "@tsconfig/svelte/tsconfig.json",
   "include": ["src/**/*"],
-  "exclude": ["node_modules"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
preparations for vite-2.5 compatibility. due to the fact that vite 2.5 is going to read local tsconfig.json the e2e-test needs to be adapted