### PR TITLE
fix: use createRequire to require svelte.config.cjs in esm project

### DIFF
--- a/.changeset/fuzzy-mails-brush.md
+++ b/.changeset/fuzzy-mails-brush.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+also try load cjs config

--- a/.changeset/fuzzy-mails-brush.md
+++ b/.changeset/fuzzy-mails-brush.md
@@ -2,4 +2,4 @@
 '@sveltejs/vite-plugin-svelte': patch
 ---
 
-also try load cjs config
+use createRequire to load svelte.config.cjs in esm projects (fixes #141)

--- a/packages/e2e-tests/configfile-custom/__tests__/configfile-custom.spec.ts
+++ b/packages/e2e-tests/configfile-custom/__tests__/configfile-custom.spec.ts
@@ -1,4 +1,15 @@
-it('should load config and work', async () => {
+import { editViteConfig } from 'testUtils';
+
+it('should load default config and work', async () => {
+	expect(await page.textContent('h1')).toMatch('Hello world!');
+	expect(await page.textContent('#test-child')).toBe('test-child');
+	expect(await page.textContent('#dependency-import')).toBe('dependency-import');
+});
+
+it('should load custom mjs config and work', async () => {
+	await editViteConfig((c) =>
+		c.replace('svelte()', `svelte({configFile:'svelte.config.custom.cjs'})`)
+	);
 	expect(await page.textContent('h1')).toMatch('Hello world!');
 	expect(await page.textContent('#test-child')).toBe('test-child');
 	expect(await page.textContent('#dependency-import')).toBe('dependency-import');

--- a/packages/e2e-tests/configfile-esm/__tests__/configfile-esm.spec.ts
+++ b/packages/e2e-tests/configfile-esm/__tests__/configfile-esm.spec.ts
@@ -1,4 +1,15 @@
-it('should load config and work', async () => {
+import { editViteConfig } from 'testUtils';
+
+it('should load default config and work', async () => {
+	expect(await page.textContent('h1')).toMatch('Hello world!');
+	expect(await page.textContent('#test-child')).toBe('test-child');
+	expect(await page.textContent('#dependency-import')).toBe('dependency-import');
+});
+
+it('should load custom cjs config and work', async () => {
+	await editViteConfig((c) =>
+		c.replace('svelte()', `svelte({configFile:'svelte.config.custom.cjs'})`)
+	);
 	expect(await page.textContent('h1')).toMatch('Hello world!');
 	expect(await page.textContent('#test-child')).toBe('test-child');
 	expect(await page.textContent('#dependency-import')).toBe('dependency-import');

--- a/packages/e2e-tests/configfile-esm/svelte.config.custom.cjs
+++ b/packages/e2e-tests/configfile-esm/svelte.config.custom.cjs
@@ -1,0 +1,5 @@
+const sveltePreprocess = require('svelte-preprocess');
+
+module.exports = {
+	preprocess: sveltePreprocess()
+};

--- a/packages/e2e-tests/hmr/__tests__/hmr.spec.ts
+++ b/packages/e2e-tests/hmr/__tests__/hmr.spec.ts
@@ -9,7 +9,8 @@ import {
 	getColor,
 	editFile,
 	addFile,
-	removeFile
+	removeFile,
+	editViteConfig
 } from '../../testUtils';
 
 test('should render App', async () => {
@@ -123,10 +124,7 @@ if (!isBuild) {
 		});
 
 		test('should work with emitCss: false', async () => {
-			await editFile('vite.config.js', (c) => c.replace('svelte()', 'svelte({emitCss:false})'));
-			await sleep(isWin ? 1000 : 500); // editing vite config restarts server, give it some time
-			await page.goto(viteTestUrl, { waitUntil: 'networkidle' });
-			await sleep(50);
+			await editViteConfig((c) => c.replace('svelte()', 'svelte({emitCss:false})'));
 			expect(await getText(`#hmr-test-1 .counter`)).toBe('0');
 			expect(await getColor(`#hmr-test-1 .label`)).toBe('green');
 			await (await getEl(`#hmr-test-1 .increment`)).click();

--- a/packages/e2e-tests/testUtils.ts
+++ b/packages/e2e-tests/testUtils.ts
@@ -196,3 +196,10 @@ export async function saveScreenshot(name?: string) {
 		console.log('failed to take screenshot', e);
 	}
 }
+
+export async function editViteConfig(replacer: (str: string) => string) {
+	editFile('vite.config.js', replacer);
+	await sleep(isWin ? 1000 : 500); // editing vite config restarts server, give it some time
+	await page.goto(viteTestUrl, { waitUntil: 'networkidle' });
+	await sleep(50);
+}

--- a/packages/vite-plugin-svelte/src/utils/load-svelte-config.ts
+++ b/packages/vite-plugin-svelte/src/utils/load-svelte-config.ts
@@ -27,7 +27,7 @@ export async function loadSvelteConfig(
 	if (configFile) {
 		let err;
 		// try to use dynamic import for svelte.config.js first
-		if (configFile.endsWith('.js') || configFile.endsWith('.mjs')) {
+		if (configFile.endsWith('.js') || configFile.endsWith('.mjs') || configFile.endsWith('.cjs')) {
 			try {
 				const result = await dynamicImportDefault(pathToFileURL(configFile).href);
 				if (result != null) {


### PR DESCRIPTION
Fixes #141

Import `.cjs` config file if app is running in `type: module`.

Also added a few more tests for loading different config files.