### PR TITLE
docs: update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # @sveltejs/vite-plugin-svelte
 
+[![npm version](https://img.shields.io/npm/v/@sveltejs/vite-plugin-svelte)](https://www.npmjs.com/package/svelte)
+[![CI](https://github.com/sveltejs/vite-plugin-svelte/actions/workflows/ci.yml/badge.svg)](https://github.com/sveltejs/vite-plugin-svelte/actions/workflows/ci.yml)
+[![Chat](https://img.shields.io/discord/457912077277855764?label=chat&logo=discord)](https://svelte.dev/chat)
+
 The official [Svelte](https://svelte.dev) plugin for [Vite](https://vitejs.dev).
 
 ## Installation
@@ -30,9 +34,9 @@ export default defineConfig({
 
 ## Packages
 
-| Package                                                     | changelog                                             |
+| Package                                                     | Changelog                                             |
 | ----------------------------------------------------------- | ----------------------------------------------------- |
-| [@sveltejs/vite-plugin-svelte](packages/vite-plugin-svelte) | [changelog](packages/vite-plugin-svelte/CHANGELOG.md) |
+| [@sveltejs/vite-plugin-svelte](packages/vite-plugin-svelte) | [Changelog](packages/vite-plugin-svelte/CHANGELOG.md) |
 
 ## Got a question? / Need help?
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -118,7 +118,7 @@ A [minimatch pattern](https://github.com/isaacs/minimatch), or array of patterns
 
 ### onwarn
 
-- **Type:**: `(warning: Warning, defaultHandler?: (warning: Warning) => void) => void` - See [Warning](https://github.com/sveltejs/svelte/blob/ce550adef65a7e04c381b11c24f07a2ae1c25783/src/compiler/interfaces.ts#L121-L130)
+- **Type:** `(warning: Warning, defaultHandler?: (warning: Warning) => void) => void` - See [Warning](https://github.com/sveltejs/svelte/blob/ce550adef65a7e04c381b11c24f07a2ae1c25783/src/compiler/interfaces.ts#L121-L130)
 
   Handles warning emitted from the Svelte compiler. Useful to suppress warning messages.
 

--- a/packages/vite-plugin-svelte/README.md
+++ b/packages/vite-plugin-svelte/README.md
@@ -2,6 +2,26 @@
 
 The official [Svelte](https://svelte.dev) plugin for [Vite](https://vitejs.dev).
 
+## Usage
+
+```js
+// vite.config.js
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+
+export default defineConfig({
+	plugins: [
+		svelte({
+			/* plugin options */
+		})
+	]
+});
+```
+
+## Documentation
+
+- [Plugin options](../../docs/config.md)
+- [FAQ](../../docs/faq.md)
+
 ## License
 
 [MIT](./LICENSE)

--- a/packages/vite-plugin-svelte/package.json
+++ b/packages/vite-plugin-svelte/package.json
@@ -31,7 +31,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sveltejs/vite-plugin-svelte.git"
+    "url": "git+https://github.com/sveltejs/vite-plugin-svelte.git",
+    "directory": "packages/vite-plugin-svelte"
   },
   "keywords": [
     "vite-plugin",
@@ -42,7 +43,7 @@
   "bugs": {
     "url": "https://github.com/sveltejs/vite-plugin-svelte/issues"
   },
-  "homepage": "https://github.com/sveltejs/vite-plugin-svelte/tree/main/packages/vite-plugin-svelte#readme",
+  "homepage": "https://github.com/sveltejs/vite-plugin-svelte#readme",
   "dependencies": {
     "@rollup/pluginutils": "^4.1.1",
     "debug": "^4.3.2",


### PR DESCRIPTION
- Badges!
- Made the `vite-plugin-svelte` package readme a bit more lively, as that would be shown in npm
- Update `package.json` links

Note: The `package.json`'s `repository.directory` is used to resolve the relative links I used in the `vite-plugin-svelte` package readme, so that npm resolves the link correctly.