### PR TITLE
fix(hmr): handle compiler warning caused by injected css selector

### DIFF
--- a/.changeset/nine-papayas-confess.md
+++ b/.changeset/nine-papayas-confess.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+suppress unused css compiler warning when component has style tag but no element to select

--- a/.changeset/nine-papayas-confess.md
+++ b/.changeset/nine-papayas-confess.md
@@ -1,5 +1,0 @@
----
-'@sveltejs/vite-plugin-svelte': patch
----
-
-warn on no scopable elements and provide improvement suggestions

--- a/.changeset/nine-papayas-confess.md
+++ b/.changeset/nine-papayas-confess.md
@@ -2,4 +2,4 @@
 '@sveltejs/vite-plugin-svelte': patch
 ---
 
-suppress unused css compiler warning when component has style tag but no element to select
+warn on no scopable elements and provide improvement suggestions

--- a/.changeset/six-ears-grow.md
+++ b/.changeset/six-ears-grow.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': minor
+---
+
+Improve dev warning message for components including only unscoped styles (fixes #153)"

--- a/.changeset/six-ears-grow.md
+++ b/.changeset/six-ears-grow.md
@@ -2,4 +2,4 @@
 '@sveltejs/vite-plugin-svelte': minor
 ---
 
-Improve dev warning message for components including only unscoped styles (fixes #153)"
+Improve dev warning message for components including only unscoped styles (fixes #153)

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -47,7 +47,7 @@ Bad:
 
 ### Where should I put my global styles?
 
-Global styles should always be placed in their own stylesheet files whwnever possible, and not in a Svelte component's `<style>` tag. The stylesheet files can then be imported directly in JS and would take advantage of Vite's own style processing. It would also significantly improve the dev server startup time.
+Global styles should always be placed in their own stylesheet files whenever possible, and not in a Svelte component's `<style>` tag. The stylesheet files can then be imported directly in JS and take advantage of Vite's own style processing. It would also significantly improve the dev server startup time.
 
 Good:
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -45,6 +45,34 @@ Bad:
 <script type="text/typescript"></script>
 ```
 
+### Where should I put my global styles?
+
+Global styles should always be placed in their own stylesheet files whwnever possible, and not in a Svelte component's `<style>` tag. The stylesheet files can then be imported directly in JS and would take advantage of Vite's own style processing. It would also significantly improve the dev server startup time.
+
+Good:
+
+```scss
+/* global.scss */
+html {
+	color: $text-color;
+}
+```
+
+```js
+// main.js
+import './global.scss';
+```
+
+Bad:
+
+```svelte
+<style lang="scss">
+	:global(html) {
+		color: $text-color;
+	}
+</style>
+```
+
 ### How do I add a Svelte preprocessor from a Vite plugin?
 
 If you are building a Vite plugin that transforms CSS or JS, you can add a `api.sveltePreprocess: PreprocessorGroup` to your Vite plugin definition and it will be added to the list of Svelte preprocessors used at runtime.

--- a/packages/playground/preprocess-with-vite/src/App.svelte
+++ b/packages/playground/preprocess-with-vite/src/App.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
 	import Foo from './Foo.svelte';
+	import Bar from './Bar.svelte';
 	const world: string = 'world'; // edit world and save to see hmr update
 </script>
 
 <h1 class="foo">Hello {world}</h1>
 <p>This is styled with scss using darken fn</p>
 <Foo />
+<Bar />
 
 <style lang="scss">
 	$blue: blue;

--- a/packages/playground/preprocess-with-vite/src/Bar.svelte
+++ b/packages/playground/preprocess-with-vite/src/Bar.svelte
@@ -1,0 +1,11 @@
+<script>
+	import Foo from './Foo.svelte';
+</script>
+
+<Foo />
+
+<style>
+	:global(.note) {
+		background-color: lightblue;
+	}
+</style>

--- a/packages/vite-plugin-svelte/src/utils/log.ts
+++ b/packages/vite-plugin-svelte/src/utils/log.ts
@@ -120,11 +120,11 @@ function ignoreCompilerWarning(
 ): boolean {
 	return (
 		(!emitCss && warning.code === 'css-unused-selector') || // same as rollup-plugin-svelte
-		(!isBuild && isNoScopeableElementWarning(warning))
+		(!isBuild && isNoScopableElementWarning(warning))
 	);
 }
 
-function isNoScopeableElementWarning(warning: Warning) {
+function isNoScopableElementWarning(warning: Warning) {
 	// see https://github.com/sveltejs/vite-plugin-svelte/issues/153
 	return warning.code === 'css-unused-selector' && warning.message.includes('"*"');
 }
@@ -132,15 +132,15 @@ function isNoScopeableElementWarning(warning: Warning) {
 function buildExtraWarnings(warnings: Warning[], isBuild: boolean): Warning[] {
 	const extraWarnings = [];
 	if (!isBuild) {
-		const noScopeableElementWarnings = warnings.filter((w) => isNoScopeableElementWarning(w));
-		if (noScopeableElementWarnings.length > 0) {
+		const noScopableElementWarnings = warnings.filter((w) => isNoScopableElementWarning(w));
+		if (noScopableElementWarnings.length > 0) {
 			// in case there are multiple, use last one as that is the one caused by our *{} rule
-			const noScopeableElementWarning =
-				noScopeableElementWarnings[noScopeableElementWarnings.length - 1];
+			const noScopableElementWarning =
+				noScopableElementWarnings[noScopableElementWarnings.length - 1];
 			extraWarnings.push({
-				...noScopeableElementWarning,
-				code: 'vite-plugin-svelte-css-no-scopeable-elements',
-				message: `No scopeable elements found in template. If you're using global styles in the style tag, you should move it into an external stylesheet file and import it in JS. See https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#where-should-i-put-my-global-styles.`
+				...noScopableElementWarning,
+				code: 'vite-plugin-svelte-css-no-scopable-elements',
+				message: `No scopable elements found in template. If you're using global styles in the style tag, you should move it into an external stylesheet file and import it in JS. See https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#where-should-i-put-my-global-styles.`
 			});
 		}
 	}

--- a/packages/vite-plugin-svelte/src/utils/log.ts
+++ b/packages/vite-plugin-svelte/src/utils/log.ts
@@ -106,6 +106,10 @@ export function logCompilerWarnings(warnings: Warning[], options: ResolvedOption
 		if (!emitCss && warning.code === 'css-unused-selector') {
 			return;
 		}
+		// suppress `* {}` warnings injected in style tags for CSS HMR
+		if (!isBuild && warning.message === 'Unused CSS selector "*"') {
+			return;
+		}
 		if (onwarn) {
 			onwarn(warning, warn);
 		} else {

--- a/packages/vite-plugin-svelte/src/utils/options.ts
+++ b/packages/vite-plugin-svelte/src/utils/options.ts
@@ -426,8 +426,8 @@ export interface ResolvedOptions extends Options {
 	// extra options
 	root: string;
 	isProduction: boolean;
-	isBuild?: boolean;
-	isServe?: boolean;
+	isBuild: boolean;
+	isServe: boolean;
 	server?: ViteDevServer;
 }
 


### PR DESCRIPTION
Fixes: #153

Transform the exisiting warning with a new warning code: `vite-plugin-svelte-css-no-scopable-elements` and recommend a better path forward.