### PR TITLE
fix: don't reinclude excluded dependencies in automatic handling

### DIFF
--- a/.changeset/strange-brooms-crash.md
+++ b/.changeset/strange-brooms-crash.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+Improve automatic dependency pre-bundling by not reincluding dependencies that are already present in optimizeDeps.exclude


### PR DESCRIPTION
This allows users to prevent certain reincludes that could break vite's optimizer, eg `@types/node`