### PR TITLE
fix: only optimize nested cjs dependencies

### DIFF
--- a/.changeset/tricky-clouds-grab.md
+++ b/.changeset/tricky-clouds-grab.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+Only optimize nested cjs dependencies

--- a/packages/e2e-tests/package-json-svelte-field/__tests__/package-json-svelte-field.spec.ts
+++ b/packages/e2e-tests/package-json-svelte-field/__tests__/package-json-svelte-field.spec.ts
@@ -7,14 +7,13 @@ test('should render component imported via svelte field in package.json', async 
 });
 
 if (!isBuild) {
-	test('should optimize nested deps of excluded svelte deps', () => {
+	test('should optimize nested cjs deps of excluded svelte deps', () => {
 		const vitePrebundleMetadata = path.resolve(__dirname, '../node_modules/.vite/_metadata.json');
 		const metadataFile = fs.readFileSync(vitePrebundleMetadata, 'utf8');
 		const metadata = JSON.parse(metadataFile);
 		const optimizedPaths = Object.keys(metadata.optimized);
 		expect(optimizedPaths).not.toContain('e2e-test-dep-svelte-nested');
 		expect(optimizedPaths).not.toContain('e2e-test-dep-svelte-simple');
-		expect(optimizedPaths).toContain('e2e-test-dep-svelte-nested > e2e-test-dep-cjs-and-esm');
 		expect(optimizedPaths).toContain(
 			'e2e-test-dep-svelte-nested > e2e-test-dep-svelte-simple > e2e-test-dep-cjs-only'
 		);

--- a/packages/e2e-tests/package-json-svelte-field/vite.config.js
+++ b/packages/e2e-tests/package-json-svelte-field/vite.config.js
@@ -3,11 +3,7 @@ const { defineConfig } = require('vite');
 
 module.exports = defineConfig(({ command, mode }) => {
 	return {
-		plugins: [
-			svelte({
-				disableDependencyReinclusion: ['e2e-test-dep-svelte-hybrid']
-			})
-		],
+		plugins: [svelte()],
 		build: {
 			// make build faster by skipping transforms and minification
 			target: 'esnext',

--- a/packages/vite-plugin-svelte/src/index.ts
+++ b/packages/vite-plugin-svelte/src/index.ts
@@ -52,7 +52,7 @@ export function svelte(inlineOptions?: Partial<Options>): Plugin {
 			}
 			options = await resolveOptions(inlineOptions, config, configEnv);
 			// extra vite config
-			const extraViteConfig = buildExtraViteConfig(options, config);
+			const extraViteConfig = buildExtraViteConfig(options, config, configEnv);
 			log.debug('additional vite config', extraViteConfig);
 			return extraViteConfig as Partial<UserConfig>;
 		},

--- a/packages/vite-plugin-svelte/src/utils/dependencies.ts
+++ b/packages/vite-plugin-svelte/src/utils/dependencies.ts
@@ -162,9 +162,8 @@ function is_common_without_svelte_field(dependency: string): boolean {
 	);
 }
 
-export function needsOptimization(dep: SvelteDependency, depOfDep: string) {
-	const localRequire = createRequire(`${dep.dir}/package.json`);
-	const depData = resolveDependencyData(depOfDep, localRequire);
+export function needsOptimization(dep: string, localRequire: NodeRequire): boolean {
+	const depData = resolveDependencyData(dep, localRequire);
 	if (!depData) return false;
 	const pkg = depData.pkg;
 	// only optimize if is cjs, using the below as heuristic

--- a/packages/vite-plugin-svelte/src/utils/dependencies.ts
+++ b/packages/vite-plugin-svelte/src/utils/dependencies.ts
@@ -167,6 +167,7 @@ export function needsOptimization(dep: string, localRequire: NodeRequire): boole
 	if (!depData) return false;
 	const pkg = depData.pkg;
 	// only optimize if is cjs, using the below as heuristic
+	// see https://github.com/sveltejs/vite-plugin-svelte/issues/162
 	return pkg.main && !pkg.module && !pkg.exports;
 }
 

--- a/packages/vite-plugin-svelte/src/utils/options.ts
+++ b/packages/vite-plugin-svelte/src/utils/options.ts
@@ -181,12 +181,12 @@ function resolveViteRoot(viteConfig: UserConfig): string | undefined {
 
 export function buildExtraViteConfig(
 	options: ResolvedOptions,
-	config: UserConfig
+	config: UserConfig,
+	configEnv: ConfigEnv
 ): Partial<UserConfig> {
 	// extra handling for svelte dependencies in the project
 	const svelteDeps = findRootSvelteDependencies(options.root);
 	const extraViteConfig: Partial<UserConfig> = {
-		optimizeDeps: buildOptimizeDepsForSvelte(svelteDeps, options, config.optimizeDeps),
 		resolve: {
 			mainFields: [...SVELTE_RESOLVE_MAIN_FIELDS],
 			dedupe: [...SVELTE_IMPORTS, ...SVELTE_HMR_IMPORTS]
@@ -196,6 +196,14 @@ export function buildExtraViteConfig(
 		// @ts-ignore
 		// knownJsSrcExtensions: options.extensions
 	};
+
+	if (configEnv.command === 'serve') {
+		extraViteConfig.optimizeDeps = buildOptimizeDepsForSvelte(
+			svelteDeps,
+			options,
+			config.optimizeDeps
+		);
+	}
 
 	// @ts-ignore
 	extraViteConfig.ssr = buildSSROptionsForSvelte(svelteDeps, options, config);


### PR DESCRIPTION
Fixes #162

This would prevent `bin`-only packages, `types`-only packages, and esm packages from pre-bundling. Essentially avoiding the issues noted at https://github.com/sveltejs/vite-plugin-svelte/issues/162#issuecomment-912992931

Also thanks to @dominikg that led to this idea!