### PR TITLE
fix: add svelte lib without components to noExternal

### DIFF
--- a/.changeset/modern-horses-reply.md
+++ b/.changeset/modern-horses-reply.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+Svelte libraries without any Svelte components are also added to ssr.noExternal

--- a/packages/e2e-tests/_test_dependencies/svelte-api-only/index.js
+++ b/packages/e2e-tests/_test_dependencies/svelte-api-only/index.js
@@ -1,0 +1,5 @@
+import { setContext } from 'svelte';
+
+export function setSomeContext() {
+	setContext('svelte-api-only', true);
+}

--- a/packages/e2e-tests/_test_dependencies/svelte-api-only/package.json
+++ b/packages/e2e-tests/_test_dependencies/svelte-api-only/package.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
   "private": true,
-  "name": "e2e-test-dep-esm-only",
+  "name": "e2e-test-dep-svelte-api-only",
   "main": "index.js",
   "module": "index.js",
   "files": [

--- a/packages/e2e-tests/kit-node/package.json
+++ b/packages/e2e-tests/kit-node/package.json
@@ -10,6 +10,7 @@
   "devDependencies": {
     "@sveltejs/adapter-node": "^1.0.0-next.46",
     "@sveltejs/kit": "^1.0.0-next.165",
+    "e2e-test-dep-svelte-api-only": "workspace:*",
     "svelte": "^3.42.4"
   },
   "type": "module",

--- a/packages/e2e-tests/kit-node/src/routes/index.svelte
+++ b/packages/e2e-tests/kit-node/src/routes/index.svelte
@@ -22,6 +22,7 @@
 	import Counter from '$lib/Counter.svelte';
 	// eslint-disable-next-line node/no-missing-import
 	import Child from '$lib/Child.svelte';
+	import { setSomeContext } from 'e2e-test-dep-svelte-api-only';
 	export let load_status = 'NOT_LOADED';
 	let mount_status = 'BEFORE_MOUNT';
 	onMount(async () => {
@@ -29,6 +30,7 @@
 		console.log(`onMount dynamic imported isSSR: ${isSSR}`);
 		mount_status = 'AFTER_MOUNT';
 	});
+	setSomeContext();
 </script>
 
 <main>

--- a/packages/e2e-tests/kit-node/svelte.config.js
+++ b/packages/e2e-tests/kit-node/svelte.config.js
@@ -19,9 +19,6 @@ const config = {
 					usePolling: true,
 					interval: 100
 				}
-			},
-			ssr: {
-				external: ['e2e-test-dep-svelte-api-only']
 			}
 		}
 	}

--- a/packages/e2e-tests/kit-node/svelte.config.js
+++ b/packages/e2e-tests/kit-node/svelte.config.js
@@ -19,6 +19,9 @@ const config = {
 					usePolling: true,
 					interval: 100
 				}
+			},
+			ssr: {
+				external: ['e2e-test-dep-svelte-api-only']
 			}
 		}
 	}

--- a/packages/vite-plugin-svelte/src/utils/dependencies.ts
+++ b/packages/vite-plugin-svelte/src/utils/dependencies.ts
@@ -119,10 +119,7 @@ function isSvelteComponentLib(pkg: Pkg) {
 }
 
 function isSvelteLib(pkg: Pkg) {
-	return (
-		Object.keys(pkg.dependencies || {}).includes('svelte') ||
-		Object.keys(pkg.peerDependencies || {}).includes('svelte')
-	);
+	return !!pkg.dependencies?.svelte || !!pkg.peerDependencies?.svelte;
 }
 
 const COMMON_DEPENDENCIES_WITHOUT_SVELTE_FIELD = [

--- a/packages/vite-plugin-svelte/src/utils/options.ts
+++ b/packages/vite-plugin-svelte/src/utils/options.ts
@@ -199,7 +199,7 @@ export function buildExtraViteConfig(
 
 	if (configEnv.command === 'serve') {
 		extraViteConfig.optimizeDeps = buildOptimizeDepsForSvelte(
-			svelteDeps,
+			svelteDeps.filter((dep) => dep.type === 'component-library'),
 			options,
 			config.optimizeDeps
 		);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,9 @@ importers:
   packages/e2e-tests/_test_dependencies/esm-only:
     specifiers: {}
 
+  packages/e2e-tests/_test_dependencies/svelte-api-only:
+    specifiers: {}
+
   packages/e2e-tests/_test_dependencies/svelte-hybrid:
     specifiers:
       '@types/node': ^16.9.0
@@ -213,10 +216,12 @@ importers:
     specifiers:
       '@sveltejs/adapter-node': ^1.0.0-next.46
       '@sveltejs/kit': ^1.0.0-next.165
+      e2e-test-dep-svelte-api-only: workspace:*
       svelte: ^3.42.4
     devDependencies:
       '@sveltejs/adapter-node': 1.0.0-next.46
       '@sveltejs/kit': 1.0.0-next.165_svelte@3.42.4
+      e2e-test-dep-svelte-api-only: link:../_test_dependencies/svelte-api-only
       svelte: 3.42.4
 
   packages/e2e-tests/package-json-svelte-field:


### PR DESCRIPTION
Fixes https://github.com/sveltejs/kit/issues/2397

Note: I can't really add a failing test since the linked `e2e-test-dep-svelte-api-only` package is automatically `noExternal` by default. I can't force it to external via `config.kit.vite.ssr.external` either since our code respects that (not actually testing the bug). For now, I've tested with the issue's repro https://github.com/Nickersoft/urql-repro and it works.