### PR TITLE
fix(tests): increase hydration delay

### DIFF
--- a/packages/e2e-tests/kit-node/__tests__/kit.spec.ts
+++ b/packages/e2e-tests/kit-node/__tests__/kit.spec.ts
@@ -36,7 +36,7 @@ describe('kit-node', () => {
 			expect(html).toMatch('BEFORE_MOUNT');
 
 			// wait a bit for hydration to kick in
-			await sleep(250);
+			await sleep(550);
 
 			// check hydrated content
 			expect(await getText('#load')).toBe('CLIENT_LOADED');

--- a/packages/e2e-tests/kit-node/src/routes/index.svelte
+++ b/packages/e2e-tests/kit-node/src/routes/index.svelte
@@ -8,7 +8,7 @@
 			return new Promise((resolve) =>
 				setTimeout(() => {
 					resolve({ props: { load_status: 'CLIENT_LOADED' } });
-				}, 200)
+				}, 500)
 			);
 		} else {
 			return { props: { load_status: 'SERVER_LOADED' } };


### PR DESCRIPTION
Maybe we can do more tests fixes altogether, but I only made one fix for now.

- Increase kit-node hydration delay so windows test passes