### PR TITLE
feat: improve compile error reporting

### DIFF
--- a/.changeset/eleven-frogs-rhyme.md
+++ b/.changeset/eleven-frogs-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': minor
+---
+
+Improved error reporting for svelte compiler errors

--- a/packages/vite-plugin-svelte/src/index.ts
+++ b/packages/vite-plugin-svelte/src/index.ts
@@ -17,6 +17,7 @@ import { ensureWatchedFile, setupWatchers } from './utils/watch';
 import { resolveViaPackageJsonSvelte } from './utils/resolve';
 import { addExtraPreprocessors } from './utils/preprocess';
 import { PartialResolvedId } from 'rollup';
+import { toRollupError } from './utils/error';
 
 export function svelte(inlineOptions?: Partial<Options>): Plugin {
 	if (process.env.DEBUG != null) {
@@ -169,7 +170,12 @@ export function svelte(inlineOptions?: Partial<Options>): Plugin {
 				log.error('failed to transform tagged svelte request', svelteRequest);
 				throw new Error(`failed to transform tagged svelte request for id ${id}`);
 			}
-			const compileData = await compileSvelte(svelteRequest, code, options);
+			let compileData;
+			try {
+				compileData = await compileSvelte(svelteRequest, code, options);
+			} catch (e) {
+				throw toRollupError(e);
+			}
 			logCompilerWarnings(compileData.compiled.warnings, options);
 			cache.update(compileData);
 			if (compileData.dependencies?.length && options.server) {

--- a/packages/vite-plugin-svelte/src/utils/error.ts
+++ b/packages/vite-plugin-svelte/src/utils/error.ts
@@ -2,7 +2,6 @@ import { RollupError } from 'rollup';
 import { Warning } from './options';
 import { buildExtendedLogMessage } from './log';
 import { PartialMessage } from 'esbuild';
-
 /**
  * convert an error thrown by svelte.compile to a RollupError so that vite displays it in a user friendly way
  * @param error
@@ -39,16 +38,24 @@ export function toESBuildError(
 ): PartialMessage {
 	const { filename, frame, start } = error;
 	const partialMessage: PartialMessage = {
-		text: buildExtendedLogMessage(error),
-		detail: frame
+		text: buildExtendedLogMessage(error)
 	};
 	if (start) {
 		partialMessage.location = {
 			line: start.line,
 			column: start.column,
 			file: filename,
-			suggestion: frame
+			lineText: lineFromFrame(start.line, frame) // needed to get a meaningful error message on cli
 		};
 	}
 	return partialMessage;
+}
+
+function lineFromFrame(lineNo: number, frame?: string): string {
+	if (!frame) {
+		return '';
+	}
+	const lines = frame.split('\n');
+	const errorLine = lines.find((line) => line.trimStart().startsWith(`${lineNo}: `));
+	return errorLine ? errorLine.substring(errorLine.indexOf(': ') + 3) : '';
 }

--- a/packages/vite-plugin-svelte/src/utils/error.ts
+++ b/packages/vite-plugin-svelte/src/utils/error.ts
@@ -2,14 +2,13 @@ import { RollupError } from 'rollup';
 import { Warning } from './options';
 import { buildExtendedLogMessage } from './log';
 import { PartialMessage } from 'esbuild';
+
 /**
  * convert an error thrown by svelte.compile to a RollupError so that vite displays it in a user friendly way
- * @param error
+ * @param error a svelte compiler error, which is a mix of Warning and an error
  * @returns {RollupError} the converted error
  */
-export function toRollupError(
-	error: Warning & Error // a svelte compiler error is a mix of Warning and an error
-): RollupError {
+export function toRollupError(error: Warning & Error): RollupError {
 	const { filename, frame, start, code, name } = error;
 	const rollupError: RollupError = {
 		name, // needed otherwise sveltekit coalesce_to_error turns it into a string
@@ -31,12 +30,10 @@ export function toRollupError(
 
 /**
  * convert an error thrown by svelte.compile to an esbuild PartialMessage
- * @param error
+ * @param error a svelte compiler error, which is a mix of Warning and an error
  * @returns {PartialMessage} the converted error
  */
-export function toESBuildError(
-	error: Warning & Error // a svelte compiler error is a mix of Warning and an error
-): PartialMessage {
+export function toESBuildError(error: Warning & Error): PartialMessage {
 	const { filename, frame, start } = error;
 	const partialMessage: PartialMessage = {
 		text: buildExtendedLogMessage(error)
@@ -54,9 +51,6 @@ export function toESBuildError(
 
 /**
  * extract line with number from codeframe
- *
- * @param lineNo
- * @param frame
  */
 function lineFromFrame(lineNo: number, frame?: string): string {
 	if (!frame) {
@@ -86,8 +80,6 @@ function lineFromFrame(lineNo: number, frame?: string): string {
  *  3 | baz
  * ```
  * @see https://github.com/vitejs/vite/blob/96591bf9989529de839ba89958755eafe4c445ae/packages/vite/src/client/overlay.ts#L116
- *
- * @param frame
  */
 function formatFrameForVite(frame?: string): string {
 	if (!frame) {

--- a/packages/vite-plugin-svelte/src/utils/error.ts
+++ b/packages/vite-plugin-svelte/src/utils/error.ts
@@ -1,0 +1,29 @@
+import { RollupError } from 'rollup';
+import { Warning } from './options';
+import { buildExtendedLogMessage } from './log';
+
+/**
+ * convert an error thrown by svelte.compile to a RollupError so that vite displays it in a user friendly way
+ * @param error
+ * @returns {RollupError} the converted error
+ */
+export function toRollupError(
+	error: Warning & Error // a svelte compiler error is a mix of Warning and an error
+): RollupError {
+	const { filename, frame, start, code, name } = error;
+	const rollupError: RollupError = {
+		name, // needed otherwise sveltekit coalesce_to_error turns it into a string
+		id: filename,
+		message: buildExtendedLogMessage(error), // include filename:line:column so that it's clickable
+		frame,
+		code
+	};
+	if (start) {
+		rollupError.loc = {
+			line: start.line,
+			column: start.column,
+			file: filename
+		};
+	}
+	return rollupError;
+}

--- a/packages/vite-plugin-svelte/src/utils/error.ts
+++ b/packages/vite-plugin-svelte/src/utils/error.ts
@@ -1,6 +1,7 @@
 import { RollupError } from 'rollup';
 import { Warning } from './options';
 import { buildExtendedLogMessage } from './log';
+import { PartialMessage } from 'esbuild';
 
 /**
  * convert an error thrown by svelte.compile to a RollupError so that vite displays it in a user friendly way
@@ -26,4 +27,28 @@ export function toRollupError(
 		};
 	}
 	return rollupError;
+}
+
+/**
+ * convert an error thrown by svelte.compile to an esbuild PartialMessage
+ * @param error
+ * @returns {PartialMessage} the converted error
+ */
+export function toESBuildError(
+	error: Warning & Error // a svelte compiler error is a mix of Warning and an error
+): PartialMessage {
+	const { filename, frame, start } = error;
+	const partialMessage: PartialMessage = {
+		text: buildExtendedLogMessage(error),
+		detail: frame
+	};
+	if (start) {
+		partialMessage.location = {
+			line: start.line,
+			column: start.column,
+			file: filename,
+			suggestion: frame
+		};
+	}
+	return partialMessage;
 }

--- a/packages/vite-plugin-svelte/src/utils/esbuild.ts
+++ b/packages/vite-plugin-svelte/src/utils/esbuild.ts
@@ -4,6 +4,7 @@ import { DepOptimizationOptions } from 'vite';
 import { Compiled } from './compile';
 import { log } from './log';
 import { CompileOptions, ResolvedOptions } from './options';
+import { toESBuildError } from './error';
 
 type EsbuildOptions = NonNullable<DepOptimizationOptions['esbuildOptions']>;
 type EsbuildPlugin = NonNullable<EsbuildOptions['plugins']>[number];
@@ -20,8 +21,12 @@ export function esbuildSveltePlugin(options: ResolvedOptions): EsbuildPlugin {
 
 			build.onLoad({ filter: svelteFilter }, async ({ path: filename }) => {
 				const code = await fs.readFile(filename, 'utf8');
-				const contents = await compileSvelte(options, { filename, code });
-				return { contents };
+				try {
+					const contents = await compileSvelte(options, { filename, code });
+					return { contents };
+				} catch (e) {
+					return { errors: [toESBuildError(e)] };
+				}
 			});
 		}
 	};

--- a/packages/vite-plugin-svelte/src/utils/log.ts
+++ b/packages/vite-plugin-svelte/src/utils/log.ts
@@ -155,7 +155,7 @@ function warnBuild(w: Warning) {
 	log.warn.enabled && log.warn(buildExtendedLogMessage(w), w.frame);
 }
 
-function buildExtendedLogMessage(w: Warning) {
+export function buildExtendedLogMessage(w: Warning) {
 	const parts = [];
 	if (w.filename) {
 		parts.push(w.filename);


### PR DESCRIPTION
convert compiler error to a RollupError that is displayed to the user in a more friendly way than the current stack pointing into vite-plugin-svelte.

This is a bit verbose and causes messages to be sent multiple times on console for sveltekit (ssr and regular compile) but at least it's showing the correct file and frame.

fixes #218