### PR TITLE
fix: ignore protocol when resolve svelte field

### DIFF
--- a/.changeset/clean-rice-fly.md
+++ b/.changeset/clean-rice-fly.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+Ignore import protocols like `node:` when resolving the `svelte` field in package.json

--- a/packages/vite-plugin-svelte/src/utils/resolve.ts
+++ b/packages/vite-plugin-svelte/src/utils/resolve.ts
@@ -14,7 +14,13 @@ export function resolveViaPackageJsonSvelte(importee: string, importer?: string)
 }
 
 function isBareImport(importee: string): boolean {
-	if (!importee || importee[0] === '.' || importee[0] === '\0' || path.isAbsolute(importee)) {
+	if (
+		!importee ||
+		importee[0] === '.' ||
+		importee[0] === '\0' ||
+		importee.includes(':') ||
+		path.isAbsolute(importee)
+	) {
 		return false;
 	}
 	const parts = importee.split('/');


### PR DESCRIPTION
Fixes the CI issue in https://github.com/sveltejs/kit/pull/3034 where the `node:` protocol was messing with resolving the `svelte` field of package.json. Adding `node-fetch`, Vite's scanner seems to resolve its nested imports using Vite plugin's `resolveId`, and because we're using `enforce: "pre"`, we encounter this scenario before Vite's default resolver, which would've handled this.

I'm also not sure why it's resolving the nested imports, but at the meantime this addition looks fine as well.