### PR TITLE
ci: fix pnpm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,11 +74,9 @@
   },
   "pnpm": {
     "overrides": {
-      "//consistent-versions": "force consistent versions for the following packages",
       "@sveltejs/vite-plugin-svelte": "workspace:*",
       "esbuild": "^0.13.15",
       "vite": "^2.7.0",
-      "//audit-fixes": "force update packages flagged by pnpm audit",
       "ansi-regex@>2.1.1 <5.0.1": "^5.0.1"
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,11 +1,9 @@
 lockfileVersion: 5.3
 
 overrides:
-  //consistent-versions: force consistent versions for the following packages
   '@sveltejs/vite-plugin-svelte': workspace:*
   esbuild: ^0.13.15
   vite: ^2.7.0
-  //audit-fixes: force update packages flagged by pnpm audit
   ansi-regex@>2.1.1 <5.0.1: ^5.0.1
 
 importers:


### PR DESCRIPTION
pnpm 6.24.0 now doesn't accept comments in `pnpm.overrides`, which seems fair to me, though now we can't document them, but I don't think it's a big deal.