### PR TITLE
feat: auto-restart SvelteKit when Svelte config changed

### DIFF
--- a/.changeset/forty-olives-look.md
+++ b/.changeset/forty-olives-look.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': minor
+---
+
+auto-restart SvelteKit when Svelte config changed

--- a/packages/e2e-tests/kit-node/__tests__/kit.spec.ts
+++ b/packages/e2e-tests/kit-node/__tests__/kit.spec.ts
@@ -7,7 +7,8 @@ import {
 	isBuild,
 	readFileContent,
 	sleep,
-	untilUpdated
+	untilUpdated,
+	waitForNavigation
 } from '../../testUtils';
 
 import fetch from 'node-fetch';
@@ -237,7 +238,7 @@ describe('kit-node', () => {
 						await button.click();
 						expect(await getText('button')).toBe('Clicks: 1');
 						editFile('svelte.config.js', (config) => config + '\n');
-						await page.waitForNavigation({ waitUntil: 'networkidle' });
+						await waitForNavigation({ waitUntil: 'networkidle' });
 						// clicks should reset, means the browser refreshed
 						expect(await getText('button')).toBe('Clicks: 0');
 					});

--- a/packages/e2e-tests/kit-node/__tests__/kit.spec.ts
+++ b/packages/e2e-tests/kit-node/__tests__/kit.spec.ts
@@ -232,14 +232,14 @@ describe('kit-node', () => {
 					});
 				});
 				describe('config file update', () => {
-					it('should show an overlay', async () => {
-						await editFile('svelte.config.js', (config) => config + '\n');
-						const errorOverlay = await page.waitForSelector('vite-error-overlay');
-						expect(errorOverlay).toBeTruthy();
-						const message = await errorOverlay.$$eval('.message-body', (m) => {
-							return m[0].innerHTML;
-						});
-						expect(message).toContain('Svelte config change detected');
+					it('should auto refresh', async () => {
+						const button = await getEl('button');
+						await button.click();
+						expect(await getText('button')).toBe('Clicks: 1');
+						editFile('svelte.config.js', (config) => config + '\n');
+						await page.waitForNavigation({ waitUntil: 'networkidle' });
+						// clicks should reset, means the browser refreshed
+						expect(await getText('button')).toBe('Clicks: 0');
 					});
 				});
 			});

--- a/packages/e2e-tests/kit-node/package.json
+++ b/packages/e2e-tests/kit-node/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@sveltejs/adapter-node": "^1.0.0-next.56",
-    "@sveltejs/kit": "^1.0.0-next.203",
+    "@sveltejs/kit": "^1.0.0-next.204",
     "e2e-test-dep-svelte-api-only": "workspace:*",
     "svelte": "^3.44.3",
     "svelte-i18n": "^3.3.13"

--- a/packages/e2e-tests/testUtils.ts
+++ b/packages/e2e-tests/testUtils.ts
@@ -213,6 +213,7 @@ export async function waitForNavigation(opts: Parameters<typeof page.waitForNavi
 			timeout - 50 // have slightly shorter timeout so error is shown before playwright timeout
 		);
 	});
-	await Promise.race([page.waitForNavigation(opts), timeoutPromise]);
-	clearTimeout(timeoutHandle);
+	await Promise.race([page.waitForNavigation(opts), timeoutPromise]).finally(() => {
+		clearTimeout(timeoutHandle);
+	});
 }

--- a/packages/e2e-tests/testUtils.ts
+++ b/packages/e2e-tests/testUtils.ts
@@ -203,3 +203,16 @@ export async function editViteConfig(replacer: (str: string) => string) {
 	await page.goto(viteTestUrl, { waitUntil: 'networkidle' });
 	await sleep(50);
 }
+
+export async function waitForNavigation(opts: Parameters<typeof page.waitForNavigation>[0]) {
+	const timeout = opts.timeout || 30000; // default playwright timeout is 30000
+	let timeoutHandle: NodeJS.Timeout;
+	const timeoutPromise = new Promise((resolve, reject) => {
+		timeoutHandle = setTimeout(
+			() => reject(new Error(`navigation timed out after ${timeout}ms`)),
+			timeout - 50 // have slightly shorter timeout so error is shown before playwright timeout
+		);
+	});
+	await Promise.race([page.waitForNavigation(opts), timeoutPromise]);
+	clearTimeout(timeoutHandle);
+}

--- a/packages/playground/kit-demo-app/package.json
+++ b/packages/playground/kit-demo-app/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@sveltejs/adapter-node": "^1.0.0-next.56",
-    "@sveltejs/kit": "^1.0.0-next.203",
+    "@sveltejs/kit": "^1.0.0-next.204",
     "svelte": "^3.44.3"
   },
   "type": "module",

--- a/packages/vite-plugin-svelte/src/utils/options.ts
+++ b/packages/vite-plugin-svelte/src/utils/options.ts
@@ -99,7 +99,7 @@ export function resolveOptions(
 	viteConfig: ResolvedConfig
 ): ResolvedOptions {
 	const defaultOptions: Partial<Options> = {
-		hot: viteConfig.isProduction ? false : { injectCss: !preResolveOptions.emitCss },
+		hot: viteConfig.isProduction ? false : { injectCss: preResolveOptions.emitCss },
 		compilerOptions: {
 			css: !preResolveOptions.emitCss,
 			dev: !viteConfig.isProduction

--- a/packages/vite-plugin-svelte/src/utils/options.ts
+++ b/packages/vite-plugin-svelte/src/utils/options.ts
@@ -82,9 +82,7 @@ export async function preResolveOptions(
 		// extras
 		root: viteConfigWithResolvedRoot.root!,
 		isBuild: viteEnv.command === 'build',
-		isServe: viteEnv.command === 'serve',
-		// @ts-expect-error we don't declare kit property of svelte config but read it once here to identify kit projects
-		isSvelteKit: !!svelteConfig?.kit
+		isServe: viteEnv.command === 'serve'
 	};
 	// configFile of svelteConfig contains the absolute path it was loaded from,
 	// prefer it over the possibly relative inline path
@@ -101,7 +99,7 @@ export function resolveOptions(
 	viteConfig: ResolvedConfig
 ): ResolvedOptions {
 	const defaultOptions: Partial<Options> = {
-		hot: viteConfig.isProduction ? false : { injectCss: preResolveOptions.emitCss },
+		hot: viteConfig.isProduction ? false : { injectCss: !preResolveOptions.emitCss },
 		compilerOptions: {
 			css: !preResolveOptions.emitCss,
 			dev: !viteConfig.isProduction
@@ -492,7 +490,6 @@ export interface PreResolvedOptions extends Options {
 	root: string;
 	isBuild: boolean;
 	isServe: boolean;
-	isSvelteKit: boolean;
 }
 
 export interface ResolvedOptions extends PreResolvedOptions {

--- a/packages/vite-plugin-svelte/src/utils/watch.ts
+++ b/packages/vite-plugin-svelte/src/utils/watch.ts
@@ -42,8 +42,8 @@ export function setupWatchers(
 	};
 
 	const triggerViteRestart = (filename: string) => {
-		if (serverConfig.middlewareMode || options.isSvelteKit) {
-			// in middlewareMode or for sveltekit we can't restart the server automatically
+		if (serverConfig.middlewareMode) {
+			// in middlewareMode we can't restart the server automatically
 			// show the user an overlay instead
 			const message =
 				'Svelte config change detected, restart your dev process to apply the changes.';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -220,13 +220,13 @@ importers:
   packages/e2e-tests/kit-node:
     specifiers:
       '@sveltejs/adapter-node': ^1.0.0-next.56
-      '@sveltejs/kit': ^1.0.0-next.203
+      '@sveltejs/kit': ^1.0.0-next.204
       e2e-test-dep-svelte-api-only: workspace:*
       svelte: ^3.44.3
       svelte-i18n: ^3.3.13
     devDependencies:
       '@sveltejs/adapter-node': 1.0.0-next.56
-      '@sveltejs/kit': 1.0.0-next.203_svelte@3.44.3
+      '@sveltejs/kit': 1.0.0-next.204_svelte@3.44.3
       e2e-test-dep-svelte-api-only: link:../_test_dependencies/svelte-api-only
       svelte: 3.44.3
       svelte-i18n: 3.3.13_svelte@3.44.3
@@ -362,7 +362,7 @@ importers:
       '@fontsource/fira-mono': ^4.5.0
       '@lukeed/uuid': ^2.0.0
       '@sveltejs/adapter-node': ^1.0.0-next.56
-      '@sveltejs/kit': ^1.0.0-next.203
+      '@sveltejs/kit': ^1.0.0-next.204
       cookie: ^0.4.1
       svelte: ^3.44.3
     dependencies:
@@ -371,7 +371,7 @@ importers:
       cookie: 0.4.1
     devDependencies:
       '@sveltejs/adapter-node': 1.0.0-next.56
-      '@sveltejs/kit': 1.0.0-next.203_svelte@3.44.3
+      '@sveltejs/kit': 1.0.0-next.204_svelte@3.44.3
       svelte: 3.44.3
 
   packages/playground/optimizedeps-include:
@@ -1313,8 +1313,8 @@ packages:
       tiny-glob: 0.2.9
     dev: true
 
-  /@sveltejs/kit/1.0.0-next.203_svelte@3.44.3:
-    resolution: {integrity: sha512-+bhfmkzquWMSCCFIJoh36U9D6IKC0p/NrIr4CBHMAdRpqzL9lMP0AYQm1fUDH20F/6b2tWvGxmEg+gAmHikRfA==}
+  /@sveltejs/kit/1.0.0-next.204_svelte@3.44.3:
+    resolution: {integrity: sha512-Jl9pyMc94YxO/hq/pCc4d+Syo354N9QH46QzZYfnu2QS+MPDL/JkHE56Cqr8qg+ewiVEDqCJ6Ljo7GxPTksspw==}
     engines: {node: '>=14.13'}
     hasBin: true
     peerDependencies:


### PR DESCRIPTION
Closes #210

Tested locally and it seems that it's working fine for SvelteKit on latest version. It probably won't work when someone updates vite-plugin-svelte and not sveltekit, but perhaps it's fine since we're in pre mode.