### PR TITLE
fix: create correct default hot options

### DIFF
--- a/packages/vite-plugin-svelte/src/utils/options.ts
+++ b/packages/vite-plugin-svelte/src/utils/options.ts
@@ -101,7 +101,7 @@ export function resolveOptions(
 	viteConfig: ResolvedConfig
 ): ResolvedOptions {
 	const defaultOptions: Partial<Options> = {
-		hot: viteConfig.isProduction ? false : { injectCss: preResolveOptions.emitCss },
+		hot: viteConfig.isProduction ? false : { injectCss: !preResolveOptions.emitCss },
 		compilerOptions: {
 			css: !preResolveOptions.emitCss,
 			dev: !viteConfig.isProduction


### PR DESCRIPTION
This should have `!` based on the previous code. Got lost after the refactor. Otherwise the `enforceOptionsForHmr()` function would make a warning on startup everytime.

I don't think this needs a changeset, since we haven't make a release of the refactor yet?