### PR TITLE
fix: support `experimental.useVitePreprocess` option for Vite 2.8

### DIFF
--- a/.changeset/soft-masks-fold.md
+++ b/.changeset/soft-masks-fold.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+fix `experimental.useVitePreprocess` option for Vite 2.8

--- a/packages/vite-plugin-svelte/src/utils/preprocess.ts
+++ b/packages/vite-plugin-svelte/src/utils/preprocess.ts
@@ -25,7 +25,8 @@ function createViteScriptPreprocessor(): Preprocessor {
 			tsconfigRaw: {
 				compilerOptions: {
 					// svelte typescript needs this flag to work with type imports
-					importsNotUsedAsValues: 'preserve'
+					importsNotUsedAsValues: 'preserve',
+					preserveValueImports: true
 				}
 			}
 		});


### PR DESCRIPTION
Add `preserveValueImports: true`, which was a breaking change for esbuild 0.14 where it is [preferred](https://github.com/evanw/esbuild/blob/master/CHANGELOG.md#0140) over `importsNotUsedAsValues: 'preserve'`. I think `importsNotUsedAsValues` can be removed too as they overlap a lot, but keeping as is seems to work fine and backwards-compatible too.