### PR TITLE
feat: re-prebundle when config changed

### DIFF
--- a/.changeset/rare-crews-give.md
+++ b/.changeset/rare-crews-give.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': minor
+---
+
+Automatically re-prebundle when Svelte config changed for `experimental.prebundleSvelteLibraries`

--- a/packages/vite-plugin-svelte/src/index.ts
+++ b/packages/vite-plugin-svelte/src/index.ts
@@ -19,6 +19,7 @@ import { ensureWatchedFile, setupWatchers } from './utils/watch';
 import { resolveViaPackageJsonSvelte } from './utils/resolve';
 import { PartialResolvedId } from 'rollup';
 import { toRollupError } from './utils/error';
+import { handleOptimizeDeps } from './utils/optimizer';
 
 export function svelte(inlineOptions?: Partial<Options>): Plugin {
 	if (process.env.DEBUG != null) {
@@ -67,6 +68,10 @@ export function svelte(inlineOptions?: Partial<Options>): Plugin {
 			compileSvelte = createCompileSvelte(options);
 			viteConfig = config;
 			log.debug('resolved options', options);
+		},
+
+		async buildStart() {
+			await handleOptimizeDeps(options, viteConfig);
 		},
 
 		configureServer(server) {

--- a/packages/vite-plugin-svelte/src/utils/optimizer.ts
+++ b/packages/vite-plugin-svelte/src/utils/optimizer.ts
@@ -21,7 +21,9 @@ export async function handleOptimizeDeps(options: ResolvedOptions, viteConfig: R
 	if (!fs.existsSync(viteMetadataPath)) return;
 
 	const svelteMetadataPath = path.resolve(viteConfig.cacheDir, '_svelte_metadata.json');
-	const currentSvelteMetadata = JSON.stringify(generateSvelteMetadata(options));
+	const currentSvelteMetadata = JSON.stringify(generateSvelteMetadata(options), (_, value) => {
+		return typeof value === 'function' ? value.toString() : value;
+	});
 
 	if (fs.existsSync(svelteMetadataPath)) {
 		const existingSvelteMetadata = fs.readFileSync(svelteMetadataPath, 'utf8');

--- a/packages/vite-plugin-svelte/src/utils/optimizer.ts
+++ b/packages/vite-plugin-svelte/src/utils/optimizer.ts
@@ -1,0 +1,41 @@
+import fs from 'fs';
+import path from 'path';
+import { optimizeDeps, ResolvedConfig } from 'vite';
+import { ResolvedOptions } from './options';
+
+// List of options that changes the prebundling result
+const PREBUNDLE_SENSITIVE_OPTIONS: (keyof ResolvedOptions)[] = [
+	'compilerOptions',
+	'configFile',
+	'experimental',
+	'extensions',
+	'ignorePluginPreprocessors',
+	'preprocess'
+];
+
+export async function handleOptimizeDeps(options: ResolvedOptions, viteConfig: ResolvedConfig) {
+	if (!options.experimental.prebundleSvelteLibraries || !viteConfig.cacheDir) return;
+
+	const viteMetadataPath = path.resolve(viteConfig.cacheDir, '_metadata.json');
+
+	if (!fs.existsSync(viteMetadataPath)) return;
+
+	const svelteMetadataPath = path.resolve(viteConfig.cacheDir, '_svelte_metadata.json');
+	const currentSvelteMetadata = JSON.stringify(generateSvelteMetadata(options));
+
+	if (fs.existsSync(svelteMetadataPath)) {
+		const existingSvelteMetadata = fs.readFileSync(svelteMetadataPath, 'utf8');
+		if (existingSvelteMetadata === currentSvelteMetadata) return;
+	}
+
+	await optimizeDeps(viteConfig, true);
+	fs.writeFileSync(svelteMetadataPath, currentSvelteMetadata);
+}
+
+function generateSvelteMetadata(options: ResolvedOptions) {
+	const metadata: Record<string, any> = {};
+	for (const key of PREBUNDLE_SENSITIVE_OPTIONS) {
+		metadata[key] = options[key];
+	}
+	return metadata;
+}

--- a/packages/vite-plugin-svelte/src/utils/watch.ts
+++ b/packages/vite-plugin-svelte/src/utils/watch.ts
@@ -54,7 +54,7 @@ export function setupWatchers(
 			});
 		} else {
 			log.info(`svelte config changed: restarting vite server. - file: ${filename}`);
-			server.restart(!!options.experimental?.prebundleSvelteLibraries);
+			server.restart();
 		}
 	};
 


### PR DESCRIPTION
Resolve `Automatic re-prebundle when svelte config change.` task of #222.

I think this works nicely based on my brief tests. The `preprocessor` field should also be taken care of by converting them into `.toString()`, which is good enough.