### PR TITLE
fix: use the resolved vite root

### DIFF
--- a/.changeset/popular-tigers-camp.md
+++ b/.changeset/popular-tigers-camp.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+use the resolved vite root to support backend integrations

--- a/packages/vite-plugin-svelte/src/utils/options.ts
+++ b/packages/vite-plugin-svelte/src/utils/options.ts
@@ -112,6 +112,7 @@ export function resolveOptions(
 			...defaultOptions.compilerOptions,
 			...preResolveOptions.compilerOptions
 		},
+		root: viteConfig.root,
 		isProduction: viteConfig.isProduction
 	};
 	addExtraPreprocessors(merged, viteConfig);


### PR DESCRIPTION
### Description 📖 

This pull request fixes a [compatibility issue] between `vite-plugin-svelte` and backend integrations like [Vite Ruby], by using the `root` provided by Vite in the `configResolved` hook.

### Background 📜 

`vite-plugin-svelte` needs to infer the `root` before `configResolved` in order to pre-scan svelte dependencies, which was last changed in #115.

Vite plugins can override options using the `config` hook. In particular, [Vite Ruby](https://github.com/ElMassimo/vite_ruby) changes the `root` option based on user configuration, which is typically a subfolder (instead of the project root, `process.cwd()`).

`vite-plugin-svelte` does not use the resolved value for `root`, which can cause Vite and `vite-plugin-svelte` to use different values of `root` to resolve paths.

### The Bug 🐞 

Since the `root` is different, the [check for file existence](https://github.com/sveltejs/vite-plugin-svelte/blob/main/packages/vite-plugin-svelte/src/utils/id.ts#L70) when creating a CSS virtual module no longer matches the expected result, preventing CSS virtual modules from [being served][compatibility issue].

### Proposed Fix  🔨 

Using the `root` that Vite provides in the `configResolved` hook fixes this and other similar problems.

### Notes ✏️ 

Since `vite-plugin-svelte` uses `enforce: 'pre'`, it's not viable for other plugins to workaround this issue without this patch.

Using `enforce: 'pre'` in other plugins would make the outcome dependent on the order in which the plugins are applied in the user config, which would be error-prone and result in a bad user experience.

[Vite Ruby]: https://github.com/ElMassimo/vite_ruby
[compatibility issue]: https://github.com/ElMassimo/vite_ruby/issues/171