### PR TITLE
chore: fix vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,8 @@
     "overrides": {
       "@sveltejs/vite-plugin-svelte": "workspace:*",
       "vite": "^2.7.13",
-      "ansi-regex@>2.1.1 <5.0.1": "^5.0.1"
+      "ansi-regex@>2.1.1 <5.0.1": "^5.0.1",
+      "node-fetch@2": "^2.6.7"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,7 @@ overrides:
   '@sveltejs/vite-plugin-svelte': workspace:*
   vite: ^2.7.13
   ansi-regex@>2.1.1 <5.0.1: ^5.0.1
+  node-fetch@2: ^2.6.7
 
 importers:
 
@@ -35,7 +36,7 @@ importers:
       jest-environment-node: ^27.4.6
       jest-junit: ^13.0.0
       lint-staged: ^12.1.7
-      node-fetch: ^2.6.6
+      node-fetch: ^2.6.7
       npm-run-all: ^4.1.5
       playwright-core: ^1.17.2
       prettier: ^2.5.1
@@ -72,7 +73,7 @@ importers:
       jest-environment-node: 27.4.6
       jest-junit: 13.0.0
       lint-staged: 12.1.7
-      node-fetch: 2.6.6
+      node-fetch: 2.6.7
       npm-run-all: 4.1.5
       playwright-core: 1.17.2
       prettier: 2.5.1
@@ -203,14 +204,14 @@ importers:
     specifiers:
       '@sveltejs/vite-plugin-svelte': workspace:*
       e2e-test-dep-svelte-simple: workspace:*
-      node-fetch: ^2.6.6
+      node-fetch: ^2.6.7
       svelte: ^3.46.2
       vite: ^2.7.13
     dependencies:
       e2e-test-dep-svelte-simple: link:../_test_dependencies/svelte-simple
     devDependencies:
       '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte
-      node-fetch: 2.6.6
+      node-fetch: 2.6.7
       svelte: 3.46.2
       vite: 2.7.13
 
@@ -867,7 +868,9 @@ packages:
     resolution: {integrity: sha512-vm5VgHwrxkMkUjFyn3UVNKLbDp9YMHd3vMf1IyJoa/7B+6VpqmtAaXyDS0zBLfN5bhzVCHrRnj4GcZXXcqrFTw==}
     dependencies:
       dataloader: 1.4.0
-      node-fetch: 2.6.6
+      node-fetch: 2.6.7
+    transitivePeerDependencies:
+      - encoding
     dev: true
 
   /@changesets/get-release-plan/3.0.4:
@@ -5169,9 +5172,14 @@ packages:
     resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
     dev: true
 
-  /node-fetch/2.6.6:
-    resolution: {integrity: sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==}
+  /node-fetch/2.6.7:
+    resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
     engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
     dependencies:
       whatwg-url: 5.0.0
     dev: true


### PR DESCRIPTION
Renovate PRs are failing on `pnpm audit`

Note: For some reason, `pnpm audit --fix` decided to add `"node-fetch@<2.6.7": ">=2.6.7"` to `pnpm.overrides`, but running `pnpm i` later doesn't fix the vulnerabilities in the lock file at all, so I modified it a bit. The same fix is applied in `vite-plugin-qrcode`.