### PR TITLE
fix: preprocess error reporting

### DIFF
--- a/.changeset/pretty-hairs-press.md
+++ b/.changeset/pretty-hairs-press.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+include stack and filename in error reporting for svelte preprocess errors

--- a/packages/vite-plugin-svelte/src/index.ts
+++ b/packages/vite-plugin-svelte/src/index.ts
@@ -170,7 +170,7 @@ export function svelte(inlineOptions?: Partial<Options>): Plugin {
 			try {
 				compileData = await compileSvelte(svelteRequest, code, options);
 			} catch (e) {
-				throw toRollupError(e);
+				throw toRollupError(e, options);
 			}
 			logCompilerWarnings(compileData.compiled.warnings, options);
 			cache.update(compileData);

--- a/packages/vite-plugin-svelte/src/utils/compile.ts
+++ b/packages/vite-plugin-svelte/src/utils/compile.ts
@@ -37,7 +37,13 @@ const _createCompileSvelte = (makeHot: Function) =>
 		let preprocessed;
 
 		if (options.preprocess) {
-			preprocessed = await preprocess(code, options.preprocess, { filename });
+			try {
+				preprocessed = await preprocess(code, options.preprocess, { filename });
+			} catch (e) {
+				e.message = `Error while preprocessing ${filename}${e.message ? ` - ${e.message}` : ''}`;
+				throw e;
+			}
+
 			if (preprocessed.dependencies) dependencies.push(...preprocessed.dependencies);
 			if (preprocessed.map) compileOptions.sourcemap = preprocessed.map;
 		}

--- a/packages/vite-plugin-svelte/src/utils/esbuild.ts
+++ b/packages/vite-plugin-svelte/src/utils/esbuild.ts
@@ -27,7 +27,7 @@ export function esbuildSveltePlugin(options: ResolvedOptions): EsbuildPlugin {
 					const contents = await compileSvelte(options, { filename, code });
 					return { contents };
 				} catch (e) {
-					return { errors: [toESBuildError(e)] };
+					return { errors: [toESBuildError(e, options)] };
 				}
 			});
 		}
@@ -73,7 +73,12 @@ async function compileSvelte(
 	let preprocessed;
 
 	if (options.preprocess) {
-		preprocessed = await preprocess(code, options.preprocess, { filename });
+		try {
+			preprocessed = await preprocess(code, options.preprocess, { filename });
+		} catch (e) {
+			e.message = `Error while preprocessing ${filename}${e.message ? ` - ${e.message}` : ''}`;
+			throw e;
+		}
 		if (preprocessed.map) compileOptions.sourcemap = preprocessed.map;
 	}
 

--- a/packages/vite-plugin-svelte/src/utils/log.ts
+++ b/packages/vite-plugin-svelte/src/utils/log.ts
@@ -164,7 +164,10 @@ export function buildExtendedLogMessage(w: Warning) {
 		parts.push(':', w.start.line, ':', w.start.column);
 	}
 	if (w.message) {
-		parts.push(' ', w.message);
+		if (parts.length > 0) {
+			parts.push(' ');
+		}
+		parts.push(w.message);
 	}
 	return parts.join('');
 }

--- a/packages/vite-plugin-svelte/src/utils/options.ts
+++ b/packages/vite-plugin-svelte/src/utils/options.ts
@@ -82,7 +82,8 @@ export async function preResolveOptions(
 		// extras
 		root: viteConfigWithResolvedRoot.root!,
 		isBuild: viteEnv.command === 'build',
-		isServe: viteEnv.command === 'serve'
+		isServe: viteEnv.command === 'serve',
+		isDebug: process.env.DEBUG != null
 	};
 	// configFile of svelteConfig contains the absolute path it was loaded from,
 	// prefer it over the possibly relative inline path
@@ -491,6 +492,7 @@ export interface PreResolvedOptions extends Options {
 	root: string;
 	isBuild: boolean;
 	isServe: boolean;
+	isDebug: boolean;
 }
 
 export interface ResolvedOptions extends PreResolvedOptions {


### PR DESCRIPTION
see #259 

include stack and filename in errors thrown from svelte.preprocess

This should give people enough information to track it down. new output looks like this

```shell
Error while preprocessing /home/dominikg/develop/sveltejs/vite-plugin-svelte/packages/playground/kit-demo-ts/src/routes/__layout.svelte - Cannot read properties of undefined (reading 'split')
TypeError: Error while preprocessing /home/dominikg/develop/sveltejs/vite-plugin-svelte/packages/playground/kit-demo-ts/src/routes/__layout.svelte - Cannot read properties of undefined (reading 'split')
    at Object.parseAttributes (/home/dominikg/develop/sveltejs/vite-plugin-svelte/node_modules/.pnpm/svelte-preprocess@4.9.0_svelte@3.46.2+typescript@4.5.5/node_modules/svelte-preprocess/dist/modules/markup.js:19:10)
    at getScriptContent (/home/dominikg/develop/sveltejs/vite-plugin-svelte/node_modules/.pnpm/svelte-preprocess@4.9.0_svelte@3.46.2+typescript@4.5.5/node_modules/svelte-preprocess/dist/transformers/typescript.js:47:38)
    at injectVarsToCode (/home/dominikg/develop/sveltejs/vite-plugin-svelte/node_modules/.pnpm/svelte-preprocess@4.9.0_svelte@3.46.2+typescript@4.5.5/node_modules/svelte-preprocess/dist/transformers/typescript.js:83:20)
    at mixedImportsTranspiler (/home/dominikg/develop/sveltejs/vite-plugin-svelte/node_modules/.pnpm/svelte-preprocess@4.9.0_svelte@3.46.2+typescript@4.5.5/node_modules/svelte-preprocess/dist/transformers/typescript.js:205:26)
    at transformer (/home/dominikg/develop/sveltejs/vite-plugin-svelte/node_modules/.pnpm/svelte-preprocess@4.9.0_svelte@3.46.2+typescript@4.5.5/node_modules/svelte-preprocess/dist/transformers/typescript.js:275:11)
    at Object.exports.transform (/home/dominikg/develop/sveltejs/vite-plugin-svelte/node_modules/.pnpm/svelte-preprocess@4.9.0_svelte@3.46.2+typescript@4.5.5/node_modules/svelte-preprocess/dist/autoProcess.js:37:12)
    at async /home/dominikg/develop/sveltejs/vite-plugin-svelte/node_modules/.pnpm/svelte-preprocess@4.9.0_svelte@3.46.2+typescript@4.5.5/node_modules/svelte-preprocess/dist/autoProcess.js:113:29
    at async script (/home/dominikg/develop/sveltejs/vite-plugin-svelte/node_modules/.pnpm/svelte-preprocess@4.9.0_svelte@3.46.2+typescript@4.5.5/node_modules/svelte-preprocess/dist/autoProcess.js:143:33)
    at async process_single_tag (file:///home/dominikg/develop/sveltejs/vite-plugin-svelte/node_modules/.pnpm/svelte@3.46.2/node_modules/svelte/compiler.mjs:32106:27)
    at async Promise.all (index 0)
```

Note: `stack` is omitted during dev for errors that include a code frame unless `DEBUG` environment variable is set. This is done to keep the noise down for compiler errors. The stack is huge and spammy and not nearly as helpful as the frame and message, in most cases.