### PR TITLE
fix: change cjs detection heuristic to take exports map into account

### DIFF
--- a/packages/e2e-tests/_test_dependencies/cjs-and-esm-exports/index.cjs
+++ b/packages/e2e-tests/_test_dependencies/cjs-and-esm-exports/index.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+	cjs_and_esm_exported: () => 'cjs-via-exports'
+}

--- a/packages/e2e-tests/_test_dependencies/cjs-and-esm-exports/index.mjs
+++ b/packages/e2e-tests/_test_dependencies/cjs-and-esm-exports/index.mjs
@@ -1,0 +1,1 @@
+export function cjs_and_esm_exported() { return 'esm-via-exports' };

--- a/packages/e2e-tests/_test_dependencies/cjs-and-esm-exports/package.json
+++ b/packages/e2e-tests/_test_dependencies/cjs-and-esm-exports/package.json
@@ -1,0 +1,17 @@
+{
+  "version": "1.0.0",
+  "private": true,
+  "name": "e2e-test-dep-cjs-and-esm-exports",
+  "files": [
+    "package.json",
+    "index.mjs",
+    "index.cjs"
+  ],
+  "exports":{
+    ".": {
+      "import": "./index.mjs",
+      "require": "./index.cjs"
+    },
+    "./package.json": "./package.json"
+  }
+}

--- a/packages/e2e-tests/_test_dependencies/cjs-only-exports/index.js
+++ b/packages/e2e-tests/_test_dependencies/cjs-only-exports/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+	cjs_exported: () => 'cjs-via-exports'
+};

--- a/packages/e2e-tests/_test_dependencies/cjs-only-exports/package.json
+++ b/packages/e2e-tests/_test_dependencies/cjs-only-exports/package.json
@@ -1,0 +1,11 @@
+{
+  "version": "1.0.0",
+  "private": true,
+  "name": "e2e-test-dep-cjs-only-exports",
+  "exports": "./index.js",
+  "files": [
+    "package.json",
+    "index.js"
+  ],
+  "type": "commonjs"
+}

--- a/packages/e2e-tests/_test_dependencies/svelte-nested/package.json
+++ b/packages/e2e-tests/_test_dependencies/svelte-nested/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "e2e-test-dep-svelte-simple": "workspace:*",
     "e2e-test-dep-cjs-and-esm": "workspace:*",
+    "e2e-test-dep-cjs-and-esm-exports": "workspace:*",
     "e2e-test-dep-scss-only": "workspace:*"
   }
 }

--- a/packages/e2e-tests/_test_dependencies/svelte-nested/src/components/Message.svelte
+++ b/packages/e2e-tests/_test_dependencies/svelte-nested/src/components/Message.svelte
@@ -2,8 +2,11 @@
 	export let id = 'id';
 	export let message = '';
 	import { cjs_and_esm } from 'e2e-test-dep-cjs-and-esm';
+	// eslint-disable-next-line node/no-missing-import
+	import { cjs_and_esm_exported } from 'e2e-test-dep-cjs-and-esm-exports';
 	import 'e2e-test-dep-scss-only';
 </script>
 
 <div {id}>{message}</div>
 <div id="cjs-and-esm">{cjs_and_esm()}</div>
+<div id="cjs-and-esm-exported">{cjs_and_esm_exported()}</div>

--- a/packages/e2e-tests/_test_dependencies/svelte-simple/package.json
+++ b/packages/e2e-tests/_test_dependencies/svelte-simple/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "svelte": "index.js",
   "dependencies": {
-    "e2e-test-dep-cjs-only": "workspace:*"
+    "e2e-test-dep-cjs-only": "workspace:*",
+    "e2e-test-dep-cjs-only-exports": "workspace:*"
   }
 }

--- a/packages/e2e-tests/_test_dependencies/svelte-simple/src/components/Dependency.svelte
+++ b/packages/e2e-tests/_test_dependencies/svelte-simple/src/components/Dependency.svelte
@@ -2,11 +2,14 @@
 	const label = 'dependency-import';
 	import * as cjsOnly from 'e2e-test-dep-cjs-only';
 	const { cjs } = cjsOnly;
+	import * as cjsOnlyExported from 'e2e-test-dep-cjs-only-exports';
+	const { cjs_exported } = cjsOnlyExported;
 </script>
 
 <div id="dependency-import"><span class="label">{label}</span></div>
 <div id="sticky-dep" class="sticky-dep">sticky-dep</div>
 <div id="cjs-only-dependency">{cjs()}</div>
+<div id="cjs-only-dependency-exported">{cjs_exported()}</div>
 
 <style>
 	.label {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,7 +95,13 @@ importers:
   packages/e2e-tests/_test_dependencies/cjs-and-esm:
     specifiers: {}
 
+  packages/e2e-tests/_test_dependencies/cjs-and-esm-exports:
+    specifiers: {}
+
   packages/e2e-tests/_test_dependencies/cjs-only:
+    specifiers: {}
+
+  packages/e2e-tests/_test_dependencies/cjs-only-exports:
     specifiers: {}
 
   packages/e2e-tests/_test_dependencies/esm-only:
@@ -118,18 +124,22 @@ importers:
   packages/e2e-tests/_test_dependencies/svelte-nested:
     specifiers:
       e2e-test-dep-cjs-and-esm: workspace:*
+      e2e-test-dep-cjs-and-esm-exports: workspace:*
       e2e-test-dep-scss-only: workspace:*
       e2e-test-dep-svelte-simple: workspace:*
     dependencies:
       e2e-test-dep-cjs-and-esm: link:../cjs-and-esm
+      e2e-test-dep-cjs-and-esm-exports: link:../cjs-and-esm-exports
       e2e-test-dep-scss-only: link:../scss-only
       e2e-test-dep-svelte-simple: link:../svelte-simple
 
   packages/e2e-tests/_test_dependencies/svelte-simple:
     specifiers:
       e2e-test-dep-cjs-only: workspace:*
+      e2e-test-dep-cjs-only-exports: workspace:*
     dependencies:
       e2e-test-dep-cjs-only: link:../cjs-only
+      e2e-test-dep-cjs-only-exports: link:../cjs-only-exports
 
   packages/e2e-tests/autoprefixer-browerslist:
     specifiers:


### PR DESCRIPTION
"exports" in package.json isn't only for esm and if it exists it takes precedence over "main". 
We can't realistically parse it to find the entry ourselves, so delegate that to require.resolve

Questions: is that the right approach? If so, should we simplify it and do it regardless of presence of main/exports?

cc @benmccann 