### PR TITLE
fix: don't try to resolve internal node modules via package.json svelte field

### DIFF
--- a/.changeset/chatty-trees-sell.md
+++ b/.changeset/chatty-trees-sell.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+don't try to resolve node internal modules via package.json svelte field

--- a/packages/vite-plugin-svelte/src/utils/resolve.ts
+++ b/packages/vite-plugin-svelte/src/utils/resolve.ts
@@ -2,13 +2,19 @@ import path from 'path';
 import { createRequire } from 'module';
 import { is_common_without_svelte_field, resolveDependencyData } from './dependencies';
 import { VitePluginSvelteCache } from './vite-plugin-svelte-cache';
+import { builtinModules } from 'module';
 
 export function resolveViaPackageJsonSvelte(
 	importee: string,
 	importer: string | undefined,
 	cache: VitePluginSvelteCache
 ): string | void {
-	if (importer && isBareImport(importee) && !is_common_without_svelte_field(importee)) {
+	if (
+		importer &&
+		isBareImport(importee) &&
+		!isNodeInternal(importee) &&
+		!is_common_without_svelte_field(importee)
+	) {
 		const cached = cache.getResolvedSvelteField(importee, importer);
 		if (cached) {
 			return cached;
@@ -26,6 +32,10 @@ export function resolveViaPackageJsonSvelte(
 			throw new Error(`failed to resolve package.json of ${importee} imported by ${importer}`);
 		}
 	}
+}
+
+function isNodeInternal(importee: string) {
+	return importee.startsWith('node:') || builtinModules.includes(importee);
 }
 
 function isBareImport(importee: string): boolean {

--- a/packages/vite-plugin-svelte/src/utils/resolve.ts
+++ b/packages/vite-plugin-svelte/src/utils/resolve.ts
@@ -1,8 +1,7 @@
 import path from 'path';
-import { createRequire } from 'module';
+import { builtinModules, createRequire } from 'module';
 import { is_common_without_svelte_field, resolveDependencyData } from './dependencies';
 import { VitePluginSvelteCache } from './vite-plugin-svelte-cache';
-import { builtinModules } from 'module';
 
 export function resolveViaPackageJsonSvelte(
 	importee: string,


### PR DESCRIPTION
i could swear is saw a response in a closed issue that node internals were printed as missing a package.json export in buildEnd.
Can't find that now but we shouldn't even be trying, even if vite is asking our resolve hook.

found it: https://github.com/sveltejs/vite-plugin-svelte/issues/244#issuecomment-1028341898