### PR TITLE
Extend docs for `useVitePreprocess`

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -191,7 +191,7 @@ export default defineConfig({
 - **Type:** `boolean`
 - **Default:** `false`
 
-  Use extra preprocessors that delegate style and TypeScript preprocessing to native Vite plugins. TypeScript will be transformed with esbuild. Styles will be transformed using [Vite's CSS plugin](https://vitejs.dev/guide/features.html#css), which handles `@imports`, `url()` references, PostCSS, CSS Modules, and `.scss`/`.sass`/`.less`/`.styl`/`.stylus` files. Do not use together with TypeScript or style preprocessors from `svelte-preprocess` as attempts to transform the content twice will break!
+  Use extra preprocessors that delegate style and TypeScript preprocessing to native Vite plugins. TypeScript will be transformed with esbuild. Styles will be transformed using [Vite's CSS plugin](https://vitejs.dev/guide/features.html#css), which handles `@imports`, `url()` references, PostCSS, CSS Modules, and `.scss`/`.sass`/`.less`/`.styl`/`.stylus` files. Do not use together with TypeScript or style preprocessors from `svelte-preprocess` as attempts to transform the content twice will fail!
 
 ### prebundleSvelteLibraries
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -191,7 +191,7 @@ export default defineConfig({
 - **Type:** `boolean`
 - **Default:** `false`
 
-  Use extra preprocessors that delegate style and TypeScript preprocessing to native Vite plugins. Do not use together with `svelte-preprocess`!
+  Use extra preprocessors that delegate style and TypeScript preprocessing to native Vite plugins. TypeScript will be transformed with esbuild. Styles will be transformed using [Vite's CSS plugin](https://vitejs.dev/guide/features.html#css), which handles `@imports`, `url()` references, PostCSS, CSS Modules, and `.scss`/`.sass`/`.less`/`.styl`/`.stylus` files. Do not use together with TypeScript or style preprocessors from `svelte-preprocess` as attempts to transform the content twice will break!
 
 ### prebundleSvelteLibraries
 


### PR DESCRIPTION
Adds a bit more detail. It wasn't exactly clear to me what the option did at first. It looks very cool now that I've learned a bit more about it!