### PR TITLE
chore: anticipate vite cache changes

### DIFF
--- a/packages/e2e-tests/package-json-svelte-field/__tests__/package-json-svelte-field.spec.ts
+++ b/packages/e2e-tests/package-json-svelte-field/__tests__/package-json-svelte-field.spec.ts
@@ -8,8 +8,7 @@ test('should render component imported via svelte field in package.json', async 
 
 if (!isBuild) {
 	test('should optimize nested cjs deps of excluded svelte deps', () => {
-		const vitePrebundleMetadata = path.resolve(__dirname, '../node_modules/.vite/_metadata.json');
-		const metadataFile = fs.readFileSync(vitePrebundleMetadata, 'utf8');
+		const metadataFile = readVitePrebundleMetadata();
 		const metadata = JSON.parse(metadataFile);
 		const optimizedPaths = Object.keys(metadata.optimized);
 		expect(optimizedPaths).not.toContain('e2e-test-dep-svelte-nested');
@@ -18,4 +17,21 @@ if (!isBuild) {
 			'e2e-test-dep-svelte-nested > e2e-test-dep-svelte-simple > e2e-test-dep-cjs-only'
 		);
 	});
+}
+
+function readVitePrebundleMetadata() {
+	const metadataPaths = [
+		'../node_modules/.vite/_metadata.json',
+		'../node_modules/.vite/deps/_metadata.json' // vite 2.9
+	];
+	for (const metadataPath of metadataPaths) {
+		try {
+			const vitePrebundleMetadata = path.resolve(__dirname, metadataPath);
+			const metadataFile = fs.readFileSync(vitePrebundleMetadata, 'utf8');
+			return metadataFile;
+		} catch {
+			// ignore
+		}
+	}
+	throw new Error('Unable to find vite prebundle metadata');
 }

--- a/packages/vite-plugin-svelte/src/utils/optimizer.ts
+++ b/packages/vite-plugin-svelte/src/utils/optimizer.ts
@@ -16,11 +16,10 @@ const PREBUNDLE_SENSITIVE_OPTIONS: (keyof ResolvedOptions)[] = [
 export async function handleOptimizeDeps(options: ResolvedOptions, viteConfig: ResolvedConfig) {
 	if (!options.experimental.prebundleSvelteLibraries || !viteConfig.cacheDir) return;
 
-	const viteMetadataPath = path.resolve(viteConfig.cacheDir, '_metadata.json');
+	const viteMetadataPath = findViteMetadataPath(viteConfig.cacheDir);
+	if (!viteMetadataPath) return;
 
-	if (!fs.existsSync(viteMetadataPath)) return;
-
-	const svelteMetadataPath = path.resolve(viteConfig.cacheDir, '_svelte_metadata.json');
+	const svelteMetadataPath = path.resolve(viteMetadataPath, '../_svelte_metadata.json');
 	const currentSvelteMetadata = JSON.stringify(generateSvelteMetadata(options), (_, value) => {
 		return typeof value === 'function' ? value.toString() : value;
 	});
@@ -40,4 +39,12 @@ function generateSvelteMetadata(options: ResolvedOptions) {
 		metadata[key] = options[key];
 	}
 	return metadata;
+}
+
+function findViteMetadataPath(cacheDir: string) {
+	const metadataPaths = ['_metadata.json', 'deps/_metadata.json'];
+	for (const metadataPath of metadataPaths) {
+		const viteMetadataPath = path.resolve(cacheDir, metadataPath);
+		if (fs.existsSync(viteMetadataPath)) return viteMetadataPath;
+	}
 }


### PR DESCRIPTION
https://github.com/vitejs/vite/pull/6758 updated the prebundling deps to be in `.vite/deps/...`, which will be merged in Vite 2.9.

I also realized with https://github.com/vitejs/vite/pull/6758, the `experimental.prebundleSvelteLibraries` option might not work well as the current flow expects prebundling to happen before server start. Will have to further verify this.

Related discussion on [discord](https://discord.com/channels/804011606160703521/945287098469060708/945293902099923005).