### PR TITLE
fix: optimize nested index-only deps

### DIFF
--- a/.changeset/gold-drinks-peel.md
+++ b/.changeset/gold-drinks-peel.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+Optimize nested index-only dependencies

--- a/packages/e2e-tests/_test_dependencies/index-only/index.js
+++ b/packages/e2e-tests/_test_dependencies/index-only/index.js
@@ -1,0 +1,1 @@
+module.exports = 'foo';

--- a/packages/e2e-tests/_test_dependencies/index-only/package.json
+++ b/packages/e2e-tests/_test_dependencies/index-only/package.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.0.0",
+  "private": true,
+  "name": "e2e-test-dep-index-only",
+  "files": [
+    "index.js"
+  ]
+}

--- a/packages/e2e-tests/_test_dependencies/types-only/index.d.ts
+++ b/packages/e2e-tests/_test_dependencies/types-only/index.d.ts
@@ -1,0 +1,1 @@
+export function foo(): string;

--- a/packages/e2e-tests/_test_dependencies/types-only/package.json
+++ b/packages/e2e-tests/_test_dependencies/types-only/package.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.0.0",
+  "private": true,
+  "name": "e2e-test-dep-types-only",
+  "types": "./index.d.ts",
+  "files": [
+    "index.d.ts"
+  ]
+}

--- a/packages/e2e-tests/dependencies/package.json
+++ b/packages/e2e-tests/dependencies/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "e2e-tests-dependencies",
+  "description": "Used by dependencies.spec.ts",
+  "private": true,
+  "version": "0.0.0",
+  "dependencies": {
+    "e2e-test-dep-cjs-and-esm": "workspace:*",
+    "e2e-test-dep-cjs-only": "workspace:*",
+    "e2e-test-dep-esm-only": "workspace:*",
+    "e2e-test-dep-index-only": "workspace:*",
+    "e2e-test-dep-scss-only": "workspace:*"
+  }
+}

--- a/packages/vite-plugin-svelte/src/utils/__tests__/dependencies.spec.ts
+++ b/packages/vite-plugin-svelte/src/utils/__tests__/dependencies.spec.ts
@@ -1,15 +1,16 @@
-import { findRootSvelteDependencies } from '../dependencies';
+import { findRootSvelteDependencies, needsOptimization } from '../dependencies';
 import * as path from 'path';
+import { createRequire } from 'module';
 
 describe('dependencies', () => {
 	describe('findRootSvelteDependencies', () => {
-		it('should find svelte dependencies in packages/e2e-test/hmr', async () => {
+		it('should find svelte dependencies in packages/e2e-test/hmr', () => {
 			const deps = findRootSvelteDependencies(path.resolve('packages/e2e-tests/hmr'));
 			expect(deps).toHaveLength(1);
 			expect(deps[0].name).toBe('e2e-test-dep-svelte-simple');
 			expect(deps[0].path).toEqual([]);
 		});
-		it('should find nested svelte dependencies in packages/e2e-test/package-json-svelte-field', async () => {
+		it('should find nested svelte dependencies in packages/e2e-test/package-json-svelte-field', () => {
 			const deps = findRootSvelteDependencies(
 				path.resolve('packages/e2e-tests/package-json-svelte-field')
 			);
@@ -24,6 +25,16 @@ describe('dependencies', () => {
 			expect(simple).toBeTruthy();
 			expect(simple.path).toHaveLength(1);
 			expect(simple.path[0]).toBe('e2e-test-dep-svelte-nested');
+		});
+	});
+	describe('needsOptimization', () => {
+		it('should optimize cjs deps only', () => {
+			const localRequire = createRequire(path.resolve('packages/e2e-tests/dependencies'));
+			expect(needsOptimization('e2e-test-dep-cjs-and-esm', localRequire)).toBe(false);
+			expect(needsOptimization('e2e-test-dep-cjs-only', localRequire)).toBe(true);
+			expect(needsOptimization('e2e-test-dep-esm-only', localRequire)).toBe(false);
+			expect(needsOptimization('e2e-test-dep-index-only', localRequire)).toBe(true);
+			expect(needsOptimization('e2e-test-dep-types-only', localRequire)).toBe(false);
 		});
 	});
 });

--- a/packages/vite-plugin-svelte/src/utils/dependencies.ts
+++ b/packages/vite-plugin-svelte/src/utils/dependencies.ts
@@ -187,12 +187,23 @@ export function needsOptimization(dep: string, localRequire: NodeRequire): boole
 	const pkg = depData.pkg;
 	// only optimize if is cjs, using the below as heuristic
 	// see https://github.com/sveltejs/vite-plugin-svelte/issues/162
-	const isCjs = pkg.main && !pkg.module && !pkg.exports;
-	if (!isCjs) return false;
-	// ensure entry is js so vite can prebundle it
-	// see https://github.com/sveltejs/vite-plugin-svelte/issues/233
-	const entryExt = path.extname(pkg.main);
-	return !entryExt || entryExt === '.js' || entryExt === '.cjs';
+	const hasEsmFields = pkg.module || pkg.exports;
+	if (hasEsmFields) return false;
+	if (pkg.main) {
+		// ensure entry is js so vite can prebundle it
+		// see https://github.com/sveltejs/vite-plugin-svelte/issues/233
+		const entryExt = path.extname(pkg.main);
+		return !entryExt || entryExt === '.js' || entryExt === '.cjs';
+	} else {
+		// check if has implicit index.js entrypoint
+		// https://github.com/sveltejs/vite-plugin-svelte/issues/281
+		try {
+			localRequire.resolve(`${dep}/index.js`);
+			return true;
+		} catch {
+			return false;
+		}
+	}
 }
 
 interface DependencyData {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
   packages/e2e-tests/_test_dependencies/esm-only:
     specifiers: {}
 
+  packages/e2e-tests/_test_dependencies/index-only:
+    specifiers: {}
+
   packages/e2e-tests/_test_dependencies/scss-only:
     specifiers: {}
 
@@ -128,6 +131,9 @@ importers:
       e2e-test-dep-cjs-only: workspace:*
     dependencies:
       e2e-test-dep-cjs-only: link:../cjs-only
+
+  packages/e2e-tests/_test_dependencies/types-only:
+    specifiers: {}
 
   packages/e2e-tests/autoprefixer-browerslist:
     specifiers:
@@ -187,6 +193,20 @@ importers:
       '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte
       svelte: 3.46.4
       vite: 2.8.0
+
+  packages/e2e-tests/dependencies:
+    specifiers:
+      e2e-test-dep-cjs-and-esm: workspace:*
+      e2e-test-dep-cjs-only: workspace:*
+      e2e-test-dep-esm-only: workspace:*
+      e2e-test-dep-index-only: workspace:*
+      e2e-test-dep-scss-only: workspace:*
+    dependencies:
+      e2e-test-dep-cjs-and-esm: link:../_test_dependencies/cjs-and-esm
+      e2e-test-dep-cjs-only: link:../_test_dependencies/cjs-only
+      e2e-test-dep-esm-only: link:../_test_dependencies/esm-only
+      e2e-test-dep-index-only: link:../_test_dependencies/index-only
+      e2e-test-dep-scss-only: link:../_test_dependencies/scss-only
 
   packages/e2e-tests/env:
     specifiers:
@@ -367,23 +387,6 @@ importers:
       cookie: 0.4.2
     devDependencies:
       '@sveltejs/adapter-auto': 1.0.0-next.28
-      '@sveltejs/kit': 1.0.0-next.278_svelte@3.46.4
-      svelte: 3.46.4
-
-  packages/playground/kit-demo-app-bak:
-    specifiers:
-      '@fontsource/fira-mono': ^4.5.3
-      '@lukeed/uuid': ^2.0.0
-      '@sveltejs/adapter-node': ^1.0.0-next.68
-      '@sveltejs/kit': ^1.0.0-next.278
-      cookie: ^0.4.2
-      svelte: ^3.46.4
-    dependencies:
-      '@fontsource/fira-mono': 4.5.3
-      '@lukeed/uuid': 2.0.0
-      cookie: 0.4.2
-    devDependencies:
-      '@sveltejs/adapter-node': 1.0.0-next.68
       '@sveltejs/kit': 1.0.0-next.278_svelte@3.46.4
       svelte: 3.46.4
 


### PR DESCRIPTION
Fixes #281

`lodash.debounce` exposes the entrypoint via `index.js` implicitly, which is considered CJS to be pre-bundled as well. 

Also added more tests for `needsOptimization()` hueristic.