### PR TITLE
fix: externalize transitive cjs only deps during dev ssr

### DIFF
--- a/.changeset/cold-pumpkins-enjoy.md
+++ b/.changeset/cold-pumpkins-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+improve handling of transitive cjs dependencies of svelte libraries during dev ssr

--- a/packages/vite-plugin-svelte/src/index.ts
+++ b/packages/vite-plugin-svelte/src/index.ts
@@ -55,7 +55,7 @@ export function svelte(inlineOptions?: Partial<Options>): Plugin {
 			// @ts-expect-error temporarily lend the options variable until fixed in configResolved
 			options = await preResolveOptions(inlineOptions, config, configEnv);
 			// extra vite config
-			const extraViteConfig = buildExtraViteConfig(options, config, configEnv);
+			const extraViteConfig = buildExtraViteConfig(options, config);
 			log.debug('additional vite config', extraViteConfig);
 			return extraViteConfig;
 		},

--- a/packages/vite-plugin-svelte/src/utils/options.ts
+++ b/packages/vite-plugin-svelte/src/utils/options.ts
@@ -318,9 +318,10 @@ function buildSSROptionsForSvelte(
 
 	if (options.isServe) {
 		// during dev, we have to externalize transitive dependencies, see https://github.com/sveltejs/vite-plugin-svelte/issues/281
-		const transitiveDepsOfSvelteLibs = [
-			...new Set(svelteDeps.flatMap((dep) => Object.keys(dep.pkg.dependencies || {})))
-		].filter(
+		// @ts-expect-error ssr still flagged in vite
+		ssr.external = Array.from(
+			new Set(svelteDeps.flatMap((dep) => Object.keys(dep.pkg.dependencies || {})))
+		).filter(
 			(dep) =>
 				!ssr.noExternal.includes(dep) &&
 				// @ts-expect-error ssr still flagged in vite
@@ -328,8 +329,6 @@ function buildSSROptionsForSvelte(
 				// @ts-expect-error ssr still flagged in vite
 				!config.ssr?.external?.includes(dep)
 		);
-		// @ts-expect-error ssr still flagged in vite
-		ssr.external = transitiveDepsOfSvelteLibs;
 	}
 
 	return ssr;

--- a/packages/vite-plugin-svelte/src/utils/options.ts
+++ b/packages/vite-plugin-svelte/src/utils/options.ts
@@ -320,7 +320,13 @@ function buildSSROptionsForSvelte(
 		// during dev, we have to externalize transitive dependencies, see https://github.com/sveltejs/vite-plugin-svelte/issues/281
 		const transitiveDepsOfSvelteLibs = [
 			...new Set(svelteDeps.flatMap((dep) => Object.keys(dep.pkg.dependencies || {})))
-		];
+			// @ts-expect-error ssr still flagged in vite
+		].filter(
+			(dep) =>
+				!ssr.noExternal.includes(dep) &&
+				!config.ssr?.noExternal.includes(dep) &&
+				!config.ssr?.external.includes(dep)
+		);
 		// @ts-expect-error ssr still flagged in vite
 		ssr.external = transitiveDepsOfSvelteLibs;
 	}

--- a/packages/vite-plugin-svelte/src/utils/options.ts
+++ b/packages/vite-plugin-svelte/src/utils/options.ts
@@ -217,13 +217,14 @@ export function buildExtraViteConfig(
 			?.filter((x) => x.includes('>'))
 			.map((x) => x.substring(x.lastIndexOf('>') + 1).trim());
 		if (optimizedTransitiveDeps?.length) {
-			// @ts-ignore
+			// @ts-expect-error ssr still flagge in vite
 			if (!extraViteConfig.ssr.external) {
-				// @ts-ignore
+				// @ts-expect-error ssr still flagge in vite
 				extraViteConfig.ssr.external = [];
 			}
-			// @ts-ignore
+			// @ts-expect-error ssr still flagge in vite
 			extraViteConfig.ssr.external.push(
+				// @ts-expect-error ssr still flagge in vite
 				...optimizedTransitiveDeps.filter((x) => !config.ssr?.noExternal?.includes(x))
 			);
 		}

--- a/packages/vite-plugin-svelte/src/utils/options.ts
+++ b/packages/vite-plugin-svelte/src/utils/options.ts
@@ -211,6 +211,23 @@ export function buildExtraViteConfig(
 	// @ts-ignore
 	extraViteConfig.ssr = buildSSROptionsForSvelte(svelteDeps, options, config);
 
+	if (configEnv.command === 'serve') {
+		// during dev, we have to externalize transitive cjs only dependencies, see https://github.com/sveltejs/vite-plugin-svelte/issues/281
+		const optimizedTransitiveDeps = extraViteConfig.optimizeDeps?.include
+			?.filter((x) => x.includes('>'))
+			.map((x) => x.substring(x.lastIndexOf('>') + 1).trim());
+		if (optimizedTransitiveDeps?.length) {
+			// @ts-ignore
+			if (!extraViteConfig.ssr.external) {
+				// @ts-ignore
+				extraViteConfig.ssr.external = [];
+			}
+			// @ts-ignore
+			extraViteConfig.ssr.external.push(
+				...optimizedTransitiveDeps.filter((x) => !config.ssr?.noExternal?.includes(x))
+			);
+		}
+	}
 	return extraViteConfig;
 }
 

--- a/packages/vite-plugin-svelte/src/utils/options.ts
+++ b/packages/vite-plugin-svelte/src/utils/options.ts
@@ -320,12 +320,13 @@ function buildSSROptionsForSvelte(
 		// during dev, we have to externalize transitive dependencies, see https://github.com/sveltejs/vite-plugin-svelte/issues/281
 		const transitiveDepsOfSvelteLibs = [
 			...new Set(svelteDeps.flatMap((dep) => Object.keys(dep.pkg.dependencies || {})))
-			// @ts-expect-error ssr still flagged in vite
 		].filter(
 			(dep) =>
 				!ssr.noExternal.includes(dep) &&
-				!config.ssr?.noExternal.includes(dep) &&
-				!config.ssr?.external.includes(dep)
+				// @ts-expect-error ssr still flagged in vite
+				!config.ssr?.noExternal?.includes(dep) &&
+				// @ts-expect-error ssr still flagged in vite
+				!config.ssr?.external?.includes(dep)
 		);
 		// @ts-expect-error ssr still flagged in vite
 		ssr.external = transitiveDepsOfSvelteLibs;


### PR DESCRIPTION
see #281 

i'm still getting an error though when adding `bytemd` to a sveltekit project 

this is rendered in the html output of localhost:3000 after a brief flash of an unstyled editor.
```
500
The requested module '/node_modules/.pnpm/codemirror-ssr@0.0.6/node_modules/codemirror-ssr/mode/gfm/gfm.js?v=9e01fcfd' does not provide an export named 'default'
SyntaxError: The requested module '/node_modules/.pnpm/codemirror-ssr@0.0.6/node_modules/codemirror-ssr/mode/gfm/gfm.js?v=9e01fcfd' does not provide an export named 'default'
```