### PR TITLE
chore: update vite peer dep changeset

### DIFF
--- a/.changeset/young-chicken-agree.md
+++ b/.changeset/young-chicken-agree.md
@@ -2,4 +2,4 @@
 '@sveltejs/vite-plugin-svelte': major
 ---
 
-Handle edge cases for `experimental.prebundleSvelteLibraries`
+Update vite peerDependency to ^2.9.0 and handle edge cases for `experimental.prebundleSvelteLibraries`

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   "pnpm": {
     "overrides": {
       "@sveltejs/vite-plugin-svelte": "workspace:*",
-      "vite": "^2.9.0",
+      "vite": "^2.9.1",
       "ansi-regex@>2.1.1 <5.0.1": "^5.0.1",
       "node-fetch@2": "^2.6.7"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,7 +2,7 @@ lockfileVersion: 5.3
 
 overrides:
   '@sveltejs/vite-plugin-svelte': workspace:*
-  vite: ^2.9.0
+  vite: ^2.9.1
   ansi-regex@>2.1.1 <5.0.1: ^5.0.1
   node-fetch@2: ^2.6.7
 
@@ -44,7 +44,7 @@ importers:
       svelte: ^3.46.6
       ts-jest: ^27.1.4
       typescript: ^4.6.3
-      vite: ^2.9.0
+      vite: ^2.9.1
     devDependencies:
       '@changesets/cli': 2.22.0
       '@svitejs/changesets-changelog-github-compact': 0.1.1
@@ -80,7 +80,7 @@ importers:
       svelte: 3.46.6
       ts-jest: 27.1.4_bdf263159739b0cb45207a4c64472a45
       typescript: 4.6.3
-      vite: 2.9.0
+      vite: 2.9.1
 
   packages/e2e-tests:
     specifiers:
@@ -147,7 +147,7 @@ importers:
       postcss-load-config: ^3.1.4
       svelte: ^3.46.6
       svelte-preprocess: ^4.10.5
-      vite: ^2.9.0
+      vite: ^2.9.1
     dependencies:
       e2e-test-dep-svelte-simple: link:../_test_dependencies/svelte-simple
     devDependencies:
@@ -157,20 +157,20 @@ importers:
       postcss-load-config: 3.1.4_postcss@8.4.12
       svelte: 3.46.6
       svelte-preprocess: 4.10.5_3ce0e22b85336b1a63f5104127fe70c5
-      vite: 2.9.0
+      vite: 2.9.1
 
   packages/e2e-tests/configfile-custom:
     specifiers:
       '@sveltejs/vite-plugin-svelte': workspace:*
       e2e-test-dep-svelte-simple: workspace:*
       svelte: ^3.46.6
-      vite: ^2.9.0
+      vite: ^2.9.1
     dependencies:
       e2e-test-dep-svelte-simple: link:../_test_dependencies/svelte-simple
     devDependencies:
       '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte
       svelte: 3.46.6
-      vite: 2.9.0
+      vite: 2.9.1
 
   packages/e2e-tests/configfile-esm:
     specifiers:
@@ -178,24 +178,24 @@ importers:
       e2e-test-dep-svelte-simple: workspace:*
       svelte: ^3.46.6
       svelte-preprocess: ^4.10.5
-      vite: ^2.9.0
+      vite: ^2.9.1
     dependencies:
       e2e-test-dep-svelte-simple: link:../_test_dependencies/svelte-simple
     devDependencies:
       '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte
       svelte: 3.46.6
       svelte-preprocess: 4.10.5_svelte@3.46.6+typescript@4.6.3
-      vite: 2.9.0
+      vite: 2.9.1
 
   packages/e2e-tests/custom-extensions:
     specifiers:
       '@sveltejs/vite-plugin-svelte': workspace:*
       svelte: ^3.46.6
-      vite: ^2.9.0
+      vite: ^2.9.1
     devDependencies:
       '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte
       svelte: 3.46.6
-      vite: 2.9.0
+      vite: 2.9.1
 
   packages/e2e-tests/dependencies:
     specifiers:
@@ -215,11 +215,11 @@ importers:
     specifiers:
       '@sveltejs/vite-plugin-svelte': workspace:*
       svelte: ^3.46.6
-      vite: ^2.9.0
+      vite: ^2.9.1
     devDependencies:
       '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte
       svelte: 3.46.6
-      vite: 2.9.0
+      vite: 2.9.1
 
   packages/e2e-tests/hmr:
     specifiers:
@@ -228,7 +228,7 @@ importers:
       e2e-test-dep-vite-plugins: workspace:*
       node-fetch: ^2.6.7
       svelte: ^3.46.6
-      vite: ^2.9.0
+      vite: ^2.9.1
     dependencies:
       e2e-test-dep-svelte-simple: link:../_test_dependencies/svelte-simple
     devDependencies:
@@ -236,7 +236,7 @@ importers:
       e2e-test-dep-vite-plugins: link:../_test_dependencies/vite-plugins
       node-fetch: 2.6.7
       svelte: 3.46.6
-      vite: 2.9.0
+      vite: 2.9.1
 
   packages/e2e-tests/kit-node:
     specifiers:
@@ -260,14 +260,14 @@ importers:
       e2e-test-dep-svelte-hybrid: workspace:*
       e2e-test-dep-svelte-nested: workspace:*
       svelte: ^3.46.6
-      vite: ^2.9.0
+      vite: ^2.9.1
     dependencies:
       e2e-test-dep-svelte-hybrid: link:../_test_dependencies/svelte-hybrid
       e2e-test-dep-svelte-nested: link:../_test_dependencies/svelte-nested
     devDependencies:
       '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte
       svelte: 3.46.6
-      vite: 2.9.0
+      vite: 2.9.1
 
   packages/e2e-tests/preprocess-with-vite:
     specifiers:
@@ -275,13 +275,13 @@ importers:
       sass: ^1.49.11
       stylus: ^0.57.0
       svelte: ^3.46.6
-      vite: ^2.9.0
+      vite: ^2.9.1
     devDependencies:
       '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte
       sass: 1.49.11
       stylus: 0.57.0
       svelte: 3.46.6
-      vite: 2.9.0_sass@1.49.11+stylus@0.57.0
+      vite: 2.9.1_sass@1.49.11+stylus@0.57.0
 
   packages/e2e-tests/svelte-preprocess:
     specifiers:
@@ -289,13 +289,13 @@ importers:
       svelte: ^3.46.6
       svelte-preprocess: ^4.10.5
       typescript: ^4.6.3
-      vite: ^2.9.0
+      vite: ^2.9.1
     devDependencies:
       '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte
       svelte: 3.46.6
       svelte-preprocess: 4.10.5_svelte@3.46.6+typescript@4.6.3
       typescript: 4.6.3
-      vite: 2.9.0
+      vite: 2.9.1
 
   packages/e2e-tests/ts-type-import:
     specifiers:
@@ -303,13 +303,13 @@ importers:
       '@tsconfig/svelte': ^3.0.0
       '@types/node': ^17.0.21
       svelte-preprocess: ^4.10.5
-      vite: ^2.9.0
+      vite: ^2.9.1
     devDependencies:
       '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte
       '@tsconfig/svelte': 3.0.0
       '@types/node': 17.0.21
       svelte-preprocess: 4.10.5_svelte@3.46.6+typescript@4.6.3
-      vite: 2.9.0
+      vite: 2.9.1
 
   packages/e2e-tests/vite-ssr:
     specifiers:
@@ -320,7 +320,7 @@ importers:
       express: ^4.17.3
       serve-static: ^1.15.0
       svelte: ^3.46.6
-      vite: ^2.9.0
+      vite: ^2.9.1
     devDependencies:
       '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte
       compression: 1.7.4
@@ -329,7 +329,7 @@ importers:
       express: 4.17.3
       serve-static: 1.15.0
       svelte: 3.46.6
-      vite: 2.9.0
+      vite: 2.9.1
 
   packages/e2e-tests/vite-ssr-esm:
     specifiers:
@@ -342,7 +342,7 @@ importers:
       npm-run-all: ^4.1.5
       serve-static: ^1.15.0
       svelte: ^3.46.6
-      vite: ^2.9.0
+      vite: ^2.9.1
     devDependencies:
       '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte
       compression: 1.7.4
@@ -353,7 +353,7 @@ importers:
       npm-run-all: 4.1.5
       serve-static: 1.15.0
       svelte: 3.46.6
-      vite: 2.9.0
+      vite: 2.9.1
 
   packages/playground:
     specifiers: {}
@@ -362,11 +362,11 @@ importers:
     specifiers:
       '@sveltejs/vite-plugin-svelte': workspace:*
       svelte: ^3.46.6
-      vite: ^2.9.0
+      vite: ^2.9.1
     devDependencies:
       '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte
       svelte: 3.46.6
-      vite: 2.9.0
+      vite: 2.9.1
 
   packages/playground/big-component-library:
     specifiers:
@@ -374,14 +374,14 @@ importers:
       carbon-components-svelte: ^0.62.3
       lodash-es: ^4.17.21
       svelte: ^3.46.6
-      vite: ^2.9.0
+      vite: ^2.9.1
     dependencies:
       lodash-es: 4.17.21
     devDependencies:
       '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte
       carbon-components-svelte: 0.62.3
       svelte: 3.46.6
-      vite: 2.9.0
+      vite: 2.9.1
 
   packages/playground/kit-demo-app:
     specifiers:
@@ -405,19 +405,19 @@ importers:
       '@sveltejs/vite-plugin-svelte': workspace:*
       svelte: ^3.46.6
       tinro: ^0.6.12
-      vite: ^2.9.0
+      vite: ^2.9.1
     devDependencies:
       '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte
       svelte: 3.46.6
       tinro: 0.6.12
-      vite: 2.9.0
+      vite: 2.9.1
 
   packages/playground/windicss:
     specifiers:
       '@sveltejs/vite-plugin-svelte': workspace:*
       diff-match-patch: ^1.0.5
       svelte: ^3.46.6
-      vite: ^2.9.0
+      vite: ^2.9.1
       vite-plugin-windicss: ^1.8.3
       windicss: ^3.5.1
     dependencies:
@@ -426,8 +426,8 @@ importers:
       '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte
       diff-match-patch: 1.0.5
       svelte: 3.46.6
-      vite: 2.9.0
-      vite-plugin-windicss: 1.8.3_vite@2.9.0
+      vite: 2.9.1
+      vite-plugin-windicss: 1.8.3_vite@2.9.1
 
   packages/vite-plugin-svelte:
     specifiers:
@@ -443,7 +443,7 @@ importers:
       svelte: ^3.46.6
       svelte-hmr: ^0.14.11
       tsup: ^5.12.4
-      vite: ^2.9.0
+      vite: ^2.9.1
     dependencies:
       '@rollup/pluginutils': 4.2.0
       debug: 4.3.4
@@ -458,7 +458,7 @@ importers:
       rollup: 2.70.1
       svelte: 3.46.6
       tsup: 5.12.4_typescript@4.6.3
-      vite: 2.9.0
+      vite: 2.9.1
 
 packages:
 
@@ -1409,7 +1409,7 @@ packages:
       '@sveltejs/vite-plugin-svelte': link:packages/vite-plugin-svelte
       sade: 1.8.1
       svelte: 3.46.6
-      vite: 2.9.0
+      vite: 2.9.1
     transitivePeerDependencies:
       - less
       - sass
@@ -7112,7 +7112,7 @@ packages:
     engines: {node: '>= 0.8'}
     dev: true
 
-  /vite-plugin-windicss/1.8.3_vite@2.9.0:
+  /vite-plugin-windicss/1.8.3_vite@2.9.1:
     resolution: {integrity: sha512-RIw2GD6H6cKNE8wZXVOBs4L1uTicVS0FaAkeqXvy1oyuXLC4SXmvnzEuoK0+qFuWJjW0ECNwE8eU+ZZhzNQKUg==}
     peerDependencies:
       vite: ^2.0.1
@@ -7120,14 +7120,14 @@ packages:
       '@windicss/plugin-utils': 1.8.3
       debug: 4.3.3
       kolorist: 1.5.1
-      vite: 2.9.0
+      vite: 2.9.1
       windicss: 3.5.1
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /vite/2.9.0:
-    resolution: {integrity: sha512-5NAnNqzPmZzJvrswZGeTS2JHrBGIzIWJA2hBTTMYuoBVEMh0xwE0b5yyIXFxf7F07hrK4ugX2LJ7q6t7iIbd4Q==}
+  /vite/2.9.1:
+    resolution: {integrity: sha512-vSlsSdOYGcYEJfkQ/NeLXgnRv5zZfpAsdztkIrs7AZHV8RCMZQkwjo4DS5BnrYTqoWqLoUe1Cah4aVO4oNNqCQ==}
     engines: {node: '>=12.2.0'}
     hasBin: true
     peerDependencies:
@@ -7142,7 +7142,7 @@ packages:
       stylus:
         optional: true
     dependencies:
-      esbuild: 0.14.29
+      esbuild: 0.14.31
       postcss: 8.4.12
       resolve: 1.22.0
       rollup: 2.70.1
@@ -7150,8 +7150,8 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /vite/2.9.0_sass@1.49.11+stylus@0.57.0:
-    resolution: {integrity: sha512-5NAnNqzPmZzJvrswZGeTS2JHrBGIzIWJA2hBTTMYuoBVEMh0xwE0b5yyIXFxf7F07hrK4ugX2LJ7q6t7iIbd4Q==}
+  /vite/2.9.1_sass@1.49.11+stylus@0.57.0:
+    resolution: {integrity: sha512-vSlsSdOYGcYEJfkQ/NeLXgnRv5zZfpAsdztkIrs7AZHV8RCMZQkwjo4DS5BnrYTqoWqLoUe1Cah4aVO4oNNqCQ==}
     engines: {node: '>=12.2.0'}
     hasBin: true
     peerDependencies:
@@ -7166,7 +7166,7 @@ packages:
       stylus:
         optional: true
     dependencies:
-      esbuild: 0.14.29
+      esbuild: 0.14.31
       postcss: 8.4.12
       resolve: 1.22.0
       rollup: 2.70.1


### PR DESCRIPTION
Note the Vite peer dep bump in the changeset.

Also updated `pnpm.overrides` for Vite 2.9.1. It should be 2.9.1 from last renovate upgrade but it didn't update the overrides. I'm also wondering now if it's better to bring back the pnpmfile so we don't have to do this manually again.