### PR TITLE
chore: replace deprecated String.prototype.substr()

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -53,6 +53,10 @@ module.exports = {
 			}
 		],
 		'node/no-deprecated-api': 'off',
+		'no-restricted-properties': [
+			'error',
+			{ property: 'substr', message: 'Use .slice instead of .substr.' }
+		],
 		'node/no-unpublished-import': 'off',
 		'node/no-unpublished-require': 'off',
 		'node/no-unsupported-features/es-syntax': 'off',

--- a/packages/vite-plugin-svelte/src/utils/hash.ts
+++ b/packages/vite-plugin-svelte/src/utils/hash.ts
@@ -14,7 +14,7 @@ export function safeBase64Hash(input: string) {
 	// OR DON'T USE A HASH AT ALL, what about a simple counter?
 	const md5 = crypto.createHash('md5');
 	md5.update(input);
-	const hash = toSafe(md5.digest('base64')).substr(0, hash_length);
+	const hash = toSafe(md5.digest('base64')).slice(0, hash_length);
 	hashes[input] = hash;
 	return hash;
 }


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.