### PR TITLE
chore: use pnpmfile to override vite

### DIFF
--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -1,0 +1,12 @@
+function readPackage(pkg) {
+	if (pkg.name === 'vite-plugin-svelte-monorepo' && !pkg.pnpm.overrides.vite) {
+		pkg.pnpm.overrides.vite = pkg.devDependencies.vite;
+	}
+	return pkg;
+}
+
+module.exports = {
+	hooks: {
+		readPackage
+	}
+};

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
   "pnpm": {
     "overrides": {
       "@sveltejs/vite-plugin-svelte": "workspace:*",
-      "vite": "^2.9.1",
       "ansi-regex@>2.1.1 <5.0.1": "^5.0.1",
       "node-fetch@2": "^2.6.7"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,7 +2,6 @@ lockfileVersion: 5.3
 
 overrides:
   '@sveltejs/vite-plugin-svelte': workspace:*
-  vite: ^2.9.1
   ansi-regex@>2.1.1 <5.0.1: ^5.0.1
   node-fetch@2: ^2.6.7
 
@@ -44,7 +43,7 @@ importers:
       svelte: ^3.47.0
       ts-jest: ^27.1.4
       typescript: ^4.6.3
-      vite: ^2.9.1
+      vite: ^2.9.5
     devDependencies:
       '@changesets/cli': 2.22.0
       '@svitejs/changesets-changelog-github-compact': 0.1.1
@@ -80,7 +79,7 @@ importers:
       svelte: 3.47.0
       ts-jest: 27.1.4_7a821434921643f91a8909d0b48334c9
       typescript: 4.6.3
-      vite: 2.9.1
+      vite: 2.9.5
 
   packages/e2e-tests:
     specifiers:
@@ -147,7 +146,7 @@ importers:
       postcss-load-config: ^3.1.4
       svelte: ^3.47.0
       svelte-preprocess: ^4.10.6
-      vite: ^2.9.1
+      vite: ^2.9.5
     dependencies:
       e2e-test-dep-svelte-simple: link:../_test_dependencies/svelte-simple
     devDependencies:
@@ -157,20 +156,20 @@ importers:
       postcss-load-config: 3.1.4_postcss@8.4.12
       svelte: 3.47.0
       svelte-preprocess: 4.10.6_8f537df1deb1f807b69cd07414ab4868
-      vite: 2.9.1
+      vite: 2.9.5
 
   packages/e2e-tests/configfile-custom:
     specifiers:
       '@sveltejs/vite-plugin-svelte': workspace:*
       e2e-test-dep-svelte-simple: workspace:*
       svelte: ^3.47.0
-      vite: ^2.9.1
+      vite: ^2.9.5
     dependencies:
       e2e-test-dep-svelte-simple: link:../_test_dependencies/svelte-simple
     devDependencies:
       '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte
       svelte: 3.47.0
-      vite: 2.9.1
+      vite: 2.9.5
 
   packages/e2e-tests/configfile-esm:
     specifiers:
@@ -178,24 +177,24 @@ importers:
       e2e-test-dep-svelte-simple: workspace:*
       svelte: ^3.47.0
       svelte-preprocess: ^4.10.6
-      vite: ^2.9.1
+      vite: ^2.9.5
     dependencies:
       e2e-test-dep-svelte-simple: link:../_test_dependencies/svelte-simple
     devDependencies:
       '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte
       svelte: 3.47.0
       svelte-preprocess: 4.10.6_svelte@3.47.0+typescript@4.6.3
-      vite: 2.9.1
+      vite: 2.9.5
 
   packages/e2e-tests/custom-extensions:
     specifiers:
       '@sveltejs/vite-plugin-svelte': workspace:*
       svelte: ^3.47.0
-      vite: ^2.9.1
+      vite: ^2.9.5
     devDependencies:
       '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte
       svelte: 3.47.0
-      vite: 2.9.1
+      vite: 2.9.5
 
   packages/e2e-tests/dependencies:
     specifiers:
@@ -215,11 +214,11 @@ importers:
     specifiers:
       '@sveltejs/vite-plugin-svelte': workspace:*
       svelte: ^3.47.0
-      vite: ^2.9.1
+      vite: ^2.9.5
     devDependencies:
       '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte
       svelte: 3.47.0
-      vite: 2.9.1
+      vite: 2.9.5
 
   packages/e2e-tests/hmr:
     specifiers:
@@ -228,7 +227,7 @@ importers:
       e2e-test-dep-vite-plugins: workspace:*
       node-fetch: ^2.6.7
       svelte: ^3.47.0
-      vite: ^2.9.1
+      vite: ^2.9.5
     dependencies:
       e2e-test-dep-svelte-simple: link:../_test_dependencies/svelte-simple
     devDependencies:
@@ -236,7 +235,7 @@ importers:
       e2e-test-dep-vite-plugins: link:../_test_dependencies/vite-plugins
       node-fetch: 2.6.7
       svelte: 3.47.0
-      vite: 2.9.1
+      vite: 2.9.5
 
   packages/e2e-tests/kit-node:
     specifiers:
@@ -260,14 +259,14 @@ importers:
       e2e-test-dep-svelte-hybrid: workspace:*
       e2e-test-dep-svelte-nested: workspace:*
       svelte: ^3.47.0
-      vite: ^2.9.1
+      vite: ^2.9.5
     dependencies:
       e2e-test-dep-svelte-hybrid: link:../_test_dependencies/svelte-hybrid
       e2e-test-dep-svelte-nested: link:../_test_dependencies/svelte-nested
     devDependencies:
       '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte
       svelte: 3.47.0
-      vite: 2.9.1
+      vite: 2.9.5
 
   packages/e2e-tests/preprocess-with-vite:
     specifiers:
@@ -275,13 +274,13 @@ importers:
       sass: ^1.50.1
       stylus: ^0.57.0
       svelte: ^3.47.0
-      vite: ^2.9.1
+      vite: ^2.9.5
     devDependencies:
       '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte
       sass: 1.50.1
       stylus: 0.57.0
       svelte: 3.47.0
-      vite: 2.9.1_sass@1.50.1+stylus@0.57.0
+      vite: 2.9.5_sass@1.50.1+stylus@0.57.0
 
   packages/e2e-tests/svelte-preprocess:
     specifiers:
@@ -289,13 +288,13 @@ importers:
       svelte: ^3.47.0
       svelte-preprocess: ^4.10.6
       typescript: ^4.6.3
-      vite: ^2.9.1
+      vite: ^2.9.5
     devDependencies:
       '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte
       svelte: 3.47.0
       svelte-preprocess: 4.10.6_svelte@3.47.0+typescript@4.6.3
       typescript: 4.6.3
-      vite: 2.9.1
+      vite: 2.9.5
 
   packages/e2e-tests/ts-type-import:
     specifiers:
@@ -303,13 +302,13 @@ importers:
       '@tsconfig/svelte': ^3.0.0
       '@types/node': ^17.0.21
       svelte-preprocess: ^4.10.6
-      vite: ^2.9.1
+      vite: ^2.9.5
     devDependencies:
       '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte
       '@tsconfig/svelte': 3.0.0
       '@types/node': 17.0.21
       svelte-preprocess: 4.10.6_svelte@3.47.0+typescript@4.6.3
-      vite: 2.9.1
+      vite: 2.9.5
 
   packages/e2e-tests/vite-ssr:
     specifiers:
@@ -320,7 +319,7 @@ importers:
       express: ^4.17.3
       serve-static: ^1.15.0
       svelte: ^3.47.0
-      vite: ^2.9.1
+      vite: ^2.9.5
     devDependencies:
       '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte
       compression: 1.7.4
@@ -329,7 +328,7 @@ importers:
       express: 4.17.3
       serve-static: 1.15.0
       svelte: 3.47.0
-      vite: 2.9.1
+      vite: 2.9.5
 
   packages/e2e-tests/vite-ssr-esm:
     specifiers:
@@ -342,7 +341,7 @@ importers:
       npm-run-all: ^4.1.5
       serve-static: ^1.15.0
       svelte: ^3.47.0
-      vite: ^2.9.1
+      vite: ^2.9.5
     devDependencies:
       '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte
       compression: 1.7.4
@@ -353,7 +352,7 @@ importers:
       npm-run-all: 4.1.5
       serve-static: 1.15.0
       svelte: 3.47.0
-      vite: 2.9.1
+      vite: 2.9.5
 
   packages/playground:
     specifiers: {}
@@ -362,11 +361,11 @@ importers:
     specifiers:
       '@sveltejs/vite-plugin-svelte': workspace:*
       svelte: ^3.47.0
-      vite: ^2.9.1
+      vite: ^2.9.5
     devDependencies:
       '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte
       svelte: 3.47.0
-      vite: 2.9.1
+      vite: 2.9.5
 
   packages/playground/big-component-library:
     specifiers:
@@ -374,14 +373,14 @@ importers:
       carbon-components-svelte: ^0.63.1
       lodash-es: ^4.17.21
       svelte: ^3.47.0
-      vite: ^2.9.1
+      vite: ^2.9.5
     dependencies:
       lodash-es: 4.17.21
     devDependencies:
       '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte
       carbon-components-svelte: 0.63.1
       svelte: 3.47.0
-      vite: 2.9.1
+      vite: 2.9.5
 
   packages/playground/kit-demo-app:
     specifiers:
@@ -405,19 +404,19 @@ importers:
       '@sveltejs/vite-plugin-svelte': workspace:*
       svelte: ^3.47.0
       tinro: ^0.6.12
-      vite: ^2.9.1
+      vite: ^2.9.5
     devDependencies:
       '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte
       svelte: 3.47.0
       tinro: 0.6.12
-      vite: 2.9.1
+      vite: 2.9.5
 
   packages/playground/windicss:
     specifiers:
       '@sveltejs/vite-plugin-svelte': workspace:*
       diff-match-patch: ^1.0.5
       svelte: ^3.47.0
-      vite: ^2.9.1
+      vite: ^2.9.5
       vite-plugin-windicss: ^1.8.4
       windicss: ^3.5.1
     dependencies:
@@ -426,8 +425,8 @@ importers:
       '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte
       diff-match-patch: 1.0.5
       svelte: 3.47.0
-      vite: 2.9.1
-      vite-plugin-windicss: 1.8.4_vite@2.9.1
+      vite: 2.9.5
+      vite-plugin-windicss: 1.8.4_vite@2.9.5
 
   packages/vite-plugin-svelte:
     specifiers:
@@ -443,7 +442,7 @@ importers:
       svelte: ^3.47.0
       svelte-hmr: ^0.14.11
       tsup: ^5.12.5
-      vite: ^2.9.1
+      vite: ^2.9.5
     dependencies:
       '@rollup/pluginutils': 4.2.1
       debug: 4.3.4
@@ -458,7 +457,7 @@ importers:
       rollup: 2.70.2
       svelte: 3.47.0
       tsup: 5.12.5_typescript@4.6.3
-      vite: 2.9.1
+      vite: 2.9.5
 
 packages:
 
@@ -7341,7 +7340,7 @@ packages:
     engines: {node: '>= 0.8'}
     dev: true
 
-  /vite-plugin-windicss/1.8.4_vite@2.9.1:
+  /vite-plugin-windicss/1.8.4_vite@2.9.5:
     resolution: {integrity: sha512-LSZAO8BZn3x406GRbYX5t5ONXXJVdqiQtN1qrznLA/Dy5/NzZVhfcrL6N1qEYYO7HsCDT4pLAjTzObvDnM9Y8A==}
     peerDependencies:
       vite: ^2.0.1
@@ -7349,7 +7348,7 @@ packages:
       '@windicss/plugin-utils': 1.8.4
       debug: 4.3.4
       kolorist: 1.5.1
-      vite: 2.9.1
+      vite: 2.9.5
       windicss: 3.5.1
     transitivePeerDependencies:
       - supports-color
@@ -7379,8 +7378,8 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /vite/2.9.1_sass@1.50.1+stylus@0.57.0:
-    resolution: {integrity: sha512-vSlsSdOYGcYEJfkQ/NeLXgnRv5zZfpAsdztkIrs7AZHV8RCMZQkwjo4DS5BnrYTqoWqLoUe1Cah4aVO4oNNqCQ==}
+  /vite/2.9.5:
+    resolution: {integrity: sha512-dvMN64X2YEQgSXF1lYabKXw3BbN6e+BL67+P3Vy4MacnY+UzT1AfkHiioFSi9+uiDUiaDy7Ax/LQqivk6orilg==}
     engines: {node: '>=12.2.0'}
     hasBin: true
     peerDependencies:
@@ -7395,10 +7394,34 @@ packages:
       stylus:
         optional: true
     dependencies:
-      esbuild: 0.14.34
+      esbuild: 0.14.36
       postcss: 8.4.12
       resolve: 1.22.0
-      rollup: 2.70.1
+      rollup: 2.70.2
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
+  /vite/2.9.5_sass@1.50.1+stylus@0.57.0:
+    resolution: {integrity: sha512-dvMN64X2YEQgSXF1lYabKXw3BbN6e+BL67+P3Vy4MacnY+UzT1AfkHiioFSi9+uiDUiaDy7Ax/LQqivk6orilg==}
+    engines: {node: '>=12.2.0'}
+    hasBin: true
+    peerDependencies:
+      less: '*'
+      sass: '*'
+      stylus: '*'
+    peerDependenciesMeta:
+      less:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+    dependencies:
+      esbuild: 0.14.36
+      postcss: 8.4.12
+      resolve: 1.22.0
+      rollup: 2.70.2
       sass: 1.50.1
       stylus: 0.57.0
     optionalDependencies:


### PR DESCRIPTION
Now renovate can update Vite properly