### PR TITLE
feat: skip reading config file with inline option

### DIFF
--- a/.changeset/good-plums-rest.md
+++ b/.changeset/good-plums-rest.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': minor
+---
+
+skip reading default svelte config file with inline option `configFile: false`

--- a/docs/config.md
+++ b/docs/config.md
@@ -36,6 +36,8 @@ export default defineConfig({
 });
 ```
 
+> To prevent reading the default config, use `configFile: false`.
+
 A basic Svelte config looks like this:
 
 ```js

--- a/packages/e2e-tests/configfile-custom/__tests__/configfile-custom.spec.ts
+++ b/packages/e2e-tests/configfile-custom/__tests__/configfile-custom.spec.ts
@@ -1,16 +1,32 @@
-import { editViteConfig } from 'testUtils';
+import { editViteConfig, isBuild } from '../../testUtils';
 
 it('should load default config and work', async () => {
+	expect(e2eServer.logs.server.out).toContain('default svelte config loaded');
 	expect(await page.textContent('h1')).toMatch('Hello world!');
 	expect(await page.textContent('#test-child')).toBe('test-child');
 	expect(await page.textContent('#dependency-import')).toBe('dependency-import');
 });
 
-it('should load custom mjs config and work', async () => {
-	await editViteConfig((c) =>
-		c.replace('svelte()', `svelte({configFile:'svelte.config.custom.cjs'})`)
-	);
-	expect(await page.textContent('h1')).toMatch('Hello world!');
-	expect(await page.textContent('#test-child')).toBe('test-child');
-	expect(await page.textContent('#dependency-import')).toBe('dependency-import');
-});
+if (!isBuild) {
+	// editing vite config does not work in build tests, build only runs once
+	// TODO split into different tests
+	it('should load custom cjs config and work', async () => {
+		await editViteConfig((c) =>
+			c.replace(/svelte\([^)]*\)/, `svelte({configFile:'svelte.config.custom.cjs'})`)
+		);
+		expect(e2eServer.logs.server.out).toContain('custom svelte config loaded cjs');
+		expect(await page.textContent('h1')).toMatch('Hello world!');
+		expect(await page.textContent('#test-child')).toBe('test-child');
+		expect(await page.textContent('#dependency-import')).toBe('dependency-import');
+	});
+
+	it('should not read default config when explicitly disabled', async () => {
+		const currentLogPos = e2eServer.logs.server.out.length;
+		await editViteConfig((c) => c.replace(/svelte\([^)]*\)/, `svelte({configFile: false})`));
+		const logsAfterChange = e2eServer.logs.server.out.slice(currentLogPos);
+		expect(logsAfterChange).not.toContain('default svelte config loaded');
+		expect(await page.textContent('h1')).toMatch('Hello world!');
+		expect(await page.textContent('#test-child')).toBe('test-child');
+		expect(await page.textContent('#dependency-import')).toBe('dependency-import');
+	});
+}

--- a/packages/e2e-tests/configfile-custom/svelte.config.cjs
+++ b/packages/e2e-tests/configfile-custom/svelte.config.cjs
@@ -1,0 +1,2 @@
+console.log('default svelte config loaded')
+module.exports = {};

--- a/packages/e2e-tests/configfile-custom/svelte.config.custom.cjs
+++ b/packages/e2e-tests/configfile-custom/svelte.config.custom.cjs
@@ -1,3 +1,4 @@
+console.log('custom svelte config loaded cjs')
 module.exports = {
 	emitCss: false
 };

--- a/packages/e2e-tests/configfile-custom/svelte.config.custom.mjs
+++ b/packages/e2e-tests/configfile-custom/svelte.config.custom.mjs
@@ -1,3 +1,4 @@
+console.log('custom svelte config loaded mjs')
 export default {
 	emitCss: false
 }

--- a/packages/e2e-tests/configfile-custom/vite.config.js
+++ b/packages/e2e-tests/configfile-custom/vite.config.js
@@ -4,7 +4,7 @@ const { defineConfig } = require('vite');
 module.exports = defineConfig(() => {
 	return {
 		root: './', // ensure custom root works, see https://github.com/sveltejs/vite-plugin-svelte/issues/113
-		plugins: [svelte({ configFile: 'svelte.config.custom.cjs' })],
+		plugins: [svelte()],
 		build: {
 			// make build faster by skipping transforms and minification
 			target: 'esnext',

--- a/packages/vite-plugin-svelte/src/utils/load-svelte-config.ts
+++ b/packages/vite-plugin-svelte/src/utils/load-svelte-config.ts
@@ -29,6 +29,9 @@ export async function loadSvelteConfig(
 	viteConfig: UserConfig,
 	inlineOptions: Partial<Options>
 ): Promise<Partial<Options> | undefined> {
+	if (inlineOptions.configFile === false) {
+		return;
+	}
 	const configFile = findConfigToLoad(viteConfig, inlineOptions);
 	if (configFile) {
 		let err;

--- a/packages/vite-plugin-svelte/src/utils/options.ts
+++ b/packages/vite-plugin-svelte/src/utils/options.ts
@@ -355,9 +355,11 @@ export interface Options {
 	/**
 	 * Path to a svelte config file, either absolute or relative to Vite root
 	 *
+	 * set to `false` to skip reading config from a file
+	 *
 	 * @see https://vitejs.dev/config/#root
 	 */
-	configFile?: string;
+	configFile?: string | false;
 
 	/**
 	 * A `picomatch` pattern, or array of patterns, which specifies the files the plugin should


### PR DESCRIPTION
useful for frameworks like sveltekit that already read the config to avoid doing duplicate work.