### PR TITLE
fix: improve support for `configFile: false`  use in kit

### DIFF
--- a/.changeset/silver-readers-wait.md
+++ b/.changeset/silver-readers-wait.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+do not warn if kit options are passed as inline config

--- a/.changeset/young-rice-bathe.md
+++ b/.changeset/young-rice-bathe.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+do not restart vite devserver on changes of svelte config when `configFile: false` is set

--- a/docs/config.md
+++ b/docs/config.md
@@ -54,9 +54,9 @@ Depending on Node's mode, make sure you're using the correct extension and synta
 
 > Try to stick with the `.js` extension whenever possible.
 
-### Disable automatic handling of svelte config
+### Disable automatic handling of Svelte config
 
-Use `configFile: false` to prevent vite-plugin-svelte from reading the config file or restarting the devserver when it changes.
+Use `configFile: false` to prevent `vite-plugin-svelte` from reading the config file or restarting the Vite dev server when it changes.
 
 ```js
 export default defineConfig({
@@ -70,8 +70,8 @@ export default defineConfig({
 ```
 
 > Warning:
-> This option primarily exists for frameworks like SvelteKit that do their own parsing of svelte config and control the devserver
-> You are responsible to provide the complete config inline when used.
+> This option primarily exists for frameworks like SvelteKit that do their own parsing of Svelte config and control the Vite dev server.
+> You are responsible to provide the complete inline config when used.
 
 ## Svelte options
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -36,8 +36,6 @@ export default defineConfig({
 });
 ```
 
-> To prevent reading the default config, use `configFile: false`.
-
 A basic Svelte config looks like this:
 
 ```js
@@ -55,6 +53,25 @@ Depending on Node's mode, make sure you're using the correct extension and synta
 - If `type: "module"` is not defined, using `.js` only allows CJS code. Use `.mjs` to allows ESM code.
 
 > Try to stick with the `.js` extension whenever possible.
+
+### Disable automatic handling of svelte config
+
+Use `configFile: false` to prevent vite-plugin-svelte from reading the config file or restarting the devserver when it changes.
+
+```js
+export default defineConfig({
+  plugins: [
+    svelte({
+      configFile: false
+      // your svelte config here
+    })
+  ]
+});
+```
+
+> Warning:
+> This option primarily exists for frameworks like SvelteKit that do their own parsing of svelte config and control the devserver
+> You are responsible to provide the complete config inline when used.
 
 ## Svelte options
 

--- a/packages/vite-plugin-svelte/src/utils/options.ts
+++ b/packages/vite-plugin-svelte/src/utils/options.ts
@@ -356,7 +356,7 @@ export interface Options {
 	/**
 	 * Path to a svelte config file, either absolute or relative to Vite root
 	 *
-	 * set to `false` to skip reading config from a file
+	 * set to `false` to ignore the svelte config file
 	 *
 	 * @see https://vitejs.dev/config/#root
 	 */

--- a/packages/vite-plugin-svelte/src/utils/options.ts
+++ b/packages/vite-plugin-svelte/src/utils/options.ts
@@ -37,7 +37,8 @@ const knownOptions = new Set([
 	'hot',
 	'ignorePluginPreprocessors',
 	'disableDependencyReinclusion',
-	'experimental'
+	'experimental',
+	'kit'
 ]);
 
 export function validateInlineOptions(inlineOptions?: Partial<Options>) {

--- a/packages/vite-plugin-svelte/src/utils/watch.ts
+++ b/packages/vite-plugin-svelte/src/utils/watch.ts
@@ -58,30 +58,34 @@ export function setupWatchers(
 		}
 	};
 
-	const possibleSvelteConfigs = knownSvelteConfigNames.map((cfg) => path.join(root, cfg));
-	const restartOnConfigAdd = (filename: string) => {
-		if (possibleSvelteConfigs.includes(filename)) {
-			triggerViteRestart(filename);
-		}
-	};
-
-	const restartOnConfigChange = (filename: string) => {
-		if (filename === svelteConfigFile) {
-			triggerViteRestart(filename);
-		}
-	};
-
 	// collection of watcher listeners by event
 	const listenerCollection = {
 		add: [] as Array<Function>,
 		change: [emitChangeEventOnDependants],
 		unlink: [removeUnlinkedFromCache, emitChangeEventOnDependants]
 	};
-	if (svelteConfigFile) {
-		listenerCollection.change.push(restartOnConfigChange);
-		listenerCollection.unlink.push(restartOnConfigChange);
-	} else {
-		listenerCollection.add.push(restartOnConfigAdd);
+
+	if (svelteConfigFile !== false) {
+		// configFile false means we ignore the file and external process is responsible
+		const possibleSvelteConfigs = knownSvelteConfigNames.map((cfg) => path.join(root, cfg));
+		const restartOnConfigAdd = (filename: string) => {
+			if (possibleSvelteConfigs.includes(filename)) {
+				triggerViteRestart(filename);
+			}
+		};
+
+		const restartOnConfigChange = (filename: string) => {
+			if (filename === svelteConfigFile) {
+				triggerViteRestart(filename);
+			}
+		};
+
+		if (svelteConfigFile) {
+			listenerCollection.change.push(restartOnConfigChange);
+			listenerCollection.unlink.push(restartOnConfigChange);
+		} else {
+			listenerCollection.add.push(restartOnConfigAdd);
+		}
 	}
 
 	Object.entries(listenerCollection).forEach(([evt, listeners]) => {


### PR DESCRIPTION
to allow sveltekit passing the whole config inline, see https://github.com/sveltejs/kit/pull/4760