### PR TITLE
fix: downgrade pnpm engine to ensure ci installs an existing version

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     ]
   },
   "engines": {
-    "pnpm": "^6.32.12",
+    "pnpm": "^6.32.0",
     "yarn": "forbidden, use pnpm",
     "npm": "forbidden, use pnpm",
     "node": "^14.13.1 || >= 16"


### PR DESCRIPTION
locally i got pnpm@6.32.11 when executing `pnpm i -g pnpm@6` not sure why, 6.32.12 exists in registry and is tagged as latest-6.

to avoid ci breaking, relax it a bit