### PR TITLE
fix(inspector): handle autocomplete keydown event

### DIFF
--- a/.changeset/hot-crabs-reply.md
+++ b/.changeset/hot-crabs-reply.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+Handle inspector autocomplete keydown event

--- a/packages/vite-plugin-svelte/src/ui/inspector/Inspector.svelte
+++ b/packages/vite-plugin-svelte/src/ui/inspector/Inspector.svelte
@@ -99,7 +99,7 @@
 	}
 
 	function keydown(event) {
-		if (event.repeat || event.key === undefined) {
+		if (event.repeat || event.key === undefined) {
 			return;
 		}
 

--- a/packages/vite-plugin-svelte/src/ui/inspector/Inspector.svelte
+++ b/packages/vite-plugin-svelte/src/ui/inspector/Inspector.svelte
@@ -99,7 +99,7 @@
 	}
 
 	function keydown(event) {
-		if (event.repeat) {
+		if (event.repeat || event.key === undefined) {
 			return;
 		}
 


### PR DESCRIPTION
Chrome triggers a "keydown" event when autocompleting in forms, which triggers a `event.getModifierState is not a function` error.
This change makes sure that only keydown events with a defined key are checked.

Related issue from another GitHub repo: https://github.com/paperjs/paper.js/issues/1398

Screenshot of bug from my project:
<img width="609" alt="Screenshot 2022-05-15 at 13 38 51" src="https://user-images.githubusercontent.com/48158184/168470850-5a85d426-2ac6-4651-949c-37de5d92291d.png">
 