### PR TITLE
fix: Remove user-set values for essential compilerOptions and log a warning

### DIFF
--- a/.changeset/three-icons-behave.md
+++ b/.changeset/three-icons-behave.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+Remove user-set values for essential compilerOptions generate, format, cssHash and filename and log a warning

--- a/.changeset/three-icons-behave.md
+++ b/.changeset/three-icons-behave.md
@@ -2,4 +2,4 @@
 '@sveltejs/vite-plugin-svelte': patch
 ---
 
-Remove user-set values for essential compilerOptions generate, format, cssHash and filename and log a warning
+Remove user-specified values for essential compilerOptions generate, format, cssHash and filename and log a warning

--- a/docs/config.md
+++ b/docs/config.md
@@ -42,6 +42,8 @@ A basic Svelte config looks like this:
 // svelte.config.js
 export default {
   // config options
+  compilerOptions: {},
+  preprocess: []
 };
 ```
 
@@ -77,13 +79,11 @@ export default defineConfig({
 
 These options are specific to the Svelte compiler and are generally shared across many bundler integrations.
 
-<!-- TODO: Also note where these options can be placed in svelte.config.js -->
-
 ### compilerOptions
 
 - **Type:** `CompileOptions` - See [svelte.compile](https://svelte.dev/docs#svelte_compile)
 
-  The options to be passed to the Svelte compiler. A few options are set by default, including `dev`, `format` and `css`. However, some options are non-configurable, like `filename`, `generate`, and `cssHash`.
+  The options to be passed to the Svelte compiler. A few options are set by default, including `dev` and `css`. However, some options are non-configurable, like `filename`, `format`, `generate`, and `cssHash` (in dev).
 
 ### preprocess
 

--- a/packages/vite-plugin-svelte/src/utils/compile.ts
+++ b/packages/vite-plugin-svelte/src/utils/compile.ts
@@ -21,7 +21,8 @@ const _createCompileSvelte = (makeHot: Function) =>
 		const compileOptions: CompileOptions = {
 			...options.compilerOptions,
 			filename,
-			generate: ssr ? 'ssr' : 'dom'
+			generate: ssr ? 'ssr' : 'dom',
+			format: 'esm'
 		};
 		if (options.hot && options.emitCss) {
 			const hash = `s-${safeBase64Hash(normalizedFilename)}`;

--- a/packages/vite-plugin-svelte/src/utils/options.ts
+++ b/packages/vite-plugin-svelte/src/utils/options.ts
@@ -176,7 +176,10 @@ function enforceOptionsForProduction(options: ResolvedOptions) {
 }
 
 function removeIgnoredOptions(options: ResolvedOptions) {
-	const ignoredCompilerOptions = ['generate', 'cssHash', 'format', 'filename'];
+	const ignoredCompilerOptions = ['generate', 'format', 'filename'];
+	if (options.hot && options.emitCss) {
+		ignoredCompilerOptions.push('cssHash');
+	}
 	const passedCompilerOptions = Object.keys(options.compilerOptions || {});
 	const passedIgnored = passedCompilerOptions.filter((o) => ignoredCompilerOptions.includes(o));
 	if (passedIgnored.length) {
@@ -416,11 +419,13 @@ export interface Options {
 	emitCss?: boolean;
 
 	/**
-	 * The options to be passed to the Svelte compiler
+	 * The options to be passed to the Svelte compiler. A few options are set by default,
+	 * including `dev` and `css`. However, some options are non-configurable, like
+	 * `filename`, `format`, `generate`, and `cssHash` (in dev).
 	 *
 	 * @see https://svelte.dev/docs#svelte_compile
 	 */
-	compilerOptions?: CompileOptions;
+	compilerOptions?: Omit<CompileOptions, 'filename' | 'format' | 'generate'>;
 
 	/**
 	 * Handles warning emitted from the Svelte compiler

--- a/packages/vite-plugin-svelte/src/utils/options.ts
+++ b/packages/vite-plugin-svelte/src/utils/options.ts
@@ -181,7 +181,7 @@ function removeIgnoredOptions(options: ResolvedOptions) {
 	const passedIgnored = passedCompilerOptions.filter((o) => ignoredCompilerOptions.includes(o));
 	if (passedIgnored.length) {
 		log.warn(
-			`The following svelte compilerOptions are controlled by vite-plugin-svelte and essential to it's functionality. User-Set values are ignored. Please remove them from your configuration: ${passedIgnored.join(
+			`The following Svelte compilerOptions are controlled by vite-plugin-svelte and essential to its functionality. User-specified values are ignored. Please remove them from your configuration: ${passedIgnored.join(
 				', '
 			)}`
 		);


### PR DESCRIPTION
see https://github.com/sveltejs/vite-plugin-svelte/issues/345#issuecomment-1138428492

this does not apply to dynamicCompileOptions so that remains  an escape-hatch for the brave. 