### PR TITLE
bump svelte-hmr version

### DIFF
--- a/.changeset/breezy-tigers-hang.md
+++ b/.changeset/breezy-tigers-hang.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+Bump svelte-hmr version

--- a/packages/vite-plugin-svelte/package.json
+++ b/packages/vite-plugin-svelte/package.json
@@ -51,7 +51,7 @@
     "deepmerge": "^4.2.2",
     "kleur": "^4.1.4",
     "magic-string": "^0.26.2",
-    "svelte-hmr": "^0.14.11"
+    "svelte-hmr": "^0.14.12"
   },
   "peerDependencies": {
     "diff-match-patch": "^1.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -456,7 +456,7 @@ importers:
       magic-string: ^0.26.2
       rollup: ^2.74.1
       svelte: ^3.48.0
-      svelte-hmr: ^0.14.11
+      svelte-hmr: ^0.14.12
       tsup: ^5.12.8
       vite: ^2.9.9
     dependencies:
@@ -465,7 +465,7 @@ importers:
       deepmerge: 4.2.2
       kleur: 4.1.4
       magic-string: 0.26.2
-      svelte-hmr: 0.14.11_svelte@3.48.0
+      svelte-hmr: 0.14.12_svelte@3.48.0
     devDependencies:
       '@types/debug': 4.1.7
       '@types/diff-match-patch': 1.0.32
@@ -5070,8 +5070,8 @@ packages:
       - sugarss
     dev: true
 
-  /svelte-hmr/0.14.11_svelte@3.48.0:
-    resolution: {integrity: sha512-R9CVfX6DXxW1Kn45Jtmx+yUe+sPhrbYSUp7TkzbW0jI5fVPn6lsNG9NEs5dFg5qRhFNAoVdRw5qQDLALNKhwbQ==}
+  /svelte-hmr/0.14.12_svelte@3.48.0:
+    resolution: {integrity: sha512-4QSW/VvXuqVcFZ+RhxiR8/newmwOCTlbYIezvkeN6302YFRE8cXy0naamHcjz8Y9Ce3ITTZtrHrIL0AGfyo61w==}
     engines: {node: ^12.20 || ^14.13.1 || >= 16}
     peerDependencies:
       svelte: '>=3.19.0'


### PR DESCRIPTION
just so we can remove the `hot.optimistic: false` override in https://github.com/sveltejs/kit/pull/5108