### PR TITLE
fix: ignore __vite-browser-external when trying to resolve svelte packages

### DIFF
--- a/.changeset/stupid-melons-try.md
+++ b/.changeset/stupid-melons-try.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+Do not try to resolve svelte field in \_\_vite-browser-external, see (#362)"

--- a/packages/vite-plugin-svelte/src/utils/dependencies.ts
+++ b/packages/vite-plugin-svelte/src/utils/dependencies.ts
@@ -144,7 +144,8 @@ const COMMON_DEPENDENCIES_WITHOUT_SVELTE_FIELD = [
 	'svelte-preprocess',
 	'tslib',
 	'typescript',
-	'vite'
+	'vite',
+	'__vite-browser-external' // see https://github.com/sveltejs/vite-plugin-svelte/issues/362
 ];
 const COMMON_PREFIXES_WITHOUT_SVELTE_FIELD = [
 	'@fontsource/',

--- a/packages/vite-plugin-svelte/src/utils/dependencies.ts
+++ b/packages/vite-plugin-svelte/src/utils/dependencies.ts
@@ -127,6 +127,7 @@ function isSvelteLib(pkg: Pkg) {
 
 const COMMON_DEPENDENCIES_WITHOUT_SVELTE_FIELD = [
 	'@lukeed/uuid',
+	'@playwright/test',
 	'@sveltejs/vite-plugin-svelte',
 	'@sveltejs/kit',
 	'autoprefixer',
@@ -136,6 +137,7 @@ const COMMON_DEPENDENCIES_WITHOUT_SVELTE_FIELD = [
 	'eslint',
 	'jest',
 	'mdsvex',
+	'playwright',
 	'postcss',
 	'prettier',
 	'svelte',
@@ -145,6 +147,7 @@ const COMMON_DEPENDENCIES_WITHOUT_SVELTE_FIELD = [
 	'tslib',
 	'typescript',
 	'vite',
+	'vitest',
 	'__vite-browser-external' // see https://github.com/sveltejs/vite-plugin-svelte/issues/362
 ];
 const COMMON_PREFIXES_WITHOUT_SVELTE_FIELD = [


### PR DESCRIPTION
this removes a confusing error log but doesn't fix the underlying issue which is in vite itself. see #362