### PR TITLE
fix: track compile errors and send hmr update when returning to working state

### DIFF
--- a/.changeset/nervous-jobs-remain.md
+++ b/.changeset/nervous-jobs-remain.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+fix hmr not updating a component when returning to the last working state from an error state

--- a/packages/vite-plugin-svelte/src/handle-hot-update.ts
+++ b/packages/vite-plugin-svelte/src/handle-hot-update.ts
@@ -15,19 +15,25 @@ export async function handleHotUpdate(
 	cache: VitePluginSvelteCache,
 	options: ResolvedOptions
 ): Promise<ModuleNode[] | void> {
+	if (!cache.has(svelteRequest)) {
+		// file hasn't been requested yet (e.g. async component)
+		log.debug(`handleHotUpdate called before initial transform for ${svelteRequest.id}`);
+		return;
+	}
 	const { read, server } = ctx;
 
 	const cachedJS = cache.getJS(svelteRequest);
-	if (!cachedJS) {
-		// file hasn't been requested yet (e.g. async component)
-		log.debug(`handleHotUpdate first call ${svelteRequest.id}`);
-		return;
-	}
 	const cachedCss = cache.getCSS(svelteRequest);
 
 	const content = await read();
-	const compileData: CompileData = await compileSvelte(svelteRequest, content, options);
-	cache.update(compileData);
+	let compileData: CompileData;
+	try {
+		compileData = await compileSvelte(svelteRequest, content, options);
+		cache.update(compileData);
+	} catch (e) {
+		cache.setError(svelteRequest, e);
+		throw e;
+	}
 
 	const affectedModules = new Set<ModuleNode | undefined>();
 
@@ -35,13 +41,13 @@ export async function handleHotUpdate(
 	const mainModule = server.moduleGraph.getModuleById(svelteRequest.id);
 	const cssUpdated = cssModule && cssChanged(cachedCss, compileData.compiled.css);
 	if (cssUpdated) {
-		log.debug('handleHotUpdate css changed');
+		log.debug(`handleHotUpdate css changed for ${svelteRequest.cssId}`);
 		affectedModules.add(cssModule);
 	}
 	const jsUpdated =
 		mainModule && jsChanged(cachedJS, compileData.compiled.js, svelteRequest.filename);
 	if (jsUpdated) {
-		log.debug('handleHotUpdate js changed');
+		log.debug(`handleHotUpdate js changed for ${svelteRequest.id}`);
 		affectedModules.add(mainModule);
 	}
 

--- a/packages/vite-plugin-svelte/src/index.ts
+++ b/packages/vite-plugin-svelte/src/index.ts
@@ -183,6 +183,7 @@ export function svelte(inlineOptions?: Partial<Options>): Plugin[] {
 				try {
 					compileData = await compileSvelte(svelteRequest, code, options);
 				} catch (e) {
+					cache.setError(svelteRequest, e);
 					throw toRollupError(e, options);
 				}
 				logCompilerWarnings(compileData.compiled.warnings, options);
@@ -209,7 +210,11 @@ export function svelte(inlineOptions?: Partial<Options>): Plugin[] {
 				}
 				const svelteRequest = requestParser(ctx.file, false, ctx.timestamp);
 				if (svelteRequest) {
-					return handleHotUpdate(compileSvelte, ctx, svelteRequest, cache, options);
+					try {
+						return handleHotUpdate(compileSvelte, ctx, svelteRequest, cache, options);
+					} catch (e) {
+						throw toRollupError(e, options);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
It's a bit tricky due to dependency tracking and also retaining information regarding first compile that needs to be ignored.
