### PR TITLE
refactor: move plugin options to "vitePlugin" in svelte.config.js

### DIFF
--- a/.changeset/healthy-worms-double.md
+++ b/.changeset/healthy-worms-double.md
@@ -9,10 +9,10 @@ update your svelte.config.js and wrap [plugin options](https://github.com/svelte
 ```diff
 // svelte.config.js
 
-  compilerOptions:{...},
-  preprocess:{...},
-  extensions:[...],
-  kit:{},
+  compilerOptions: {...},
+  preprocess: {...},
+  extensions: [...],
+  kit: {},
 + vitePlugin: {
    // include, exclude, emitCss, onwarn, hot, ignorePluginPreprocessors, disableDependencyReinclusion, experimental
 + }

--- a/.changeset/healthy-worms-double.md
+++ b/.changeset/healthy-worms-double.md
@@ -12,8 +12,9 @@ update your svelte.config.js and wrap [plugin options](https://github.com/svelte
   compilerOptions: {...},
   preprocess: {...},
   extensions: [...],
+  onwarn: () => {...},
   kit: {},
 + vitePlugin: {
-   // include, exclude, emitCss, onwarn, hot, ignorePluginPreprocessors, disableDependencyReinclusion, experimental
+   // include, exclude, emitCss, hot, ignorePluginPreprocessors, disableDependencyReinclusion, experimental
 + }
 ```

--- a/.changeset/healthy-worms-double.md
+++ b/.changeset/healthy-worms-double.md
@@ -1,0 +1,19 @@
+---
+'@sveltejs/vite-plugin-svelte': major
+---
+
+move plugin options in svelte.config.js into "vitePlugin"
+
+update your svelte.config.js and wrap [plugin options](https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/config.md#plugin-options) with `vitePlugin`
+
+```diff
+// svelte.config.js
+
+  compilerOptions:{...},
+  preprocess:{...},
+  extensions:[...],
+  kit:{},
++ vitePlugin: {
+   // include, exclude, emitCss, onwarn, hot, ignorePluginPreprocessors, disableDependencyReinclusion, experimental
++ }
+```

--- a/docs/config.md
+++ b/docs/config.md
@@ -204,7 +204,7 @@ A [picomatch pattern](https://github.com/micromatch/picomatch), or array of patt
 
 These options are considered experimental and breaking changes to them can occur in any release! Specify them under the `experimental` option.
 
-Either in Vite config
+Either in Vite config:
 
 ```js
 // vite.config.js

--- a/docs/config.md
+++ b/docs/config.md
@@ -3,6 +3,7 @@
 `vite-plugin-svelte` accepts inline options that can be used to change its behaviour. An object can be passed to the first argument of the `svelte` plugin:
 
 ```js
+// vite.config.js
 export default defineConfig({
   plugins: [
     svelte({
@@ -18,7 +19,7 @@ Explore the various options below!
 
 ### Config file resolving
 
-Besides inline options, `vite-plugin-svelte` will also automatically resolve options from a Svelte config file if one exists. The default search paths are:
+Besides inline options in Vite config, `vite-plugin-svelte` will also automatically resolve options from a Svelte config file if one exists. The default search paths are:
 
 - `svelte.config.js`
 - `svelte.config.mjs`
@@ -27,6 +28,7 @@ Besides inline options, `vite-plugin-svelte` will also automatically resolve opt
 To set a specific config file, use the `configFile` inline option. The path can be absolute or relative to the [Vite root](https://vitejs.dev/config/#root). For example:
 
 ```js
+// vite.config.js
 export default defineConfig({
   plugins: [
     svelte({
@@ -42,12 +44,15 @@ A basic Svelte config looks like this:
 // svelte.config.js
 export default {
   // svelte options
+  extensions: ['.svelte'],
   compilerOptions: {},
   preprocess: [],
   // plugin options
-  onwarn: (warning, handler) => handler(warning),
-  // experimental options
-  experimental: {}
+  vitePlugin: {
+    onwarn: (warning, handler) => handler(warning),
+    // experimental options
+    experimental: {}
+  }
 };
 ```
 
@@ -65,6 +70,7 @@ Depending on Node's mode, make sure you're using the correct extension and synta
 Use `configFile: false` to prevent `vite-plugin-svelte` from reading the config file or restarting the Vite dev server when it changes.
 
 ```js
+// vite.config.js
 export default defineConfig({
   plugins: [
     svelte({
@@ -98,6 +104,7 @@ These options are specific to the Svelte compiler and are generally shared acros
   **Example:**
 
   ```js
+  // vite.config.js
   import sveltePreprocess from 'svelte-preprocess';
 
   export default defineConfig({
@@ -197,7 +204,10 @@ A [picomatch pattern](https://github.com/micromatch/picomatch), or array of patt
 
 These options are considered experimental and breaking changes to them can occur in any release! Specify them under the `experimental` option.
 
+Either in Vite config
+
 ```js
+// vite.config.js
 export default defineConfig({
   plugins: [
     svelte({
@@ -207,6 +217,19 @@ export default defineConfig({
     })
   ]
 });
+```
+
+or in svelte config
+
+```js
+// svelte.config.js
+export default {
+  vitePlugin: {
+    experimental: {
+      // experimental options
+    }
+  }
+};
 ```
 
 ### useVitePreprocess
@@ -247,6 +270,7 @@ export default defineConfig({
   **Example:**
 
   ```js
+  // vite.config.js
   export default defineConfig({
     plugins: [
       svelte({
@@ -321,6 +345,7 @@ export default defineConfig({
   **Example:**
 
   ```js
+  // vite.config.js
   export default defineConfig({
     plugins: [
       svelte({

--- a/docs/config.md
+++ b/docs/config.md
@@ -47,9 +47,10 @@ export default {
   extensions: ['.svelte'],
   compilerOptions: {},
   preprocess: [],
+  onwarn: (warning, handler) => handler(warning),
   // plugin options
   vitePlugin: {
-    onwarn: (warning, handler) => handler(warning),
+    exclude: [],
     // experimental options
     experimental: {}
   }
@@ -116,35 +117,12 @@ These options are specific to the Svelte compiler and are generally shared acros
   });
   ```
 
-## Plugin options
-
-These options are specific to the Vite plugin itself.
-
-### include
-
-- **Type:** `string | string[]`
-
-A [picomatch pattern](https://github.com/micromatch/picomatch), or array of patterns, which specifies the files the plugin should operate on. By default, all svelte files are included.
-
-### exclude
-
-- **Type:** `string | string[]`
-
-A [picomatch pattern](https://github.com/micromatch/picomatch), or array of patterns, which specifies the files to be ignored by the plugin. By default, no files are ignored.
-
 ### extensions
 
 - **Type:** `string[]`
 - **Default:** `['.svelte']`
 
   A list of file extensions to be compiled by Svelte. Useful for custom extensions like `.svg` and `.svx`.
-
-### emitCss
-
-- **Type:** `boolean`
-- **Default:** `true`
-
-  Emit Svelte styles as virtual CSS files for Vite and other plugins to process.
 
 ### onwarn
 
@@ -169,6 +147,29 @@ A [picomatch pattern](https://github.com/micromatch/picomatch), or array of patt
     ]
   });
   ```
+
+## Plugin options
+
+These options are specific to the Vite plugin itself.
+
+### include
+
+- **Type:** `string | string[]`
+
+A [picomatch pattern](https://github.com/micromatch/picomatch), or array of patterns, which specifies the files the plugin should operate on. By default, all svelte files are included.
+
+### exclude
+
+- **Type:** `string | string[]`
+
+A [picomatch pattern](https://github.com/micromatch/picomatch), or array of patterns, which specifies the files to be ignored by the plugin. By default, no files are ignored.
+
+### emitCss
+
+- **Type:** `boolean`
+- **Default:** `true`
+
+  Emit Svelte styles as virtual CSS files for Vite and other plugins to process.
 
 ### hot
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -219,7 +219,7 @@ export default defineConfig({
 });
 ```
 
-or in svelte config
+or in Svelte config:
 
 ```js
 // svelte.config.js

--- a/packages/e2e-tests/configfile-custom/svelte.config.custom.cjs
+++ b/packages/e2e-tests/configfile-custom/svelte.config.custom.cjs
@@ -1,4 +1,6 @@
 console.log('custom svelte config loaded cjs')
 module.exports = {
-	emitCss: false
+	vitePlugin:{
+		emitCss: false
+	}
 };

--- a/packages/e2e-tests/configfile-custom/svelte.config.custom.cjs
+++ b/packages/e2e-tests/configfile-custom/svelte.config.custom.cjs
@@ -1,6 +1,6 @@
 console.log('custom svelte config loaded cjs')
 module.exports = {
-	vitePlugin:{
+	vitePlugin: {
 		emitCss: false
 	}
 };

--- a/packages/e2e-tests/configfile-custom/svelte.config.custom.mjs
+++ b/packages/e2e-tests/configfile-custom/svelte.config.custom.mjs
@@ -1,4 +1,6 @@
 console.log('custom svelte config loaded mjs')
 export default {
-	emitCss: false
+	vitePlugin:{
+		emitCss: false
+	}
 }

--- a/packages/e2e-tests/configfile-custom/svelte.config.custom.mjs
+++ b/packages/e2e-tests/configfile-custom/svelte.config.custom.mjs
@@ -1,6 +1,6 @@
 console.log('custom svelte config loaded mjs')
 export default {
-	vitePlugin:{
+	vitePlugin: {
 		emitCss: false
 	}
 }

--- a/packages/e2e-tests/hmr/__tests__/hmr.spec.ts
+++ b/packages/e2e-tests/hmr/__tests__/hmr.spec.ts
@@ -149,7 +149,7 @@ if (!isBuild) {
 		});
 
 		test('should work with emitCss: false in svelte config', async () => {
-			addFile('svelte.config.cjs', `module.exports={emitCss:false}`);
+			addFile('svelte.config.cjs', `module.exports={vitePlugin:{emitCss:false}}`);
 			await sleep(isWin ? 1000 : 500); // adding config restarts server, give it some time
 			await page.goto(viteTestUrl, { waitUntil: 'networkidle' });
 			await sleep(50);

--- a/packages/e2e-tests/inspector-kit/svelte.config.js
+++ b/packages/e2e-tests/inspector-kit/svelte.config.js
@@ -1,9 +1,11 @@
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	kit: {},
-	experimental: {
-		inspector: {
-			showToggleButton: 'always'
+	vitePlugin: {
+		experimental: {
+			inspector: {
+				showToggleButton: 'always'
+			}
 		}
 	}
 };

--- a/packages/vite-plugin-svelte/src/index.ts
+++ b/packages/vite-plugin-svelte/src/index.ts
@@ -227,6 +227,8 @@ export { loadSvelteConfig } from './utils/load-svelte-config';
 
 export {
 	Options,
+	PluginOptions,
+	SvelteOptions,
 	Preprocessor,
 	PreprocessorGroup,
 	CompileOptions,

--- a/packages/vite-plugin-svelte/src/utils/load-svelte-config.ts
+++ b/packages/vite-plugin-svelte/src/utils/load-svelte-config.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import fs from 'fs';
 import { pathToFileURL } from 'url';
 import { log } from './log';
-import { Options } from './options';
+import { Options, SvelteOptions } from './options';
 import { UserConfig } from 'vite';
 
 // used to require cjs config in esm.
@@ -29,7 +29,7 @@ const dynamicImportDefault = new Function(
 export async function loadSvelteConfig(
 	viteConfig?: UserConfig,
 	inlineOptions?: Partial<Options>
-): Promise<Partial<Options> | undefined> {
+): Promise<Partial<SvelteOptions> | undefined> {
 	if (inlineOptions?.configFile === false) {
 		return;
 	}

--- a/packages/vite-plugin-svelte/src/utils/options.ts
+++ b/packages/vite-plugin-svelte/src/utils/options.ts
@@ -458,9 +458,9 @@ export function patchResolvedViteConfig(viteConfig: ResolvedConfig, options: Res
 	}
 }
 
-export type Options = Omit<SvelteOptions & PluginOptions, 'vitePlugin'>;
+export type Options = Omit<SvelteOptions, 'vitePlugin'> & PluginOptionsInline;
 
-export interface PluginOptions {
+interface PluginOptionsInline extends PluginOptions {
 	/**
 	 * Path to a svelte config file, either absolute or relative to Vite root
 	 *
@@ -469,7 +469,9 @@ export interface PluginOptions {
 	 * @see https://vitejs.dev/config/#root
 	 */
 	configFile?: string | false;
+}
 
+export interface PluginOptions {
 	/**
 	 * A `picomatch` pattern, or array of patterns, which specifies the files the plugin should
 	 * operate on. By default, all svelte files are included.
@@ -579,7 +581,7 @@ export interface SvelteOptions {
 	/**
 	 * Options for vite-plugin-svelte
 	 */
-	vitePlugin?: Options;
+	vitePlugin?: PluginOptions;
 }
 
 /**

--- a/packages/vite-plugin-svelte/src/utils/options.ts
+++ b/packages/vite-plugin-svelte/src/utils/options.ts
@@ -32,14 +32,13 @@ const allowedPluginOptions = new Set([
 	'include',
 	'exclude',
 	'emitCss',
-	'onwarn',
 	'hot',
 	'ignorePluginPreprocessors',
 	'disableDependencyReinclusion',
 	'experimental'
 ]);
 
-const knownRootOptions = new Set(['extensions', 'compilerOptions', 'preprocess']);
+const knownRootOptions = new Set(['extensions', 'compilerOptions', 'preprocess', 'onwarn']);
 
 const allowedInlineOptions = new Set([
 	'configFile',
@@ -495,11 +494,6 @@ export interface PluginOptions {
 	emitCss?: boolean;
 
 	/**
-	 * Handles warning emitted from the Svelte compiler
-	 */
-	onwarn?: (warning: Warning, defaultHandler?: (warning: Warning) => void) => void;
-
-	/**
 	 * Enable or disable Hot Module Replacement.
 	 *
 	 * !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -568,6 +562,11 @@ export interface SvelteOptions {
 	 * @see https://svelte.dev/docs#svelte_compile
 	 */
 	compilerOptions?: Omit<CompileOptions, 'filename' | 'format' | 'generate'>;
+
+	/**
+	 * Handles warning emitted from the Svelte compiler
+	 */
+	onwarn?: (warning: Warning, defaultHandler?: (warning: Warning) => void) => void;
 
 	/**
 	 * Options for SvelteKit

--- a/packages/vite-plugin-svelte/src/utils/options.ts
+++ b/packages/vite-plugin-svelte/src/utils/options.ts
@@ -19,8 +19,7 @@ import type {
 	Processed
 	// eslint-disable-next-line node/no-missing-import
 } from 'svelte/types/compiler/preprocess';
-// eslint-disable-next-line node/no-missing-import
-import type { KitConfig } from '@sveltejs/kit';
+
 import path from 'path';
 import { findRootSvelteDependencies, needsOptimization, SvelteDependency } from './dependencies';
 import { createRequire } from 'module';
@@ -266,14 +265,17 @@ function removeIgnoredOptions(options: ResolvedOptions) {
 
 // some SvelteKit options need compilerOptions to work, so set them here.
 function addSvelteKitOptions(options: ResolvedOptions) {
+	// @ts-expect-error kit is not typed to avoid dependency on sveltekit
 	if (options?.kit != null) {
-		const hydratable = options.kit.browser?.hydrate !== false;
+		// @ts-expect-error kit is not typed to avoid dependency on sveltekit
+		const kit_browser_hydrate = options.kit.browser?.hydrate;
+		const hydratable = kit_browser_hydrate !== false;
 		if (
 			options.compilerOptions.hydratable != null &&
 			options.compilerOptions.hydratable !== hydratable
 		) {
 			log.warn(
-				`Conflicting values "compilerOptions.hydratable: ${options.compilerOptions.hydratable}" and "kit.browser.hydrate: ${options.kit.browser?.hydrate}" in your svelte config. You should remove "compilerOptions.hydratable".`
+				`Conflicting values "compilerOptions.hydratable: ${options.compilerOptions.hydratable}" and "kit.browser.hydrate: ${kit_browser_hydrate}" in your svelte config. You should remove "compilerOptions.hydratable".`
 			);
 		}
 		log.debug(`Setting compilerOptions.hydratable: ${hydratable} for SvelteKit`);
@@ -569,14 +571,6 @@ export interface SvelteOptions {
 	 * Handles warning emitted from the Svelte compiler
 	 */
 	onwarn?: (warning: Warning, defaultHandler?: (warning: Warning) => void) => void;
-
-	/**
-	 * Options for SvelteKit
-	 * @internal
-	 *
-	 * users should always use svelte.config.js or kit() in vite.config.js to set this
-	 */
-	kit?: KitConfig;
 
 	/**
 	 * Options for vite-plugin-svelte


### PR DESCRIPTION
To avoid problems with future name clashes we introduce `vitePlugin` namespace in svelte.config.js.

svelte options that are of global interest, eg `compilerOptions`, `preprocess` and `extensions` remain in the config root.

All other options mentioned in https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/config.md#plugin-options are moved.

Additional validation/errors have been introduced to avoid invalid options and inform the user.