### PR TITLE
chore: remove the loglevel=warning setting now that action setup-node is fixed

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-#set loglevel to warn to avoid bug with pnpm cache in setup-node action, see https://github.com/actions/setup-node/issues/543
-loglevel=warn


### PR DESCRIPTION
.