### PR TITLE
docs: update svelte compile options URL

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -92,7 +92,7 @@ These options are specific to the Svelte compiler and are generally shared acros
 
 ### compilerOptions
 
-- **Type:** `CompileOptions` - See [svelte.compile](https://svelte.dev/docs#svelte_compile)
+- **Type:** `CompileOptions` - See [svelte.compile](https://svelte.dev/docs#compile-time-svelte-compile)
 
   The options to be passed to the Svelte compiler. A few options are set by default, including `dev` and `css`. However, some options are non-configurable, like `filename`, `format`, `generate`, and `cssHash` ([in dev](./faq.md#why-cant-csshash-be-set-in-development-mode)).
 


### PR DESCRIPTION
Hi... I find the URL to svelte compile options documentation is invalid. Just updated the URL.