### PR TITLE
fix: avoid runtime error by ignoring keyless keyup events

### DIFF
--- a/.changeset/polite-seas-rule.md
+++ b/.changeset/polite-seas-rule.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+ignore keyup events without key in inspector

--- a/packages/vite-plugin-svelte/src/ui/inspector/Inspector.svelte
+++ b/packages/vite-plugin-svelte/src/ui/inspector/Inspector.svelte
@@ -99,7 +99,7 @@
 	}
 
 	function keydown(event) {
-		if (event.repeat || event.key === undefined) {
+		if (event.repeat || event.key == null) {
 			return;
 		}
 
@@ -112,7 +112,7 @@
 	}
 
 	function keyup(event) {
-		if (event.repeat) {
+		if (event.repeat || event.key == null) {
 			return;
 		}
 		const k = event.key.toLowerCase();


### PR DESCRIPTION
they happen eg when using paste from rightclick context menu. 
The inspector only cares about pressed keys though to determine combo use, so it is safe to ignore events that do not have a key set.