### PR TITLE
feat: add drilling and tag display to inspector

### DIFF
--- a/.changeset/fair-dodos-dance.md
+++ b/.changeset/fair-dodos-dance.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': minor
+---
+
+svelte-inspector: use arrow up/down to allow selecting parent/child elements that cannot be moused over (see #435)

--- a/.changeset/light-readers-leave.md
+++ b/.changeset/light-readers-leave.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': minor
+---
+
+svelte-inspector: display active element tag

--- a/docs/config.md
+++ b/docs/config.md
@@ -306,6 +306,14 @@ export default {
     toggleKeyCombo?: string;
 
     /**
+     * define keys to drill from the active element (up selects parent, down selects child).
+     * @default {up: 'ArrowUp',down: 'ArrowDown'}
+     *
+     * This is useful when components wrap another one without providing any hoverable area between them
+     */
+    drillKeys?: { up: string; down: string };
+
+    /**
      * inspector is automatically disabled when releasing toggleKeyCombo after holding it for a longpress
      * @default false
      */

--- a/packages/playground/kit-demo-app/svelte.config.js
+++ b/packages/playground/kit-demo-app/svelte.config.js
@@ -9,6 +9,11 @@ const config = {
 		methodOverride: {
 			allowed: ['PATCH', 'DELETE']
 		}
+	},
+	vitePlugin: {
+		experimental: {
+			inspector: true
+		}
 	}
 };
 

--- a/packages/vite-plugin-svelte/src/ui/inspector/Inspector.svelte
+++ b/packages/vite-plugin-svelte/src/ui/inspector/Inspector.svelte
@@ -37,18 +37,30 @@
 		y = event.y;
 	}
 
-	function findMetaEl(el) {
+	function find_parent_with_meta(el) {
 		while (el) {
-			const file = el.__svelte_meta?.loc?.file;
-			if (el !== toggle_el && file && !file.includes('node_modules/')) {
+			if (has_meta(el)) {
 				return el;
 			}
 			el = el.parentNode;
 		}
 	}
 
+	function find_child_with_meta(el) {
+		return [...el.querySelectorAll('*')].find(has_meta);
+	}
+
+	function has_meta(el) {
+		const file = el.__svelte_meta?.loc?.file;
+		return el !== toggle_el && file && !file.includes('node_modules/');
+	}
+
 	function mouseover(event) {
-		const el = findMetaEl(event.target);
+		const el = find_parent_with_meta(event.target);
+		activate(el);
+	}
+
+	function activate(el) {
 		if (options.customStyles && el !== active_el) {
 			if (active_el) {
 				active_el.classList.remove('svelte-inspector-active-target');
@@ -107,6 +119,16 @@
 			toggle();
 			if (options.holdMode && enabled) {
 				enabled_ts = Date.now();
+			}
+		} else if (event.key === 'ArrowUp' && active_el) {
+			const el = find_parent_with_meta(active_el.parentNode);
+			if (el) {
+				activate(el);
+			}
+		} else if (event.key === 'ArrowDown' && active_el) {
+			const el = find_child_with_meta(active_el);
+			if (el) {
+				activate(el);
 			}
 		}
 	}
@@ -203,7 +225,7 @@
 		style:top="{y + 30}px"
 		bind:offsetWidth={w}
 	>
-		{file_loc}
+		&lt;{active_el.tagName.toLowerCase()}&gt;&nbsp;{file_loc}
 	</div>
 {/if}
 

--- a/packages/vite-plugin-svelte/src/ui/inspector/Inspector.svelte
+++ b/packages/vite-plugin-svelte/src/ui/inspector/Inspector.svelte
@@ -80,9 +80,7 @@
 
 	function click(event) {
 		if (file_loc) {
-			event.preventDefault();
-			event.stopPropagation();
-			event.stopImmediatePropagation();
+			stop(event);
 			fetch(`/__open-in-editor?file=${encodeURIComponent(file_loc)}`);
 			if (options.holdMode && is_holding()) {
 				disable();
@@ -110,6 +108,12 @@
 		return enabled_ts && Date.now() - enabled_ts > 250;
 	}
 
+	function stop(event) {
+		event.preventDefault();
+		event.stopPropagation();
+		event.stopImmediatePropagation();
+	}
+
 	function keydown(event) {
 		if (event.repeat || event.key == null) {
 			return;
@@ -120,15 +124,17 @@
 			if (options.holdMode && enabled) {
 				enabled_ts = Date.now();
 			}
-		} else if (event.key === 'ArrowUp' && active_el) {
+		} else if (event.key === options.drillKeys.up && active_el) {
 			const el = find_parent_with_meta(active_el.parentNode);
 			if (el) {
 				activate(el);
+				stop(event);
 			}
-		} else if (event.key === 'ArrowDown' && active_el) {
+		} else if (event.key === options.drillKeys.down && active_el) {
 			const el = find_child_with_meta(active_el);
 			if (el) {
 				activate(el);
+				stop(event);
 			}
 		}
 	}

--- a/packages/vite-plugin-svelte/src/ui/inspector/plugin.ts
+++ b/packages/vite-plugin-svelte/src/ui/inspector/plugin.ts
@@ -8,6 +8,7 @@ import { idToFile } from './utils';
 
 const defaultInspectorOptions: InspectorOptions = {
 	toggleKeyCombo: process.platform === 'win32' ? 'control-shift' : 'meta-shift',
+	drillKeys: { up: 'ArrowUp', down: 'ArrowDown' },
 	holdMode: false,
 	showToggleButton: 'active',
 	toggleButtonPos: 'top-right',

--- a/packages/vite-plugin-svelte/src/utils/options.ts
+++ b/packages/vite-plugin-svelte/src/utils/options.ts
@@ -644,6 +644,14 @@ export interface InspectorOptions {
 	toggleKeyCombo?: string;
 
 	/**
+	 * define keys to drill from the active element (up selects parent, down selects child).
+	 * @default {up: 'ArrowUp',down: 'ArrowDown'}
+	 *
+	 * This is useful when components wrap another one without providing any hoverable area between them
+	 */
+	drillKeys?: { up: string; down: string };
+
+	/**
 	 * inspector is automatically disabled when releasing toggleKeyCombo after holding it for a longpress
 	 * @default false
 	 */


### PR DESCRIPTION
fixes #435 

needs documentation, but where?

svelte-inspector is going to be extracted into a separate package in this monorepo to enable code-sharing with the editor plugin that was demoed on svelte-summit.

@lukaszpolowczyk  i hope you are fine with ArrowUp/Down, that seems more fitting than +/-. 