### PR TITLE
fix: update svelte-hmr and enable partial accept

### DIFF
--- a/.changeset/little-ligers-look.md
+++ b/.changeset/little-ligers-look.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+update svelte-hmr and enable partial hmr accept by default (fixes #134)

--- a/packages/e2e-tests/hmr/__tests__/hmr.spec.ts
+++ b/packages/e2e-tests/hmr/__tests__/hmr.spec.ts
@@ -146,6 +146,12 @@ if (!isBuild) {
 			await updateModuleContext((content) => content.replace('y = 1', 'y = 2'));
 			expect(await getText(`#hmr-with-context`)).toContain('x=0 y=2 slot=2');
 			expect(await getText(`#hmr-without-context`)).toContain('x=0 y=2 slot=');
+			expect(browserLogs).toEqual(
+				expect.arrayContaining([expect.stringMatching(/hot updated:.*UsingNamed.svelte/)])
+			);
+			expect(browserLogs).not.toEqual(
+				expect.arrayContaining([expect.stringMatching(/hot updated:.*UsingOnlyDefault.svelte/)])
+			);
 		});
 
 		test('should work with emitCss: false in vite config', async () => {

--- a/packages/e2e-tests/hmr/__tests__/hmr.spec.ts
+++ b/packages/e2e-tests/hmr/__tests__/hmr.spec.ts
@@ -54,6 +54,10 @@ test('should respect transforms', async () => {
 if (!isBuild) {
 	describe('hmr', () => {
 		const updateHmrTest = editFileAndWaitForHmrComplete.bind(null, 'src/components/HmrTest.svelte');
+		const updateModuleContext = editFileAndWaitForHmrComplete.bind(
+			null,
+			'src/components/partial-hmr/ModuleContext.svelte'
+		);
 		const updateApp = editFileAndWaitForHmrComplete.bind(null, 'src/App.svelte');
 		const updateStore = editFileAndWaitForHmrComplete.bind(null, 'src/stores/hmr-stores.js');
 
@@ -134,6 +138,14 @@ if (!isBuild) {
 			expect(await getText(`#hmr-test-2 .counter`)).toBe('1');
 			// a third instance has been added
 			expect(await getText(`#hmr-test-3 .counter`)).toBe('0');
+		});
+
+		test('should work when editing script context="module"', async () => {
+			expect(await getText(`#hmr-with-context`)).toContain('x=0 y=1 slot=1');
+			expect(await getText(`#hmr-without-context`)).toContain('x=0 y=1 slot=');
+			await updateModuleContext((content) => content.replace('y = 1', 'y = 2'));
+			expect(await getText(`#hmr-with-context`)).toContain('x=0 y=2 slot=2');
+			expect(await getText(`#hmr-without-context`)).toContain('x=0 y=2 slot=');
 		});
 
 		test('should work with emitCss: false in vite config', async () => {

--- a/packages/e2e-tests/hmr/__tests__/hmr.spec.ts
+++ b/packages/e2e-tests/hmr/__tests__/hmr.spec.ts
@@ -4,6 +4,7 @@ import {
 	getEl,
 	getText,
 	editFileAndWaitForHmrComplete,
+	hmrCount,
 	untilMatches,
 	sleep,
 	getColor,
@@ -143,15 +144,13 @@ if (!isBuild) {
 		test('should work when editing script context="module"', async () => {
 			expect(await getText(`#hmr-with-context`)).toContain('x=0 y=1 slot=1');
 			expect(await getText(`#hmr-without-context`)).toContain('x=0 y=1 slot=');
+			expect(hmrCount('UsingNamed.svelte'), 'updates for UsingNamed.svelte').toBe(0);
+			expect(hmrCount('UsingDefault.svelte'), 'updates for UsingDefault.svelte').toBe(0);
 			await updateModuleContext((content) => content.replace('y = 1', 'y = 2'));
 			expect(await getText(`#hmr-with-context`)).toContain('x=0 y=2 slot=2');
 			expect(await getText(`#hmr-without-context`)).toContain('x=0 y=2 slot=');
-			expect(browserLogs).toEqual(
-				expect.arrayContaining([expect.stringMatching(/hot updated:.*UsingNamed.svelte/)])
-			);
-			expect(browserLogs).not.toEqual(
-				expect.arrayContaining([expect.stringMatching(/hot updated:.*UsingOnlyDefault.svelte/)])
-			);
+			expect(hmrCount('UsingNamed.svelte'), 'updates for UsingNamed.svelte').toBe(1);
+			expect(hmrCount('UsingDefault.svelte'), 'updates for UsingDefault.svelte').toBe(0);
 		});
 
 		test('should work with emitCss: false in vite config', async () => {

--- a/packages/e2e-tests/hmr/src/App.svelte
+++ b/packages/e2e-tests/hmr/src/App.svelte
@@ -2,6 +2,7 @@
 	import StaticImport from './components/StaticImport.svelte';
 	import Dependency from 'e2e-test-dep-svelte-simple';
 	import HmrTest from './components/HmrTest.svelte';
+	import PartialHmr from './components/partial-hmr/PartialHmr.svelte';
 	const jsTransform = '__JS_TRANSFORM_1__';
 	let dynamicImportComponent;
 	function importDynamic() {
@@ -25,6 +26,9 @@
 <HmrTest id="hmr-test-2" />
 
 <!-- HMR-TEMPLATE-INJECT -->
+
+<PartialHmr />
+
 <style>
 	h1 {
 		color: #111111;

--- a/packages/e2e-tests/hmr/src/components/partial-hmr/ModuleContext.svelte
+++ b/packages/e2e-tests/hmr/src/components/partial-hmr/ModuleContext.svelte
@@ -1,0 +1,12 @@
+<script context="module">
+	export let y = 1;
+</script>
+
+<script>
+	export let id;
+	let x = 0;
+</script>
+
+<pre {id}>
+  x={x} y={y} slot=<slot />
+</pre>

--- a/packages/e2e-tests/hmr/src/components/partial-hmr/PartialHmr.svelte
+++ b/packages/e2e-tests/hmr/src/components/partial-hmr/PartialHmr.svelte
@@ -1,0 +1,6 @@
+<script>
+	import ModuleContext, { y } from './ModuleContext.svelte';
+</script>
+
+<ModuleContext id="hmr-with-context">{y}</ModuleContext>
+<ModuleContext id="hmr-without-context" />

--- a/packages/e2e-tests/hmr/src/components/partial-hmr/PartialHmr.svelte
+++ b/packages/e2e-tests/hmr/src/components/partial-hmr/PartialHmr.svelte
@@ -1,6 +1,7 @@
 <script>
-	import ModuleContext, { y } from './ModuleContext.svelte';
+	import UsingNamed from './UsingNamed.svelte';
+	import UsingOnlyDefault from './UsingOnlyDefault.svelte';
 </script>
 
-<ModuleContext id="hmr-with-context">{y}</ModuleContext>
-<ModuleContext id="hmr-without-context" />
+<UsingNamed />
+<UsingOnlyDefault />

--- a/packages/e2e-tests/hmr/src/components/partial-hmr/UsingNamed.svelte
+++ b/packages/e2e-tests/hmr/src/components/partial-hmr/UsingNamed.svelte
@@ -1,0 +1,5 @@
+<script>
+	import ModuleContext, { y } from './ModuleContext.svelte';
+</script>
+
+<ModuleContext id="hmr-with-context">{y}</ModuleContext>

--- a/packages/e2e-tests/hmr/src/components/partial-hmr/UsingOnlyDefault.svelte
+++ b/packages/e2e-tests/hmr/src/components/partial-hmr/UsingOnlyDefault.svelte
@@ -1,0 +1,5 @@
+<script>
+	import ModuleContext from './ModuleContext.svelte';
+</script>
+
+<ModuleContext id="hmr-without-context" />

--- a/packages/e2e-tests/testUtils.ts
+++ b/packages/e2e-tests/testUtils.ts
@@ -7,7 +7,7 @@ import colors from 'css-color-names';
 import { ElementHandle } from 'playwright-core';
 import fetch from 'node-fetch';
 
-import { isBuild, isWin, isCI, page, testDir, viteTestUrl } from './vitestSetup';
+import { isBuild, isWin, isCI, page, testDir, viteTestUrl, browserLogs } from './vitestSetup';
 
 export * from './vitestSetup';
 
@@ -175,6 +175,10 @@ export async function editFileAndWaitForHmrComplete(file, replacer, fileUpdateTo
 		await saveScreenshot(`failed_update_${file}`);
 		throw lastErr;
 	}
+}
+
+export function hmrCount(file) {
+	return browserLogs.filter((line) => line.includes('hot updated') && line.includes(file)).length;
 }
 
 export async function saveScreenshot(name: string) {

--- a/packages/playground/kit-demo-app/src/routes/about/+page.js
+++ b/packages/playground/kit-demo-app/src/routes/about/+page.js
@@ -1,4 +1,4 @@
-import { browser, dev } from '$app/env';
+import { browser, dev } from '$app/environment';
 
 // we don't need any JS on this page, though we'll load
 // it in dev so that we get hot module replacement...

--- a/packages/vite-plugin-svelte/package.json
+++ b/packages/vite-plugin-svelte/package.json
@@ -51,7 +51,7 @@
     "deepmerge": "^4.2.2",
     "kleur": "^4.1.5",
     "magic-string": "^0.26.3",
-    "svelte-hmr": "^0.14.12"
+    "svelte-hmr": "^0.15.0"
   },
   "peerDependencies": {
     "diff-match-patch": "^1.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -473,7 +473,7 @@ importers:
       magic-string: ^0.26.3
       rollup: ^2.79.0
       svelte: ^3.50.0
-      svelte-hmr: ^0.14.12
+      svelte-hmr: ^0.15.0
       tsup: ^6.2.3
       vite: ^3.1.0
     dependencies:
@@ -482,7 +482,7 @@ importers:
       deepmerge: 4.2.2
       kleur: 4.1.5
       magic-string: 0.26.3
-      svelte-hmr: 0.14.12_svelte@3.50.0
+      svelte-hmr: 0.15.0_svelte@3.50.0
     devDependencies:
       '@types/debug': 4.1.7
       '@types/diff-match-patch': 1.0.32
@@ -5112,8 +5112,8 @@ packages:
       - sugarss
     dev: true
 
-  /svelte-hmr/0.14.12_svelte@3.50.0:
-    resolution: {integrity: sha512-4QSW/VvXuqVcFZ+RhxiR8/newmwOCTlbYIezvkeN6302YFRE8cXy0naamHcjz8Y9Ce3ITTZtrHrIL0AGfyo61w==}
+  /svelte-hmr/0.15.0_svelte@3.50.0:
+    resolution: {integrity: sha512-Aw21SsyoohyVn4yiKXWPNCSW2DQNH/76kvUnE9kpt4h9hcg9tfyQc6xshx9hzgMfGF0kVx0EGD8oBMWSnATeOg==}
     engines: {node: ^12.20 || ^14.13.1 || >= 16}
     peerDependencies:
       svelte: '>=3.19.0'


### PR DESCRIPTION
to allow context=module updates, see issue #134

This is enabled by default, but can be disabled by either  
`hot:{partialAccept: false}` in vite-plugin-svelte options or
`experimental: {hmrPartialAccept: false}` in vite config.


