### PR TITLE
test: harden partialAccept test

### DIFF
--- a/packages/e2e-tests/hmr/__tests__/hmr.spec.ts
+++ b/packages/e2e-tests/hmr/__tests__/hmr.spec.ts
@@ -146,6 +146,12 @@ if (!isBuild) {
 			await updateModuleContext((content) => content.replace('y = 1', 'y = 2'));
 			expect(await getText(`#hmr-with-context`)).toContain('x=0 y=2 slot=2');
 			expect(await getText(`#hmr-without-context`)).toContain('x=0 y=2 slot=');
+			expect(browserLogs).toEqual(
+				expect.arrayContaining([expect.stringMatching(/hot updated:.*UsingNamed.svelte/)])
+			);
+			expect(browserLogs).not.toEqual(
+				expect.arrayContaining([expect.stringMatching(/hot updated:.*UsingOnlyDefault.svelte/)])
+			);
 		});
 
 		test('should work with emitCss: false in vite config', async () => {

--- a/packages/e2e-tests/hmr/src/components/partial-hmr/PartialHmr.svelte
+++ b/packages/e2e-tests/hmr/src/components/partial-hmr/PartialHmr.svelte
@@ -1,6 +1,7 @@
 <script>
-	import ModuleContext, { y } from './ModuleContext.svelte';
+	import UsingNamed from './UsingNamed.svelte';
+	import UsingOnlyDefault from './UsingOnlyDefault.svelte';
 </script>
 
-<ModuleContext id="hmr-with-context">{y}</ModuleContext>
-<ModuleContext id="hmr-without-context" />
+<UsingNamed />
+<UsingOnlyDefault />

--- a/packages/e2e-tests/hmr/src/components/partial-hmr/UsingNamed.svelte
+++ b/packages/e2e-tests/hmr/src/components/partial-hmr/UsingNamed.svelte
@@ -1,0 +1,5 @@
+<script>
+	import ModuleContext, { y } from './ModuleContext.svelte';
+</script>
+
+<ModuleContext id="hmr-with-context">{y}</ModuleContext>

--- a/packages/e2e-tests/hmr/src/components/partial-hmr/UsingOnlyDefault.svelte
+++ b/packages/e2e-tests/hmr/src/components/partial-hmr/UsingOnlyDefault.svelte
@@ -1,0 +1,5 @@
+<script>
+	import ModuleContext from './ModuleContext.svelte';
+</script>
+
+<ModuleContext id="hmr-without-context" />


### PR DESCRIPTION
Adding these assertions ensure that the test is not passing by updating too eagerly. For example, with old svelte-hmr option `acceptNamedExports:false`, the current test would pass, but the hardened version would not.

We only want the actual consumers of the named exports to be impacted by the HMR bubble. Consumers of only the default export (i.e. the component) should not be impacted, because the default export is accepted by the component itself.