### PR TITLE
fix: use esnext for useVitePreprocess

### DIFF
--- a/.changeset/cuddly-tools-fold.md
+++ b/.changeset/cuddly-tools-fold.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+Use esnext for useVitePreprocess

--- a/packages/vite-plugin-svelte/src/utils/preprocess.ts
+++ b/packages/vite-plugin-svelte/src/utils/preprocess.ts
@@ -23,6 +23,7 @@ function createViteScriptPreprocessor(): Preprocessor {
 		if (!supportedScriptLangs.includes(lang)) return;
 		const transformResult = await transformWithEsbuild(content, filename, {
 			loader: lang as ESBuildOptions['loader'],
+			target: 'esnext',
 			tsconfigRaw: {
 				compilerOptions: {
 					// svelte typescript needs this flag to work with type imports


### PR DESCRIPTION
Similar as https://github.com/vitejs/vite/pull/10207, use `esnext` so we don't lower the syntax, as we only want to transpile ts -> js.