### PR TITLE
refactor: remove `@rollup/pluginutils` dependency

### DIFF
--- a/.changeset/ninety-pans-wave.md
+++ b/.changeset/ninety-pans-wave.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+Remove `@rollup/pluginutils` dependency

--- a/packages/vite-plugin-svelte/package.json
+++ b/packages/vite-plugin-svelte/package.json
@@ -46,7 +46,6 @@
   },
   "homepage": "https://github.com/sveltejs/vite-plugin-svelte#readme",
   "dependencies": {
-    "@rollup/pluginutils": "^4.2.1",
     "debug": "^4.3.4",
     "deepmerge": "^4.2.2",
     "kleur": "^4.1.5",

--- a/packages/vite-plugin-svelte/src/utils/id.ts
+++ b/packages/vite-plugin-svelte/src/utils/id.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-unused-vars */
-import { createFilter } from '@rollup/pluginutils';
+import { createFilter } from 'vite';
 import { Arrayable, ResolvedOptions } from './options';
 import { normalizePath } from 'vite';
 import * as fs from 'fs';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -460,7 +460,6 @@ importers:
 
   packages/vite-plugin-svelte:
     specifiers:
-      '@rollup/pluginutils': ^4.2.1
       '@types/debug': ^4.1.7
       '@types/diff-match-patch': ^1.0.32
       debug: ^4.3.4
@@ -475,7 +474,6 @@ importers:
       tsup: ^6.2.3
       vite: ^3.1.8
     dependencies:
-      '@rollup/pluginutils': 4.2.1
       debug: 4.3.4
       deepmerge: 4.2.2
       kleur: 4.1.5
@@ -960,6 +958,7 @@ packages:
     dependencies:
       estree-walker: 2.0.2
       picomatch: 2.3.1
+    dev: true
 
   /@sveltejs/adapter-auto/1.0.0-next.83:
     resolution: {integrity: sha512-6Km4x792PjHaN0H0odsy7JOj3jdDZqN1tA58B1b96xWUUUj87tw6XYC7VWRBjwo2wZqWkRat94IegrtAAhYVaA==}
@@ -2628,6 +2627,7 @@ packages:
 
   /estree-walker/2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+    dev: true
 
   /esutils/2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
@@ -4211,6 +4211,7 @@ packages:
   /picomatch/2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
+    dev: true
 
   /pidtree/0.3.1:
     resolution: {integrity: sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==}


### PR DESCRIPTION
Import `createFilter` from `vite` instead (available since Vite 3).

This should autoclose #468