### PR TITLE
chore: remove internal dependency type

### DIFF
--- a/.changeset/gentle-paws-listen.md
+++ b/.changeset/gentle-paws-listen.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+chore: remove internal dependency type

--- a/packages/vite-plugin-svelte/src/utils/options.ts
+++ b/packages/vite-plugin-svelte/src/utils/options.ts
@@ -393,9 +393,6 @@ function buildOptimizeDepsForSvelte(
 		return { include, exclude };
 	}
 
-	// only svelte component libraries needs to be processed for optimizeDeps, js libraries work fine
-	svelteDeps = svelteDeps.filter((dep) => dep.type === 'component-library');
-
 	const svelteDepsToExclude = Array.from(new Set(svelteDeps.map((dep) => dep.name))).filter(
 		(dep) => !isIncluded(dep)
 	);


### PR DESCRIPTION
We want to deprecate the `svelte` field, so remove reliance on it when crawling dependencies. Crawling more dependencies may have some small negative performance implications, but overall removing the `svelte` field will greatly improve performance by allowing us to more often resolve prebundled Svelte libraries which we can't do when the `svelte` field is present