### PR TITLE
Add types to the exports

### DIFF
--- a/.changeset/shaggy-panthers-leave.md
+++ b/.changeset/shaggy-panthers-leave.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+add types to exports map in package.json

--- a/packages/vite-plugin-svelte/package.json
+++ b/packages/vite-plugin-svelte/package.json
@@ -16,6 +16,7 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },


### PR DESCRIPTION
Add missing "types" definition to the exports object. In some cases the one defined at the root level of the package json file is ignored if exports is also defined.

Usecase:
I have a package (type module) where I export preconfigured vite configs and I use this plugin in one of them. Pre-processing the configs using vite and vite-plugin-dts reports this error:

```sh
[vite:dts] Start generate declaration files...
src/configs/app-svelte-vite.config.ts:1:24 - error TS7016: Could not find a declaration file for module '@sveltejs/vite-plugin-svelte'. '/home/alex/git/js/node_modules/.pnpm/@sveltejs+vite-plugin-svelte@1.1.0_svelte@3.52.0+vite@3.2.3/node_modules/@sveltejs/vite-plugin-svelte/dist/index.cjs' implicitly has an 'any' type.
  Try `npm i --save-dev @types/sveltejs__vite-plugin-svelte` if it exists or add a new declaration (.d.ts) file containing `declare module '@sveltejs/vite-plugin-svelte';`

1 import { svelte } from '@sveltejs/vite-plugin-svelte';
                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

If I manually add this line in `node_modules` the error goes away.

(The declaration seems to be resolved just fine by the language server, no errors are reported in the editor)