### PR TITLE
fix: bump svelte-hmr to support compileOptions.css='external'

### DIFF
--- a/.changeset/giant-pears-act.md
+++ b/.changeset/giant-pears-act.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+bump svelte-hmr to support compileOptions.css='external' from svelte 3.53

--- a/packages/vite-plugin-svelte/package.json
+++ b/packages/vite-plugin-svelte/package.json
@@ -51,7 +51,7 @@
     "deepmerge": "^4.2.2",
     "kleur": "^4.1.5",
     "magic-string": "^0.26.7",
-    "svelte-hmr": "^0.15.0",
+    "svelte-hmr": "^0.15.1",
     "vitefu": "^0.2.0"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -505,7 +505,7 @@ importers:
       magic-string: ^0.26.7
       rollup: ^2.79.1
       svelte: 3.53.1
-      svelte-hmr: ^0.15.0
+      svelte-hmr: ^0.15.1
       tsup: ^6.4.0
       vite: ^3.2.3
       vitefu: ^0.2.0
@@ -514,7 +514,7 @@ importers:
       deepmerge: 4.2.2
       kleur: 4.1.5
       magic-string: 0.26.7
-      svelte-hmr: 0.15.0_svelte@3.53.1
+      svelte-hmr: 0.15.1_svelte@3.53.1
       vitefu: 0.2.0_vite@3.2.3
     devDependencies:
       '@types/debug': 4.1.7
@@ -5058,8 +5058,8 @@ packages:
       - sugarss
     dev: true
 
-  /svelte-hmr/0.15.0_svelte@3.53.1:
-    resolution: {integrity: sha512-Aw21SsyoohyVn4yiKXWPNCSW2DQNH/76kvUnE9kpt4h9hcg9tfyQc6xshx9hzgMfGF0kVx0EGD8oBMWSnATeOg==}
+  /svelte-hmr/0.15.1_svelte@3.53.1:
+    resolution: {integrity: sha512-BiKB4RZ8YSwRKCNVdNxK/GfY+r4Kjgp9jCLEy0DuqAKfmQtpL38cQK3afdpjw4sqSs4PLi3jIPJIFp259NkZtA==}
     engines: {node: ^12.20 || ^14.13.1 || >= 16}
     peerDependencies:
       svelte: '>=3.19.0'


### PR DESCRIPTION
the change in svelte-hmr is tiny and just for supporting css='external' properly. 
bump it just to avoid someone updating v-p-s without updating svelte-hmr

see https://github.com/sveltejs/svelte-hmr/pull/63