### PR TITLE
fix: use a recursive helper to find named parent package

### DIFF
--- a/.changeset/dry-seahorses-sin.md
+++ b/.changeset/dry-seahorses-sin.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+improve robustness of compile stats taking

--- a/packages/vite-plugin-svelte/package.json
+++ b/packages/vite-plugin-svelte/package.json
@@ -52,7 +52,7 @@
     "kleur": "^4.1.5",
     "magic-string": "^0.26.7",
     "svelte-hmr": "^0.15.1",
-    "vitefu": "^0.2.1"
+    "vitefu": "^0.2.2"
   },
   "peerDependencies": {
     "diff-match-patch": "^1.0.5",

--- a/packages/vite-plugin-svelte/src/utils/vite-plugin-svelte-stats.ts
+++ b/packages/vite-plugin-svelte/src/utils/vite-plugin-svelte-stats.ts
@@ -131,6 +131,7 @@ export class VitePluginSvelteStats {
 				if (collection.finished) {
 					throw new Error('called after finish() has been used');
 				}
+				file = normalizePath(file);
 				const start = performance.now();
 				const stat: Stat = { file, start, end: start };
 				return () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -588,14 +588,14 @@ importers:
       svelte-hmr: ^0.15.1
       tsup: ^6.5.0
       vite: ^3.2.3
-      vitefu: ^0.2.1
+      vitefu: ^0.2.2
     dependencies:
       debug: 4.3.4
       deepmerge: 4.2.2
       kleur: 4.1.5
       magic-string: 0.26.7
       svelte-hmr: 0.15.1_svelte@3.53.1
-      vitefu: 0.2.1_vite@3.2.3
+      vitefu: 0.2.2_vite@3.2.3
     devDependencies:
       '@types/debug': 4.1.7
       '@types/diff-match-patch': 1.0.32
@@ -5899,8 +5899,8 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /vitefu/0.2.1_vite@3.2.3:
-    resolution: {integrity: sha512-clkvXTAeUf+XQKm3bhWUhT4pye+3acm6YCTGaWhxxIvZZ/QjnA3JA8Zud+z/mO5y5XYvJJhevs5Sjkv/FI8nRw==}
+  /vitefu/0.2.2_vite@3.2.3:
+    resolution: {integrity: sha512-8CKEIWPm4B4DUDN+h+hVJa9pyNi7rzc5MYmbxhs1wcMakueGFNWB5/DL30USm9qU3xUPnL4/rrLEAwwFiD1tag==}
     peerDependencies:
       vite: ^3.0.0 || ^3.2.0
     peerDependenciesMeta:


### PR DESCRIPTION
 catch errors to avoid breaking the process just because stats didn't work