### PR TITLE
feat: log deprecation warning if svelte field causes difference in resolve

### DIFF
--- a/.changeset/cold-horses-begin.md
+++ b/.changeset/cold-horses-begin.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+log deprecation warnings for packages that use the "svelte" field to resolve svelte files differently than standard vite resolve

--- a/packages/vite-plugin-svelte/src/utils/compile.ts
+++ b/packages/vite-plugin-svelte/src/utils/compile.ts
@@ -113,6 +113,7 @@ const _createCompileSvelte = (makeHot: Function) => {
 			compiled.js.code = makeHot({
 				id: filename,
 				compiledCode: compiled.js.code,
+				// @ts-expect-error hot isn't a boolean anymore at this point
 				hotOptions: { ...options.hot, injectCss: options.hot?.injectCss === true && hasCss },
 				compiled,
 				originalCode: code,

--- a/packages/vite-plugin-svelte/src/utils/log.ts
+++ b/packages/vite-plugin-svelte/src/utils/log.ts
@@ -73,7 +73,7 @@ function createLogger(level: string): LogFn {
 	const logFn: LogFn = _log.bind(null, logger) as LogFn;
 	const logged = new Set<String>();
 	const once = function (message: string, payload?: any) {
-		if (logged.has(message)) {
+		if (!logger.enabled || logged.has(message)) {
 			return;
 		}
 		logged.add(message);

--- a/packages/vite-plugin-svelte/src/utils/options.ts
+++ b/packages/vite-plugin-svelte/src/utils/options.ts
@@ -33,6 +33,7 @@ import {
 import { atLeastSvelte } from './svelte-version';
 import { isCommonDepWithoutSvelteField } from './dependencies';
 import { VitePluginSvelteStats } from './vite-plugin-svelte-stats';
+import { VitePluginSvelteCache } from './vite-plugin-svelte-cache';
 
 // svelte 3.53.0 changed compilerOptions.css from boolean to string | boolen, use string when available
 const cssAsString = atLeastSvelte('3.53.0');
@@ -180,7 +181,8 @@ function mergeConfigs<T>(...configs: (Partial<T> | undefined)[]): T {
 // also validates the final config.
 export function resolveOptions(
 	preResolveOptions: PreResolvedOptions,
-	viteConfig: ResolvedConfig
+	viteConfig: ResolvedConfig,
+	cache: VitePluginSvelteCache
 ): ResolvedOptions {
 	const css = cssAsString
 		? preResolveOptions.emitCss
@@ -217,7 +219,7 @@ export function resolveOptions(
 	const statsEnabled =
 		disableCompileStats !== true && disableCompileStats !== (merged.isBuild ? 'build' : 'dev');
 	if (statsEnabled && isLogLevelInfo) {
-		merged.stats = new VitePluginSvelteStats();
+		merged.stats = new VitePluginSvelteStats(cache);
 	}
 	return merged;
 }

--- a/packages/vite-plugin-svelte/src/utils/vite-plugin-svelte-cache.ts
+++ b/packages/vite-plugin-svelte/src/utils/vite-plugin-svelte-cache.ts
@@ -1,5 +1,17 @@
 import { SvelteRequest } from './id';
 import { Code, CompileData } from './compile';
+import { readFileSync } from 'fs';
+import { dirname } from 'path';
+//eslint-disable-next-line node/no-missing-import
+import { findClosestPkgJsonPath } from 'vitefu';
+import { normalizePath } from 'vite';
+
+interface PackageInfo {
+	name: string;
+	version: string;
+	svelte?: string;
+	path: string;
+}
 
 export class VitePluginSvelteCache {
 	private _css = new Map<string, Code>();
@@ -8,6 +20,7 @@ export class VitePluginSvelteCache {
 	private _dependants = new Map<string, Set<string>>();
 	private _resolvedSvelteFields = new Map<string, string>();
 	private _errors = new Map<string, any>();
+	private _packageInfos: PackageInfo[] = [];
 
 	public update(compileData: CompileData) {
 		this._errors.delete(compileData.normalizedFilename);
@@ -124,4 +137,43 @@ export class VitePluginSvelteCache {
 	private _getResolvedSvelteFieldKey(importee: string, importer?: string): string {
 		return importer ? `${importer} > ${importee}` : importee;
 	}
+
+	public async getPackageInfo(file: string): Promise<PackageInfo> {
+		let info = this._packageInfos.find((pi) => file.startsWith(pi.path));
+		if (!info) {
+			info = await findPackageInfo(file);
+			this._packageInfos.push(info);
+		}
+		return info;
+	}
+}
+
+/**
+ * utility to get some info from the package.json a file belongs to (closest one with a "name" set)
+ *
+ * @param {string} file to find info for
+ * @returns {PackageInfo}
+ */
+async function findPackageInfo(file: string): Promise<PackageInfo> {
+	const info: PackageInfo = {
+		name: '$unknown',
+		version: '0.0.0-unknown',
+		path: '$unknown'
+	};
+	let path = await findClosestPkgJsonPath(file, (pkgPath) => {
+		const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+		if (pkg.name != null) {
+			info.name = pkg.name;
+			if (pkg.version != null) {
+				info.version = pkg.version;
+			}
+			info.svelte = pkg.svelte;
+			return true;
+		}
+		return false;
+	});
+	// return normalized path with appended '/' so .startsWith works for future file checks
+	path = normalizePath(dirname(path ?? file)) + '/';
+	info.path = path;
+	return info;
 }


### PR DESCRIPTION
- [ ] add documentation and update log message to contain link


1) do we need an option to disable these warnings
2) should they be logged upon encountering them or batched in buildEnd
3) how do we test this