### PR TITLE
feat!: update svelte peerDependency to ^3.54.0

### DIFF
--- a/.changeset/silver-jokes-do.md
+++ b/.changeset/silver-jokes-do.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': major
+---
+
+update svelte peerDependency to ^3.54.0

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "prettier": "^2.8.0",
     "prettier-plugin-svelte": "^2.8.1",
     "rimraf": "^3.0.2",
-    "svelte": "^3.53.1",
+    "svelte": "^3.54.0",
     "typescript": "^4.9.3",
     "vite": "^4.0.0-beta.1",
     "vitest": "^0.25.4"

--- a/packages/e2e-tests/_test_dependencies/svelte-api-only/package.json
+++ b/packages/e2e-tests/_test_dependencies/svelte-api-only/package.json
@@ -16,6 +16,6 @@
   },
   "type": "module",
   "dependencies": {
-    "svelte": "^3.53.1"
+    "svelte": "^3.54.0"
   }
 }

--- a/packages/e2e-tests/autoprefixer-browerslist/package.json
+++ b/packages/e2e-tests/autoprefixer-browerslist/package.json
@@ -15,7 +15,7 @@
     "autoprefixer": "^10.4.13",
     "postcss": "^8.4.19",
     "postcss-load-config": "^4.0.1",
-    "svelte": "^3.53.1",
+    "svelte": "^3.54.0",
     "svelte-preprocess": "^4.10.7",
     "vite": "^4.0.0-beta.1"
   },

--- a/packages/e2e-tests/configfile-custom/package.json
+++ b/packages/e2e-tests/configfile-custom/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "workspace:*",
-    "svelte": "^3.53.1",
+    "svelte": "^3.54.0",
     "vite": "^4.0.0-beta.1"
   },
   "type": "module"

--- a/packages/e2e-tests/configfile-esm/package.json
+++ b/packages/e2e-tests/configfile-esm/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "workspace:*",
-    "svelte": "^3.53.1",
+    "svelte": "^3.54.0",
     "svelte-preprocess": "^4.10.7",
     "vite": "^4.0.0-beta.1"
   },

--- a/packages/e2e-tests/css-none/package.json
+++ b/packages/e2e-tests/css-none/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "workspace:*",
-    "svelte": "^3.53.1",
+    "svelte": "^3.54.0",
     "vite": "^4.0.0-beta.1"
   }
 }

--- a/packages/e2e-tests/custom-extensions/package.json
+++ b/packages/e2e-tests/custom-extensions/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "workspace:*",
-    "svelte": "^3.53.1",
+    "svelte": "^3.54.0",
     "vite": "^4.0.0-beta.1"
   },
   "type": "module"

--- a/packages/e2e-tests/env/package.json
+++ b/packages/e2e-tests/env/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "workspace:*",
-    "svelte": "^3.53.1",
+    "svelte": "^3.54.0",
     "vite": "^4.0.0-beta.1"
   },
   "type": "module"

--- a/packages/e2e-tests/hmr/package.json
+++ b/packages/e2e-tests/hmr/package.json
@@ -14,7 +14,7 @@
     "@sveltejs/vite-plugin-svelte": "workspace:*",
     "e2e-test-dep-vite-plugins": "file:../_test_dependencies/vite-plugins",
     "node-fetch": "^3.3.0",
-    "svelte": "^3.53.1",
+    "svelte": "^3.54.0",
     "vite": "^4.0.0-beta.1"
   },
   "type": "module"

--- a/packages/e2e-tests/import-queries/package.json
+++ b/packages/e2e-tests/import-queries/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "workspace:*",
     "sass": "^1.56.1",
-    "svelte": "^3.53.1",
+    "svelte": "^3.54.0",
     "vite": "^4.0.0-beta.1"
   }
 }

--- a/packages/e2e-tests/inspector-kit/package.json
+++ b/packages/e2e-tests/inspector-kit/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@sveltejs/kit": "^1.0.0-next.572",
-    "svelte": "^3.53.1",
+    "svelte": "^3.54.0",
     "vite": "^4.0.0-beta.1"
   },
   "type": "module"

--- a/packages/e2e-tests/inspector-vite/package.json
+++ b/packages/e2e-tests/inspector-vite/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "workspace:*",
-    "svelte": "^3.53.1",
+    "svelte": "^3.54.0",
     "vite": "^4.0.0-beta.1"
   }
 }

--- a/packages/e2e-tests/kit-node/package.json
+++ b/packages/e2e-tests/kit-node/package.json
@@ -15,7 +15,7 @@
     "@sveltejs/kit": "^1.0.0-next.572",
     "e2e-test-dep-svelte-api-only": "file:../_test_dependencies/svelte-api-only",
     "e2e-test-dep-vite-plugins": "file:../_test_dependencies/vite-plugins",
-    "svelte": "^3.53.1",
+    "svelte": "^3.54.0",
     "svelte-check": "^2.10.1",
     "svelte-i18n": "^3.6.0",
     "tiny-glob": "^0.2.9",

--- a/packages/e2e-tests/package-json-svelte-field/package.json
+++ b/packages/e2e-tests/package-json-svelte-field/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "workspace:*",
-    "svelte": "^3.53.1",
+    "svelte": "^3.54.0",
     "vite": "^4.0.0-beta.1"
   },
   "type": "module"

--- a/packages/e2e-tests/prebundle-svelte-deps/package.json
+++ b/packages/e2e-tests/prebundle-svelte-deps/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "workspace:*",
     "sass": "^1.56.1",
-    "svelte": "^3.53.1",
+    "svelte": "^3.54.0",
     "svelte-preprocess": "^4.10.7",
     "vite": "^4.0.0-beta.1"
   }

--- a/packages/e2e-tests/preprocess-with-vite/package.json
+++ b/packages/e2e-tests/preprocess-with-vite/package.json
@@ -11,7 +11,7 @@
     "@sveltejs/vite-plugin-svelte": "workspace:*",
     "sass": "^1.56.1",
     "stylus": "^0.59.0",
-    "svelte": "^3.53.1",
+    "svelte": "^3.54.0",
     "vite": "^4.0.0-beta.1"
   },
   "type": "module"

--- a/packages/e2e-tests/resolve-exports-svelte/package.json
+++ b/packages/e2e-tests/resolve-exports-svelte/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "workspace:*",
-    "svelte": "3.53.1",
+    "svelte": "^3.54.0",
     "vite": "^4.0.0-beta.1"
   }
 }

--- a/packages/e2e-tests/svelte-preprocess/package.json
+++ b/packages/e2e-tests/svelte-preprocess/package.json
@@ -10,7 +10,7 @@
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "workspace:*",
     "sass": "^1.56.1",
-    "svelte": "^3.53.1",
+    "svelte": "^3.54.0",
     "svelte-preprocess": "^4.10.7",
     "typescript": "^4.9.3",
     "vite": "^4.0.0-beta.1"

--- a/packages/e2e-tests/ts-type-import/package.json
+++ b/packages/e2e-tests/ts-type-import/package.json
@@ -11,7 +11,7 @@
     "@sveltejs/vite-plugin-svelte": "workspace:*",
     "@tsconfig/svelte": "^3.0.0",
     "@types/node": "^18.11.11",
-    "svelte": "^3.53.1",
+    "svelte": "^3.54.0",
     "svelte-preprocess": "^4.10.7",
     "vite": "^4.0.0-beta.1"
   },

--- a/packages/e2e-tests/vite-ssr-esm/package.json
+++ b/packages/e2e-tests/vite-ssr-esm/package.json
@@ -20,7 +20,7 @@
     "express": "^4.18.2",
     "npm-run-all": "^4.1.5",
     "serve-static": "^1.15.0",
-    "svelte": "^3.53.1",
+    "svelte": "^3.54.0",
     "vite": "^4.0.0-beta.1"
   }
 }

--- a/packages/e2e-tests/vite-ssr/package.json
+++ b/packages/e2e-tests/vite-ssr/package.json
@@ -17,7 +17,7 @@
     "e2e-test-dep-esm-only": "file:../_test_dependencies/esm-only",
     "express": "^4.18.2",
     "serve-static": "^1.15.0",
-    "svelte": "^3.53.1",
+    "svelte": "^3.54.0",
     "vite": "^4.0.0-beta.1"
   }
 }

--- a/packages/playground/big-component-library-kit/package.json
+++ b/packages/playground/big-component-library-kit/package.json
@@ -16,7 +16,7 @@
 		"carbon-icons-svelte": "^11.4.0",
 		"carbon-preprocess-svelte": "^0.9.1",
 		"lodash-es": "^4.17.21",
-		"svelte": "^3.53.1",
+		"svelte": "^3.54.0",
 		"svelte-check": "^2.10.1",
 		"svelte-preprocess": "^4.10.7",
 		"typescript": "^4.9.3",

--- a/packages/playground/big-component-library-vite-ssr/package.json
+++ b/packages/playground/big-component-library-vite-ssr/package.json
@@ -22,7 +22,7 @@
     "carbon-preprocess-svelte": "^0.9.1",
     "cross-env": "^7.0.3",
     "lodash-es": "^4.17.21",
-    "svelte": "^3.53.1",
+    "svelte": "^3.54.0",
     "svelte-preprocess": "^4.10.7",
     "vite": "^4.0.0-beta.1"
   }

--- a/packages/playground/big-component-library/package.json
+++ b/packages/playground/big-component-library/package.json
@@ -13,7 +13,7 @@
     "carbon-components-svelte": "^0.70.12",
     "carbon-icons-svelte": "^11.4.0",
     "carbon-preprocess-svelte": "^0.9.1",
-    "svelte": "^3.53.1",
+    "svelte": "^3.54.0",
     "svelte-preprocess": "^4.10.7",
     "vite": "^4.0.0-beta.1"
   },

--- a/packages/playground/big/package.json
+++ b/packages/playground/big/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "workspace:*",
-    "svelte": "^3.53.1",
+    "svelte": "^3.54.0",
     "vite": "^4.0.0-beta.1"
   }
 }

--- a/packages/playground/kit-demo-app/package.json
+++ b/packages/playground/kit-demo-app/package.json
@@ -15,7 +15,7 @@
 		"@sveltejs/adapter-auto": "^1.0.0-next.90",
 		"@sveltejs/kit": "^1.0.0-next.572",
 		"@types/cookie": "^0.5.1",
-		"svelte": "^3.53.1",
+		"svelte": "^3.54.0",
 		"svelte-check": "^2.10.1",
 		"typescript": "^4.9.3",
 		"vite": "^4.0.0-beta.1"

--- a/packages/playground/optimizedeps-include/package.json
+++ b/packages/playground/optimizedeps-include/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "workspace:*",
-    "svelte": "^3.53.1",
+    "svelte": "^3.54.0",
     "tinro": "^0.6.12",
     "vite": "^4.0.0-beta.1"
   }

--- a/packages/playground/windicss/package.json
+++ b/packages/playground/windicss/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "workspace:*",
     "diff-match-patch": "^1.0.5",
-    "svelte": "^3.53.1",
+    "svelte": "^3.54.0",
     "vite": "^4.0.0-beta.1",
     "vite-plugin-windicss": "^1.8.8"
   }

--- a/packages/vite-plugin-svelte/package.json
+++ b/packages/vite-plugin-svelte/package.json
@@ -50,14 +50,14 @@
     "vitefu": "^0.2.2"
   },
   "peerDependencies": {
-    "svelte": "^3.44.0",
+    "svelte": "^3.54.0",
     "vite": "^4.0.0-beta.1"
   },
   "devDependencies": {
     "@types/debug": "^4.1.7",
     "esbuild": "^0.16.1",
     "rollup": "^2.79.1",
-    "svelte": "^3.53.1",
+    "svelte": "^3.54.0",
     "tsup": "^6.5.0",
     "vite": "^4.0.0-beta.1"
   }

--- a/packages/vite-plugin-svelte/src/utils/esbuild.ts
+++ b/packages/vite-plugin-svelte/src/utils/esbuild.ts
@@ -5,12 +5,10 @@ import { Compiled } from './compile';
 import { log } from './log';
 import { CompileOptions, ResolvedOptions } from './options';
 import { toESBuildError } from './error';
-import { atLeastSvelte } from './svelte-version';
 import { StatCollection } from './vite-plugin-svelte-stats';
 
 type EsbuildOptions = NonNullable<DepOptimizationOptions['esbuildOptions']>;
 type EsbuildPlugin = NonNullable<EsbuildOptions['plugins']>[number];
-const isCssString = atLeastSvelte('3.53.0');
 
 export const facadeEsbuildSveltePluginName = 'vite-plugin-svelte:facade';
 
@@ -53,7 +51,8 @@ async function compileSvelte(
 ): Promise<string> {
 	let css = options.compilerOptions.css;
 	if (css !== 'none') {
-		css = isCssString ? 'injected' : true;
+		// TODO ideally we'd be able to externalize prebundled styles too, but for now always put them in the js
+		css = 'injected';
 	}
 	const compileOptions: CompileOptions = {
 		...options.compilerOptions,

--- a/packages/vite-plugin-svelte/src/utils/options.ts
+++ b/packages/vite-plugin-svelte/src/utils/options.ts
@@ -30,12 +30,9 @@ import {
 	isDepNoExternaled
 	// eslint-disable-next-line node/no-missing-import
 } from 'vitefu';
-import { atLeastSvelte } from './svelte-version';
+
 import { isCommonDepWithoutSvelteField } from './dependencies';
 import { VitePluginSvelteStats } from './vite-plugin-svelte-stats';
-
-// svelte 3.53.0 changed compilerOptions.css from boolean to string | boolen, use string when available
-const cssAsString = atLeastSvelte('3.53.0');
 
 const allowedPluginOptions = new Set([
 	'include',
@@ -182,16 +179,12 @@ export function resolveOptions(
 	preResolveOptions: PreResolvedOptions,
 	viteConfig: ResolvedConfig
 ): ResolvedOptions {
-	const css = cssAsString
-		? preResolveOptions.emitCss
-			? 'external'
-			: 'injected'
-		: !preResolveOptions.emitCss;
+	const css = preResolveOptions.emitCss ? 'external' : 'injected';
 	const defaultOptions: Partial<Options> = {
 		hot: viteConfig.isProduction
 			? false
 			: {
-					injectCss: css === true || css === 'injected',
+					injectCss: css === 'injected',
 					partialAccept: !!viteConfig.experimental?.hmrPartialAccept
 			  },
 		compilerOptions: {
@@ -235,7 +228,7 @@ function enforceOptionsForHmr(options: ResolvedOptions) {
 			}
 			const css = options.compilerOptions.css;
 			if (css === true || css === 'injected') {
-				const forcedCss = cssAsString ? 'external' : false;
+				const forcedCss = 'external';
 				log.warn(
 					`hmr and emitCss are enabled but compilerOptions.css is ${css}, forcing it to ${forcedCss}`
 				);
@@ -254,7 +247,7 @@ function enforceOptionsForHmr(options: ResolvedOptions) {
 			}
 			const css = options.compilerOptions.css;
 			if (!(css === true || css === 'injected')) {
-				const forcedCss = cssAsString ? 'injected' : true;
+				const forcedCss = 'injected';
 				log.warn(
 					`hmr with emitCss disabled requires compilerOptions.css to be enabled, forcing it to ${forcedCss}`
 				);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,7 +34,7 @@ importers:
       prettier: ^2.8.0
       prettier-plugin-svelte: ^2.8.1
       rimraf: ^3.0.2
-      svelte: ^3.53.1
+      svelte: ^3.54.0
       typescript: ^4.9.3
       vite: ^4.0.0-beta.1
       vitest: ^0.25.4
@@ -54,7 +54,7 @@ importers:
       eslint-plugin-markdown: 3.0.0_eslint@8.29.0
       eslint-plugin-node: 11.1.0_eslint@8.29.0
       eslint-plugin-prettier: 4.2.1_nrhoyyjffvfyk4vtlt5destxgm
-      eslint-plugin-svelte3: 4.0.0_kzv3boqmfymw5ol254gxmp75rq
+      eslint-plugin-svelte3: 4.0.0_2aagxyyd66x6iymg5nfckajqjq
       execa: 6.1.0
       fs-extra: 10.1.0
       husky: 8.0.2
@@ -63,9 +63,9 @@ importers:
       npm-run-all: 4.1.5
       playwright-core: 1.28.1
       prettier: 2.8.0
-      prettier-plugin-svelte: 2.8.1_3ndnxlh52lolrqe4kgjgbxb3xa
+      prettier-plugin-svelte: 2.8.1_kaioqtfwjumrsfopsgfoca65re
       rimraf: 3.0.2
-      svelte: 3.53.1
+      svelte: 3.54.0
       typescript: 4.9.3
       vite: 4.0.0-beta.1_@types+node@18.11.11
       vitest: 0.25.4
@@ -97,9 +97,9 @@ importers:
 
   packages/e2e-tests/_test_dependencies/svelte-api-only:
     specifiers:
-      svelte: ^3.53.1
+      svelte: ^3.54.0
     dependencies:
-      svelte: 3.53.1
+      svelte: 3.54.0
 
   packages/e2e-tests/_test_dependencies/svelte-exports-simple:
     specifiers:
@@ -144,7 +144,7 @@ importers:
       e2e-test-dep-svelte-simple: file:../_test_dependencies/svelte-simple
       postcss: ^8.4.19
       postcss-load-config: ^4.0.1
-      svelte: ^3.53.1
+      svelte: ^3.54.0
       svelte-preprocess: ^4.10.7
       vite: ^4.0.0-beta.1
     dependencies:
@@ -154,56 +154,56 @@ importers:
       autoprefixer: 10.4.13_postcss@8.4.19
       postcss: 8.4.19
       postcss-load-config: 4.0.1_postcss@8.4.19
-      svelte: 3.53.1
-      svelte-preprocess: 4.10.7_g7z2chviobwh5b53nr2x4mtdq4
+      svelte: 3.54.0
+      svelte-preprocess: 4.10.7_v4f7ozfe3bsi7lgm4qy7utpt3q
       vite: 4.0.0-beta.1
 
   packages/e2e-tests/configfile-custom:
     specifiers:
       '@sveltejs/vite-plugin-svelte': workspace:*
       e2e-test-dep-svelte-simple: file:../_test_dependencies/svelte-simple
-      svelte: ^3.53.1
+      svelte: ^3.54.0
       vite: ^4.0.0-beta.1
     dependencies:
       e2e-test-dep-svelte-simple: file:packages/e2e-tests/_test_dependencies/svelte-simple
     devDependencies:
       '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte
-      svelte: 3.53.1
+      svelte: 3.54.0
       vite: 4.0.0-beta.1
 
   packages/e2e-tests/configfile-esm:
     specifiers:
       '@sveltejs/vite-plugin-svelte': workspace:*
       e2e-test-dep-svelte-simple: file:../_test_dependencies/svelte-simple
-      svelte: ^3.53.1
+      svelte: ^3.54.0
       svelte-preprocess: ^4.10.7
       vite: ^4.0.0-beta.1
     dependencies:
       e2e-test-dep-svelte-simple: file:packages/e2e-tests/_test_dependencies/svelte-simple
     devDependencies:
       '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte
-      svelte: 3.53.1
-      svelte-preprocess: 4.10.7_svelte@3.53.1
+      svelte: 3.54.0
+      svelte-preprocess: 4.10.7_svelte@3.54.0
       vite: 4.0.0-beta.1
 
   packages/e2e-tests/css-none:
     specifiers:
       '@sveltejs/vite-plugin-svelte': workspace:*
-      svelte: ^3.53.1
+      svelte: ^3.54.0
       vite: ^4.0.0-beta.1
     devDependencies:
       '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte
-      svelte: 3.53.1
+      svelte: 3.54.0
       vite: 4.0.0-beta.1
 
   packages/e2e-tests/custom-extensions:
     specifiers:
       '@sveltejs/vite-plugin-svelte': workspace:*
-      svelte: ^3.53.1
+      svelte: ^3.54.0
       vite: ^4.0.0-beta.1
     devDependencies:
       '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte
-      svelte: 3.53.1
+      svelte: 3.54.0
       vite: 4.0.0-beta.1
 
   packages/e2e-tests/dependencies:
@@ -223,11 +223,11 @@ importers:
   packages/e2e-tests/env:
     specifiers:
       '@sveltejs/vite-plugin-svelte': workspace:*
-      svelte: ^3.53.1
+      svelte: ^3.54.0
       vite: ^4.0.0-beta.1
     devDependencies:
       '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte
-      svelte: 3.53.1
+      svelte: 3.54.0
       vite: 4.0.0-beta.1
 
   packages/e2e-tests/hmr:
@@ -236,7 +236,7 @@ importers:
       e2e-test-dep-svelte-simple: file:../_test_dependencies/svelte-simple
       e2e-test-dep-vite-plugins: file:../_test_dependencies/vite-plugins
       node-fetch: ^3.3.0
-      svelte: ^3.53.1
+      svelte: ^3.54.0
       vite: ^4.0.0-beta.1
     dependencies:
       e2e-test-dep-svelte-simple: file:packages/e2e-tests/_test_dependencies/svelte-simple
@@ -244,39 +244,39 @@ importers:
       '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte
       e2e-test-dep-vite-plugins: file:packages/e2e-tests/_test_dependencies/vite-plugins
       node-fetch: 3.3.0
-      svelte: 3.53.1
+      svelte: 3.54.0
       vite: 4.0.0-beta.1
 
   packages/e2e-tests/import-queries:
     specifiers:
       '@sveltejs/vite-plugin-svelte': workspace:*
       sass: ^1.56.1
-      svelte: ^3.53.1
+      svelte: ^3.54.0
       vite: ^4.0.0-beta.1
     devDependencies:
       '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte
       sass: 1.56.1
-      svelte: 3.53.1
+      svelte: 3.54.0
       vite: 4.0.0-beta.1_sass@1.56.1
 
   packages/e2e-tests/inspector-kit:
     specifiers:
       '@sveltejs/kit': ^1.0.0-next.572
-      svelte: ^3.53.1
+      svelte: ^3.54.0
       vite: ^4.0.0-beta.1
     devDependencies:
-      '@sveltejs/kit': 1.0.0-next.572_3ooora7siwcqeevktvnilli43e
-      svelte: 3.53.1
+      '@sveltejs/kit': 1.0.0-next.572_owb2ncz5iz7yvythbmu4fo2zsq
+      svelte: 3.54.0
       vite: 4.0.0-beta.1
 
   packages/e2e-tests/inspector-vite:
     specifiers:
       '@sveltejs/vite-plugin-svelte': workspace:*
-      svelte: ^3.53.1
+      svelte: ^3.54.0
       vite: ^4.0.0-beta.1
     devDependencies:
       '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte
-      svelte: 3.53.1
+      svelte: 3.54.0
       vite: 4.0.0-beta.1
 
   packages/e2e-tests/kit-node:
@@ -285,7 +285,7 @@ importers:
       '@sveltejs/kit': ^1.0.0-next.572
       e2e-test-dep-svelte-api-only: file:../_test_dependencies/svelte-api-only
       e2e-test-dep-vite-plugins: file:../_test_dependencies/vite-plugins
-      svelte: ^3.53.1
+      svelte: ^3.54.0
       svelte-check: ^2.10.1
       svelte-i18n: ^3.6.0
       tiny-glob: ^0.2.9
@@ -293,12 +293,12 @@ importers:
       vite: ^4.0.0-beta.1
     devDependencies:
       '@sveltejs/adapter-node': 1.0.0-next.102
-      '@sveltejs/kit': 1.0.0-next.572_3ooora7siwcqeevktvnilli43e
+      '@sveltejs/kit': 1.0.0-next.572_owb2ncz5iz7yvythbmu4fo2zsq
       e2e-test-dep-svelte-api-only: file:packages/e2e-tests/_test_dependencies/svelte-api-only
       e2e-test-dep-vite-plugins: file:packages/e2e-tests/_test_dependencies/vite-plugins
-      svelte: 3.53.1
-      svelte-check: 2.10.1_svelte@3.53.1
-      svelte-i18n: 3.6.0_svelte@3.53.1
+      svelte: 3.54.0
+      svelte-check: 2.10.1_svelte@3.54.0
+      svelte-i18n: 3.6.0_svelte@3.54.0
       tiny-glob: 0.2.9
       typescript: 4.9.3
       vite: 4.0.0-beta.1
@@ -308,14 +308,14 @@ importers:
       '@sveltejs/vite-plugin-svelte': workspace:*
       e2e-test-dep-svelte-hybrid: file:../_test_dependencies/svelte-hybrid
       e2e-test-dep-svelte-nested: file:../_test_dependencies/svelte-nested
-      svelte: ^3.53.1
+      svelte: ^3.54.0
       vite: ^4.0.0-beta.1
     dependencies:
       e2e-test-dep-svelte-hybrid: file:packages/e2e-tests/_test_dependencies/svelte-hybrid
       e2e-test-dep-svelte-nested: file:packages/e2e-tests/_test_dependencies/svelte-nested
     devDependencies:
       '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte
-      svelte: 3.53.1
+      svelte: 3.54.0
       vite: 4.0.0-beta.1
 
   packages/e2e-tests/prebundle-svelte-deps:
@@ -327,7 +327,7 @@ importers:
       e2e-test-dep-svelte-nested: file:../_test_dependencies/svelte-nested
       e2e-test-dep-svelte-simple: file:../_test_dependencies/svelte-simple
       sass: ^1.56.1
-      svelte: ^3.53.1
+      svelte: ^3.54.0
       svelte-preprocess: ^4.10.7
       vite: ^4.0.0-beta.1
     dependencies:
@@ -339,8 +339,8 @@ importers:
     devDependencies:
       '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte
       sass: 1.56.1
-      svelte: 3.53.1
-      svelte-preprocess: 4.10.7_sass@1.56.1+svelte@3.53.1
+      svelte: 3.54.0
+      svelte-preprocess: 4.10.7_sass@1.56.1+svelte@3.54.0
       vite: 4.0.0-beta.1_sass@1.56.1
 
   packages/e2e-tests/preprocess-with-vite:
@@ -348,41 +348,41 @@ importers:
       '@sveltejs/vite-plugin-svelte': workspace:*
       sass: ^1.56.1
       stylus: ^0.59.0
-      svelte: ^3.53.1
+      svelte: ^3.54.0
       vite: ^4.0.0-beta.1
     devDependencies:
       '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte
       sass: 1.56.1
       stylus: 0.59.0
-      svelte: 3.53.1
+      svelte: 3.54.0
       vite: 4.0.0-beta.1_sass@1.56.1+stylus@0.59.0
 
   packages/e2e-tests/resolve-exports-svelte:
     specifiers:
       '@sveltejs/vite-plugin-svelte': workspace:*
       e2e-test-dep-svelte-exports-simple: file:../_test_dependencies/svelte-exports-simple
-      svelte: 3.53.1
+      svelte: ^3.54.0
       vite: ^4.0.0-beta.1
     dependencies:
       e2e-test-dep-svelte-exports-simple: file:packages/e2e-tests/_test_dependencies/svelte-exports-simple
     devDependencies:
       '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte
-      svelte: 3.53.1
+      svelte: 3.54.0
       vite: 4.0.0-beta.1
 
   packages/e2e-tests/svelte-preprocess:
     specifiers:
       '@sveltejs/vite-plugin-svelte': workspace:*
       sass: ^1.56.1
-      svelte: ^3.53.1
+      svelte: ^3.54.0
       svelte-preprocess: ^4.10.7
       typescript: ^4.9.3
       vite: ^4.0.0-beta.1
     devDependencies:
       '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte
       sass: 1.56.1
-      svelte: 3.53.1
-      svelte-preprocess: 4.10.7_xysbxxmdqcznjs3sfrwdyjxdzm
+      svelte: 3.54.0
+      svelte-preprocess: 4.10.7_readneprqrqhy7fhstbfazcfw4
       typescript: 4.9.3
       vite: 4.0.0-beta.1_sass@1.56.1
 
@@ -391,15 +391,15 @@ importers:
       '@sveltejs/vite-plugin-svelte': workspace:*
       '@tsconfig/svelte': ^3.0.0
       '@types/node': ^18.11.11
-      svelte: ^3.53.1
+      svelte: ^3.54.0
       svelte-preprocess: ^4.10.7
       vite: ^4.0.0-beta.1
     devDependencies:
       '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte
       '@tsconfig/svelte': 3.0.0
       '@types/node': 18.11.11
-      svelte: 3.53.1
-      svelte-preprocess: 4.10.7_svelte@3.53.1
+      svelte: 3.54.0
+      svelte-preprocess: 4.10.7_svelte@3.54.0
       vite: 4.0.0-beta.1_@types+node@18.11.11
 
   packages/e2e-tests/vite-ssr:
@@ -410,7 +410,7 @@ importers:
       e2e-test-dep-esm-only: file:../_test_dependencies/esm-only
       express: ^4.18.2
       serve-static: ^1.15.0
-      svelte: ^3.53.1
+      svelte: ^3.54.0
       vite: ^4.0.0-beta.1
     devDependencies:
       '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte
@@ -419,7 +419,7 @@ importers:
       e2e-test-dep-esm-only: file:packages/e2e-tests/_test_dependencies/esm-only
       express: 4.18.2
       serve-static: 1.15.0
-      svelte: 3.53.1
+      svelte: 3.54.0
       vite: 4.0.0-beta.1
 
   packages/e2e-tests/vite-ssr-esm:
@@ -432,7 +432,7 @@ importers:
       express: ^4.18.2
       npm-run-all: ^4.1.5
       serve-static: ^1.15.0
-      svelte: ^3.53.1
+      svelte: ^3.54.0
       vite: ^4.0.0-beta.1
     devDependencies:
       '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte
@@ -443,7 +443,7 @@ importers:
       express: 4.18.2
       npm-run-all: 4.1.5
       serve-static: 1.15.0
-      svelte: 3.53.1
+      svelte: 3.54.0
       vite: 4.0.0-beta.1
 
   packages/playground:
@@ -452,11 +452,11 @@ importers:
   packages/playground/big:
     specifiers:
       '@sveltejs/vite-plugin-svelte': workspace:*
-      svelte: ^3.53.1
+      svelte: ^3.54.0
       vite: ^4.0.0-beta.1
     devDependencies:
       '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte
-      svelte: 3.53.1
+      svelte: 3.54.0
       vite: 4.0.0-beta.1
 
   packages/playground/big-component-library:
@@ -466,7 +466,7 @@ importers:
       carbon-icons-svelte: ^11.4.0
       carbon-preprocess-svelte: ^0.9.1
       lodash-es: ^4.17.21
-      svelte: ^3.53.1
+      svelte: ^3.54.0
       svelte-preprocess: ^4.10.7
       vite: ^4.0.0-beta.1
     dependencies:
@@ -475,9 +475,9 @@ importers:
       '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte
       carbon-components-svelte: 0.70.12
       carbon-icons-svelte: 11.4.0
-      carbon-preprocess-svelte: 0.9.1_svelte@3.53.1
-      svelte: 3.53.1
-      svelte-preprocess: 4.10.7_svelte@3.53.1
+      carbon-preprocess-svelte: 0.9.1_svelte@3.54.0
+      svelte: 3.54.0
+      svelte-preprocess: 4.10.7_svelte@3.54.0
       vite: 4.0.0-beta.1
 
   packages/playground/big-component-library-kit:
@@ -488,21 +488,21 @@ importers:
       carbon-icons-svelte: ^11.4.0
       carbon-preprocess-svelte: ^0.9.1
       lodash-es: ^4.17.21
-      svelte: ^3.53.1
+      svelte: ^3.54.0
       svelte-check: ^2.10.1
       svelte-preprocess: ^4.10.7
       typescript: ^4.9.3
       vite: ^4.0.0-beta.1
     devDependencies:
       '@sveltejs/adapter-auto': 1.0.0-next.90
-      '@sveltejs/kit': 1.0.0-next.572_3ooora7siwcqeevktvnilli43e
+      '@sveltejs/kit': 1.0.0-next.572_owb2ncz5iz7yvythbmu4fo2zsq
       carbon-components-svelte: 0.70.12
       carbon-icons-svelte: 11.4.0
-      carbon-preprocess-svelte: 0.9.1_svelte@3.53.1
+      carbon-preprocess-svelte: 0.9.1_svelte@3.54.0
       lodash-es: 4.17.21
-      svelte: 3.53.1
-      svelte-check: 2.10.1_svelte@3.53.1
-      svelte-preprocess: 4.10.7_7dvewpees4iyn2tkw2qzal77a4
+      svelte: 3.54.0
+      svelte-check: 2.10.1_svelte@3.54.0
+      svelte-preprocess: 4.10.7_gf4dcx76vtk2o62ixxeqx7chra
       typescript: 4.9.3
       vite: 4.0.0-beta.1
 
@@ -517,7 +517,7 @@ importers:
       express: ^4.18.2
       lodash-es: ^4.17.21
       sirv: ^2.0.2
-      svelte: ^3.53.1
+      svelte: ^3.54.0
       svelte-preprocess: ^4.10.7
       vite: ^4.0.0-beta.1
     dependencies:
@@ -528,11 +528,11 @@ importers:
       '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte
       carbon-components-svelte: 0.70.12
       carbon-icons-svelte: 11.4.0
-      carbon-preprocess-svelte: 0.9.1_svelte@3.53.1
+      carbon-preprocess-svelte: 0.9.1_svelte@3.54.0
       cross-env: 7.0.3
       lodash-es: 4.17.21
-      svelte: 3.53.1
-      svelte-preprocess: 4.10.7_svelte@3.53.1
+      svelte: 3.54.0
+      svelte-preprocess: 4.10.7_svelte@3.54.0
       vite: 4.0.0-beta.1
 
   packages/playground/kit-demo-app:
@@ -542,7 +542,7 @@ importers:
       '@sveltejs/adapter-auto': ^1.0.0-next.90
       '@sveltejs/kit': ^1.0.0-next.572
       '@types/cookie': ^0.5.1
-      svelte: ^3.53.1
+      svelte: ^3.54.0
       svelte-check: ^2.10.1
       typescript: ^4.9.3
       vite: ^4.0.0-beta.1
@@ -550,22 +550,22 @@ importers:
       '@fontsource/fira-mono': 4.5.10
       '@neoconfetti/svelte': 1.0.0
       '@sveltejs/adapter-auto': 1.0.0-next.90
-      '@sveltejs/kit': 1.0.0-next.572_3ooora7siwcqeevktvnilli43e
+      '@sveltejs/kit': 1.0.0-next.572_owb2ncz5iz7yvythbmu4fo2zsq
       '@types/cookie': 0.5.1
-      svelte: 3.53.1
-      svelte-check: 2.10.1_svelte@3.53.1
+      svelte: 3.54.0
+      svelte-check: 2.10.1_svelte@3.54.0
       typescript: 4.9.3
       vite: 4.0.0-beta.1
 
   packages/playground/optimizedeps-include:
     specifiers:
       '@sveltejs/vite-plugin-svelte': workspace:*
-      svelte: ^3.53.1
+      svelte: ^3.54.0
       tinro: ^0.6.12
       vite: ^4.0.0-beta.1
     devDependencies:
       '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte
-      svelte: 3.53.1
+      svelte: 3.54.0
       tinro: 0.6.12
       vite: 4.0.0-beta.1
 
@@ -573,7 +573,7 @@ importers:
     specifiers:
       '@sveltejs/vite-plugin-svelte': workspace:*
       diff-match-patch: ^1.0.5
-      svelte: ^3.53.1
+      svelte: ^3.54.0
       vite: ^4.0.0-beta.1
       vite-plugin-windicss: ^1.8.8
       windicss: ^3.5.6
@@ -582,7 +582,7 @@ importers:
     devDependencies:
       '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte
       diff-match-patch: 1.0.5
-      svelte: 3.53.1
+      svelte: 3.54.0
       vite: 4.0.0-beta.1
       vite-plugin-windicss: 1.8.8_vite@4.0.0-beta.1
 
@@ -595,7 +595,7 @@ importers:
       kleur: ^4.1.5
       magic-string: ^0.27.0
       rollup: ^2.79.1
-      svelte: ^3.53.1
+      svelte: ^3.54.0
       svelte-hmr: ^0.15.1
       tsup: ^6.5.0
       vite: ^4.0.0-beta.1
@@ -605,13 +605,13 @@ importers:
       deepmerge: 4.2.2
       kleur: 4.1.5
       magic-string: 0.27.0
-      svelte-hmr: 0.15.1_svelte@3.53.1
+      svelte-hmr: 0.15.1_svelte@3.54.0
       vitefu: 0.2.2_vite@4.0.0-beta.1
     devDependencies:
       '@types/debug': 4.1.7
       esbuild: 0.16.1
       rollup: 2.79.1
-      svelte: 3.53.1
+      svelte: 3.54.0
       tsup: 6.5.0
       vite: 4.0.0-beta.1
 
@@ -1276,7 +1276,7 @@ packages:
       rollup: 2.79.1
     dev: true
 
-  /@sveltejs/kit/1.0.0-next.572_3ooora7siwcqeevktvnilli43e:
+  /@sveltejs/kit/1.0.0-next.572_owb2ncz5iz7yvythbmu4fo2zsq:
     resolution: {integrity: sha512-PiKEr55L/uJyMKvDPdyoa5MlAYQwdgs8HLMbr28YcCBmhw/v6V7gutKOKdqeXc3YwKEFVS3z7TvW6c7eDokJdQ==}
     engines: {node: '>=16.14'}
     hasBin: true
@@ -1295,7 +1295,7 @@ packages:
       sade: 1.8.1
       set-cookie-parser: 2.5.1
       sirv: 2.0.2
-      svelte: 3.53.1
+      svelte: 3.54.0
       tiny-glob: 0.2.9
       undici: 5.13.0
       vite: 4.0.0-beta.1
@@ -1873,11 +1873,11 @@ packages:
     resolution: {integrity: sha512-p/llZde2kP2BI9SOqM+QFKGfQnYrW+4dVxF1rAYriEADXDsjt9EYlh+KpQ5qf4JpXAq+e2+TB/r/lIG1xdUbAQ==}
     dev: true
 
-  /carbon-preprocess-svelte/0.9.1_svelte@3.53.1:
+  /carbon-preprocess-svelte/0.9.1_svelte@3.54.0:
     resolution: {integrity: sha512-i0hj5JrpSeu1F6q5Hehn4Qe3mpb1oXi57ybbsTF2TexFBGtzaBDQ3/mmXBKRNuk4PVQCtTIXQe4vk1A6Uyso6g==}
     dependencies:
       purgecss: 4.1.3
-      svelte-preprocess: 4.10.7_7dvewpees4iyn2tkw2qzal77a4
+      svelte-preprocess: 4.10.7_gf4dcx76vtk2o62ixxeqx7chra
       typescript: 4.9.3
     transitivePeerDependencies:
       - '@babel/core'
@@ -2756,14 +2756,14 @@ packages:
       prettier-linter-helpers: 1.0.0
     dev: true
 
-  /eslint-plugin-svelte3/4.0.0_kzv3boqmfymw5ol254gxmp75rq:
+  /eslint-plugin-svelte3/4.0.0_2aagxyyd66x6iymg5nfckajqjq:
     resolution: {integrity: sha512-OIx9lgaNzD02+MDFNLw0GEUbuovNcglg+wnd/UY0fbZmlQSz7GlQiQ1f+yX0XvC07XPcDOnFcichqI3xCwp71g==}
     peerDependencies:
       eslint: '>=8.0.0'
       svelte: ^3.2.0
     dependencies:
       eslint: 8.29.0
-      svelte: 3.53.1
+      svelte: 3.54.0
     dev: true
 
   /eslint-scope/5.1.1:
@@ -4545,14 +4545,14 @@ packages:
       fast-diff: 1.2.0
     dev: true
 
-  /prettier-plugin-svelte/2.8.1_3ndnxlh52lolrqe4kgjgbxb3xa:
+  /prettier-plugin-svelte/2.8.1_kaioqtfwjumrsfopsgfoca65re:
     resolution: {integrity: sha512-KA3K1J3/wKDnCxW7ZDRA/QL2Q67N7Xs3gOERqJ5X1qFjq1DdnN3K1R29scSKwh+kA8FF67pXbYytUpvN/i3iQw==}
     peerDependencies:
       prettier: ^1.16.4 || ^2.0.0
       svelte: ^3.2.0
     dependencies:
       prettier: 2.8.0
-      svelte: 3.53.1
+      svelte: 3.54.0
     dev: true
 
   /prettier/2.8.0:
@@ -5200,7 +5200,7 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  /svelte-check/2.10.1_svelte@3.53.1:
+  /svelte-check/2.10.1_svelte@3.54.0:
     resolution: {integrity: sha512-uscZovyuOPA89NuAkc4vO27mzx//2wFBNtwTsgYcNs7JwaFpJ2TqBawQ/avG7gkieYQ3QXqFUggJZ+s51fQGDQ==}
     hasBin: true
     peerDependencies:
@@ -5212,8 +5212,8 @@ packages:
       import-fresh: 3.3.0
       picocolors: 1.0.0
       sade: 1.8.1
-      svelte: 3.53.1
-      svelte-preprocess: 4.10.7_7dvewpees4iyn2tkw2qzal77a4
+      svelte: 3.54.0
+      svelte-preprocess: 4.10.7_gf4dcx76vtk2o62ixxeqx7chra
       typescript: 4.9.3
     transitivePeerDependencies:
       - '@babel/core'
@@ -5228,16 +5228,16 @@ packages:
       - sugarss
     dev: true
 
-  /svelte-hmr/0.15.1_svelte@3.53.1:
+  /svelte-hmr/0.15.1_svelte@3.54.0:
     resolution: {integrity: sha512-BiKB4RZ8YSwRKCNVdNxK/GfY+r4Kjgp9jCLEy0DuqAKfmQtpL38cQK3afdpjw4sqSs4PLi3jIPJIFp259NkZtA==}
     engines: {node: ^12.20 || ^14.13.1 || >= 16}
     peerDependencies:
       svelte: '>=3.19.0'
     dependencies:
-      svelte: 3.53.1
+      svelte: 3.54.0
     dev: false
 
-  /svelte-i18n/3.6.0_svelte@3.53.1:
+  /svelte-i18n/3.6.0_svelte@3.54.0:
     resolution: {integrity: sha512-qvvcMqHVCXJ5pHoQR5uGzWAW5vS3qB9mBq+W6veLZ6jkrzZGOziR+wyOUJsc59BupMh+Ae30qjOndFrRU6v5jA==}
     engines: {node: '>= 16'}
     hasBin: true
@@ -5249,11 +5249,11 @@ packages:
       estree-walker: 2.0.2
       intl-messageformat: 9.13.0
       sade: 1.8.1
-      svelte: 3.53.1
+      svelte: 3.54.0
       tiny-glob: 0.2.9
     dev: true
 
-  /svelte-preprocess/4.10.7_7dvewpees4iyn2tkw2qzal77a4:
+  /svelte-preprocess/4.10.7_gf4dcx76vtk2o62ixxeqx7chra:
     resolution: {integrity: sha512-sNPBnqYD6FnmdBrUmBCaqS00RyCsCpj2BG58A1JBswNF7b0OKviwxqVrOL/CKyJrLSClrSeqQv5BXNg2RUbPOw==}
     engines: {node: '>= 9.11.2'}
     requiresBuild: true
@@ -5300,11 +5300,164 @@ packages:
       magic-string: 0.25.9
       sorcery: 0.10.0
       strip-indent: 3.0.0
-      svelte: 3.53.1
+      svelte: 3.54.0
       typescript: 4.9.3
     dev: true
 
-  /svelte-preprocess/4.10.7_g7z2chviobwh5b53nr2x4mtdq4:
+  /svelte-preprocess/4.10.7_readneprqrqhy7fhstbfazcfw4:
+    resolution: {integrity: sha512-sNPBnqYD6FnmdBrUmBCaqS00RyCsCpj2BG58A1JBswNF7b0OKviwxqVrOL/CKyJrLSClrSeqQv5BXNg2RUbPOw==}
+    engines: {node: '>= 9.11.2'}
+    requiresBuild: true
+    peerDependencies:
+      '@babel/core': ^7.10.2
+      coffeescript: ^2.5.1
+      less: ^3.11.3 || ^4.0.0
+      node-sass: '*'
+      postcss: ^7 || ^8
+      postcss-load-config: ^2.1.0 || ^3.0.0 || ^4.0.0
+      pug: ^3.0.0
+      sass: ^1.26.8
+      stylus: ^0.55.0 || ^0.58.0
+      sugarss: ^2.0.0
+      svelte: ^3.23.0
+      typescript: ^3.9.5 || ^4.0.0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      coffeescript:
+        optional: true
+      less:
+        optional: true
+      node-sass:
+        optional: true
+      postcss:
+        optional: true
+      postcss-load-config:
+        optional: true
+      pug:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      '@types/pug': 2.0.6
+      '@types/sass': 1.43.1
+      detect-indent: 6.1.0
+      magic-string: 0.25.9
+      sass: 1.56.1
+      sorcery: 0.10.0
+      strip-indent: 3.0.0
+      svelte: 3.54.0
+      typescript: 4.9.3
+    dev: true
+
+  /svelte-preprocess/4.10.7_sass@1.56.1+svelte@3.54.0:
+    resolution: {integrity: sha512-sNPBnqYD6FnmdBrUmBCaqS00RyCsCpj2BG58A1JBswNF7b0OKviwxqVrOL/CKyJrLSClrSeqQv5BXNg2RUbPOw==}
+    engines: {node: '>= 9.11.2'}
+    requiresBuild: true
+    peerDependencies:
+      '@babel/core': ^7.10.2
+      coffeescript: ^2.5.1
+      less: ^3.11.3 || ^4.0.0
+      node-sass: '*'
+      postcss: ^7 || ^8
+      postcss-load-config: ^2.1.0 || ^3.0.0 || ^4.0.0
+      pug: ^3.0.0
+      sass: ^1.26.8
+      stylus: ^0.55.0 || ^0.58.0
+      sugarss: ^2.0.0
+      svelte: ^3.23.0
+      typescript: ^3.9.5 || ^4.0.0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      coffeescript:
+        optional: true
+      less:
+        optional: true
+      node-sass:
+        optional: true
+      postcss:
+        optional: true
+      postcss-load-config:
+        optional: true
+      pug:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      '@types/pug': 2.0.6
+      '@types/sass': 1.43.1
+      detect-indent: 6.1.0
+      magic-string: 0.25.9
+      sass: 1.56.1
+      sorcery: 0.10.0
+      strip-indent: 3.0.0
+      svelte: 3.54.0
+    dev: true
+
+  /svelte-preprocess/4.10.7_svelte@3.54.0:
+    resolution: {integrity: sha512-sNPBnqYD6FnmdBrUmBCaqS00RyCsCpj2BG58A1JBswNF7b0OKviwxqVrOL/CKyJrLSClrSeqQv5BXNg2RUbPOw==}
+    engines: {node: '>= 9.11.2'}
+    requiresBuild: true
+    peerDependencies:
+      '@babel/core': ^7.10.2
+      coffeescript: ^2.5.1
+      less: ^3.11.3 || ^4.0.0
+      node-sass: '*'
+      postcss: ^7 || ^8
+      postcss-load-config: ^2.1.0 || ^3.0.0 || ^4.0.0
+      pug: ^3.0.0
+      sass: ^1.26.8
+      stylus: ^0.55.0 || ^0.58.0
+      sugarss: ^2.0.0
+      svelte: ^3.23.0
+      typescript: ^3.9.5 || ^4.0.0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      coffeescript:
+        optional: true
+      less:
+        optional: true
+      node-sass:
+        optional: true
+      postcss:
+        optional: true
+      postcss-load-config:
+        optional: true
+      pug:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      '@types/pug': 2.0.6
+      '@types/sass': 1.43.1
+      detect-indent: 6.1.0
+      magic-string: 0.25.9
+      sorcery: 0.10.0
+      strip-indent: 3.0.0
+      svelte: 3.54.0
+    dev: true
+
+  /svelte-preprocess/4.10.7_v4f7ozfe3bsi7lgm4qy7utpt3q:
     resolution: {integrity: sha512-sNPBnqYD6FnmdBrUmBCaqS00RyCsCpj2BG58A1JBswNF7b0OKviwxqVrOL/CKyJrLSClrSeqQv5BXNg2RUbPOw==}
     engines: {node: '>= 9.11.2'}
     requiresBuild: true
@@ -5353,164 +5506,11 @@ packages:
       postcss-load-config: 4.0.1_postcss@8.4.19
       sorcery: 0.10.0
       strip-indent: 3.0.0
-      svelte: 3.53.1
+      svelte: 3.54.0
     dev: true
 
-  /svelte-preprocess/4.10.7_sass@1.56.1+svelte@3.53.1:
-    resolution: {integrity: sha512-sNPBnqYD6FnmdBrUmBCaqS00RyCsCpj2BG58A1JBswNF7b0OKviwxqVrOL/CKyJrLSClrSeqQv5BXNg2RUbPOw==}
-    engines: {node: '>= 9.11.2'}
-    requiresBuild: true
-    peerDependencies:
-      '@babel/core': ^7.10.2
-      coffeescript: ^2.5.1
-      less: ^3.11.3 || ^4.0.0
-      node-sass: '*'
-      postcss: ^7 || ^8
-      postcss-load-config: ^2.1.0 || ^3.0.0 || ^4.0.0
-      pug: ^3.0.0
-      sass: ^1.26.8
-      stylus: ^0.55.0 || ^0.58.0
-      sugarss: ^2.0.0
-      svelte: ^3.23.0
-      typescript: ^3.9.5 || ^4.0.0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      coffeescript:
-        optional: true
-      less:
-        optional: true
-      node-sass:
-        optional: true
-      postcss:
-        optional: true
-      postcss-load-config:
-        optional: true
-      pug:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      '@types/pug': 2.0.6
-      '@types/sass': 1.43.1
-      detect-indent: 6.1.0
-      magic-string: 0.25.9
-      sass: 1.56.1
-      sorcery: 0.10.0
-      strip-indent: 3.0.0
-      svelte: 3.53.1
-    dev: true
-
-  /svelte-preprocess/4.10.7_svelte@3.53.1:
-    resolution: {integrity: sha512-sNPBnqYD6FnmdBrUmBCaqS00RyCsCpj2BG58A1JBswNF7b0OKviwxqVrOL/CKyJrLSClrSeqQv5BXNg2RUbPOw==}
-    engines: {node: '>= 9.11.2'}
-    requiresBuild: true
-    peerDependencies:
-      '@babel/core': ^7.10.2
-      coffeescript: ^2.5.1
-      less: ^3.11.3 || ^4.0.0
-      node-sass: '*'
-      postcss: ^7 || ^8
-      postcss-load-config: ^2.1.0 || ^3.0.0 || ^4.0.0
-      pug: ^3.0.0
-      sass: ^1.26.8
-      stylus: ^0.55.0 || ^0.58.0
-      sugarss: ^2.0.0
-      svelte: ^3.23.0
-      typescript: ^3.9.5 || ^4.0.0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      coffeescript:
-        optional: true
-      less:
-        optional: true
-      node-sass:
-        optional: true
-      postcss:
-        optional: true
-      postcss-load-config:
-        optional: true
-      pug:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      '@types/pug': 2.0.6
-      '@types/sass': 1.43.1
-      detect-indent: 6.1.0
-      magic-string: 0.25.9
-      sorcery: 0.10.0
-      strip-indent: 3.0.0
-      svelte: 3.53.1
-    dev: true
-
-  /svelte-preprocess/4.10.7_xysbxxmdqcznjs3sfrwdyjxdzm:
-    resolution: {integrity: sha512-sNPBnqYD6FnmdBrUmBCaqS00RyCsCpj2BG58A1JBswNF7b0OKviwxqVrOL/CKyJrLSClrSeqQv5BXNg2RUbPOw==}
-    engines: {node: '>= 9.11.2'}
-    requiresBuild: true
-    peerDependencies:
-      '@babel/core': ^7.10.2
-      coffeescript: ^2.5.1
-      less: ^3.11.3 || ^4.0.0
-      node-sass: '*'
-      postcss: ^7 || ^8
-      postcss-load-config: ^2.1.0 || ^3.0.0 || ^4.0.0
-      pug: ^3.0.0
-      sass: ^1.26.8
-      stylus: ^0.55.0 || ^0.58.0
-      sugarss: ^2.0.0
-      svelte: ^3.23.0
-      typescript: ^3.9.5 || ^4.0.0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      coffeescript:
-        optional: true
-      less:
-        optional: true
-      node-sass:
-        optional: true
-      postcss:
-        optional: true
-      postcss-load-config:
-        optional: true
-      pug:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      '@types/pug': 2.0.6
-      '@types/sass': 1.43.1
-      detect-indent: 6.1.0
-      magic-string: 0.25.9
-      sass: 1.56.1
-      sorcery: 0.10.0
-      strip-indent: 3.0.0
-      svelte: 3.53.1
-      typescript: 4.9.3
-    dev: true
-
-  /svelte/3.53.1:
-    resolution: {integrity: sha512-Q4/hHkktZogGhN5iqxqSi9sjEVoe/NbIxX4hXEHoasTxj+TxEQVAq66LnDMdAZxjmsodkoI5F3slqsS68U7FNw==}
+  /svelte/3.54.0:
+    resolution: {integrity: sha512-tdrgeJU0hob0ZWAMoKXkhcxXA7dpTg6lZGxUeko5YqvPdJBiyRspGsCwV27kIrbrqPP2WUoSV9ca0gnLlw8YzQ==}
     engines: {node: '>= 8'}
 
   /term-size/2.2.1:
@@ -6270,7 +6270,7 @@ packages:
     name: e2e-test-dep-svelte-api-only
     version: 1.0.0
     dependencies:
-      svelte: 3.53.1
+      svelte: 3.54.0
 
   file:packages/e2e-tests/_test_dependencies/svelte-exports-simple:
     resolution: {directory: packages/e2e-tests/_test_dependencies/svelte-exports-simple, type: directory}


### PR DESCRIPTION
3.53 introduced new compilerOptions.css string values that are an improvement over boolean before and 3.54 fixed a security issue.

We are able to simplify our code and get users to update their svelte dependency
