### PR TITLE
fix: bump vitefu

### DIFF
--- a/.changeset/chilly-maps-talk.md
+++ b/.changeset/chilly-maps-talk.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+update minimum version of vitefu dependency to avoid peer mismatch

--- a/packages/vite-plugin-svelte/package.json
+++ b/packages/vite-plugin-svelte/package.json
@@ -47,7 +47,7 @@
     "kleur": "^4.1.5",
     "magic-string": "^0.27.0",
     "svelte-hmr": "^0.15.1",
-    "vitefu": "^0.2.2"
+    "vitefu": "^0.2.3"
   },
   "peerDependencies": {
     "svelte": "^3.54.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -599,14 +599,14 @@ importers:
       svelte-hmr: ^0.15.1
       tsup: ^6.5.0
       vite: ^4.0.0
-      vitefu: ^0.2.2
+      vitefu: ^0.2.3
     dependencies:
       debug: 4.3.4
       deepmerge: 4.2.2
       kleur: 4.1.5
       magic-string: 0.27.0
       svelte-hmr: 0.15.1_svelte@3.54.0
-      vitefu: 0.2.2_vite@4.0.0
+      vitefu: 0.2.3_vite@4.0.0
     devDependencies:
       '@types/debug': 4.1.7
       esbuild: 0.16.3
@@ -1356,8 +1356,8 @@ packages:
   /@types/node/18.11.11:
     resolution: {integrity: sha512-KJ021B1nlQUBLopzZmPBVuGU9un7WJd/W4ya7Ih02B4Uwky5Nja0yGYav2EfYIk0RR2Q9oVhf60S2XR1BCWJ2g==}
 
-  /@types/node/18.11.12:
-    resolution: {integrity: sha512-FgD3NtTAKvyMmD44T07zz2fEf+OKwutgBCEVM8GcvMGVGaDktiLNTDvPwC/LUe3PinMW+X6CuLOF2Ui1mAlSXg==}
+  /@types/node/18.11.13:
+    resolution: {integrity: sha512-IASpMGVcWpUsx5xBOrxMj7Bl8lqfuTY7FKAnPmu5cHkfQVWF8GulWS1jbRqA934qZL35xh5xN/+Xe/i26Bod4w==}
 
   /@types/node/18.11.9:
     resolution: {integrity: sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==}
@@ -1378,7 +1378,7 @@ packages:
   /@types/sass/1.43.1:
     resolution: {integrity: sha512-BPdoIt1lfJ6B7rw35ncdwBZrAssjcwzI5LByIrYs+tpXlj/CAkuVdRsgZDdP4lq5EjyWzwxZCqAoFyHKFwp32g==}
     dependencies:
-      '@types/node': 18.11.12
+      '@types/node': 18.11.13
     dev: true
 
   /@types/semver/6.2.3:
@@ -6000,8 +6000,8 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /vitefu/0.2.2_vite@4.0.0:
-    resolution: {integrity: sha512-8CKEIWPm4B4DUDN+h+hVJa9pyNi7rzc5MYmbxhs1wcMakueGFNWB5/DL30USm9qU3xUPnL4/rrLEAwwFiD1tag==}
+  /vitefu/0.2.3_vite@4.0.0:
+    resolution: {integrity: sha512-75l7TTuU8isAhz1QFtNKjDkqjxvndfMC1AfIMjJ0ZQ59ZD0Ow9QOIsJJX16Wv9PS8f+zMzp6fHy5cCbKG/yVUQ==}
     peerDependencies:
       vite: ^3.0.0 || ^4.0.0
     peerDependenciesMeta:
@@ -6289,7 +6289,7 @@ packages:
     version: 1.0.0
     hasBin: true
     dependencies:
-      '@types/node': 18.11.12
+      '@types/node': 18.11.13
       e2e-test-dep-cjs-only: file:packages/e2e-tests/_test_dependencies/cjs-only
     dev: false
 


### PR DESCRIPTION
vitefu 0.2.2 still peers with vite 3, and some package managers don't auto-update leading to peer dependency warnings.
bump to 0.2.3 so their hand is forced