### PR TITLE
Fixes: Inspector doesn't work with firefox on Linux because of 'meta-shift' as default for all platforms but Windows

### DIFF
--- a/.changeset/gorgeous-peas-mix.md
+++ b/.changeset/gorgeous-peas-mix.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': minor
+---
+
+makes 'meta-shift' the exceptin for the mac - fixes the problem on Linux / firefox etc.

--- a/docs/config.md
+++ b/docs/config.md
@@ -286,7 +286,7 @@ export default {
   interface InspectorOptions {
     /**
      * define a key combo to toggle inspector,
-     * @default 'control-shift' on windows, 'meta-shift' on other os
+     * @default 'meta-shift' on mac, 'control-shift' on other os
      *
      * any number of modifiers `control` `shift` `alt` `meta` followed by zero or one regular key, separated by -
      * examples: control-shift, control-o, control-alt-s  meta-x control-meta

--- a/packages/vite-plugin-svelte/src/ui/inspector/plugin.ts
+++ b/packages/vite-plugin-svelte/src/ui/inspector/plugin.ts
@@ -7,10 +7,10 @@ import fs from 'fs';
 import { idToFile } from './utils';
 
 const defaultInspectorOptions: InspectorOptions = {
-	toggleKeyCombo: process.platform === 'win32' ? 'control-shift' : 'meta-shift',
+	toggleKeyCombo: ['linux', 'win32'].includes(process.platform) ? 'control-shift' : 'meta-shift',
 	navKeys: { parent: 'ArrowUp', child: 'ArrowDown', next: 'ArrowRight', prev: 'ArrowLeft' },
 	openKey: 'Enter',
-	holdMode: false,
+	holdMode: process.platform === 'linux',
 	showToggleButton: 'active',
 	toggleButtonPos: 'top-right',
 	customStyles: true

--- a/packages/vite-plugin-svelte/src/ui/inspector/plugin.ts
+++ b/packages/vite-plugin-svelte/src/ui/inspector/plugin.ts
@@ -7,10 +7,10 @@ import fs from 'fs';
 import { idToFile } from './utils';
 
 const defaultInspectorOptions: InspectorOptions = {
-	toggleKeyCombo: ['linux', 'win32'].includes(process.platform) ? 'control-shift' : 'meta-shift',
+	toggleKeyCombo: process.platform === 'darwin' ? 'meta-shift' : 'control-shift',
 	navKeys: { parent: 'ArrowUp', child: 'ArrowDown', next: 'ArrowRight', prev: 'ArrowLeft' },
 	openKey: 'Enter',
-	holdMode: process.platform === 'linux',
+	holdMode: false,
 	showToggleButton: 'active',
 	toggleButtonPos: 'top-right',
 	customStyles: true

--- a/packages/vite-plugin-svelte/src/utils/options.ts
+++ b/packages/vite-plugin-svelte/src/utils/options.ts
@@ -727,7 +727,7 @@ export interface ExperimentalOptions {
 export interface InspectorOptions {
 	/**
 	 * define a key combo to toggle inspector,
-	 * @default 'control-shift' on windows, 'meta-shift' on other os
+	 * @default 'meta-shift' on mac, 'control-shift' on other os
 	 *
 	 * any number of modifiers `control` `shift` `alt` `meta` followed by zero or one regular key, separated by -
 	 * examples: control-shift, control-o, control-alt-s  meta-x control-meta


### PR DESCRIPTION
The 'meta-shift' shortcut won't work on firefox when used on linux. Also in KDE the shortcut is preset to draw mouse trails on the screen. Switching to control-shift on linux but is a little tricke to work with, because of the way it handles the click to activate the browser window again.

Having tried all sort of options/combinations it seems the best working for all browsers
is the combination of "control-shift" and holdMode: true

_**I'm stil wondering**_  if instead of checking
['linux', 'win32'].includes(process.platform) ? 'control-shift' : 'meta-shift',

it would make more sense to check just for mac by doing a 

process.platform === 'darvin' ? 'meta-shift' : 'control-shift',

for sure it is cumbersome having to change the options in svelte.config.js manually every time when switching the platform (mac <-> linux)

Discussed some on:
https://discord.com/channels/457912077277855764/1052953876724207676

Note: The preset of meta-shift can be deactivated in systemsettings of KDE but firefox still won't work with it.