### PR TITLE
feat(inspector): make holdMode the new default

### DIFF
--- a/.changeset/lazy-peas-accept.md
+++ b/.changeset/lazy-peas-accept.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': minor
+---
+
+Makes "holdMode: true" the new default for the inspector plugin

--- a/docs/config.md
+++ b/docs/config.md
@@ -318,7 +318,7 @@ export default {
 
     /**
      * inspector is automatically disabled when releasing toggleKeyCombo after holding it for a longpress
-     * @default false
+     * @default true
      */
     holdMode?: boolean;
 

--- a/packages/vite-plugin-svelte/src/ui/inspector/plugin.ts
+++ b/packages/vite-plugin-svelte/src/ui/inspector/plugin.ts
@@ -10,7 +10,7 @@ const defaultInspectorOptions: InspectorOptions = {
 	toggleKeyCombo: process.platform === 'win32' ? 'control-shift' : 'meta-shift',
 	navKeys: { parent: 'ArrowUp', child: 'ArrowDown', next: 'ArrowRight', prev: 'ArrowLeft' },
 	openKey: 'Enter',
-	holdMode: false,
+	holdMode: true,
 	showToggleButton: 'active',
 	toggleButtonPos: 'top-right',
 	customStyles: true

--- a/packages/vite-plugin-svelte/src/utils/options.ts
+++ b/packages/vite-plugin-svelte/src/utils/options.ts
@@ -764,7 +764,7 @@ export interface InspectorOptions {
 
 	/**
 	 * inspector is automatically disabled when releasing toggleKeyCombo after holding it for a longpress
-	 * @default false
+	 * @default true
 	 */
 	holdMode?: boolean;
 	/**


### PR DESCRIPTION
According to the discussion on, let's try holdMode as the new default as long as the plugin is experimental

https://discord.com/channels/457912077277855764/1053296007246516314