### PR TITLE
fix: Don't use PostCSS config file when preprocessing other languages

### DIFF
--- a/packages/vite-plugin-svelte/src/preprocess.ts
+++ b/packages/vite-plugin-svelte/src/preprocess.ts
@@ -67,6 +67,17 @@ function viteStyle(config: InlineConfig | ResolvedConfig = {}): {
 					process.env.NODE_ENV === 'production' ? 'build' : 'serve'
 				);
 			}
+			if (lang !== 'postcss') {
+				resolvedConfig = {
+					...resolvedConfig,
+					css: {
+						...(resolvedConfig.css ?? {}),
+						postcss: {
+							plugins: [{ postcssPlugin: 'vitePreprocess' }]
+						}
+					}
+				};
+			}
 			transform = getCssTransformFn(resolvedConfig);
 		}
 		const moduleId = `${filename}.${lang}`;


### PR DESCRIPTION
When the **lang** attribute of the **style** block isn't **postcss**, that means another preprocessor is wanted for the preprocessing, like sass for example `<style lang="scss">`

But when a postcss config is found the `preprocessCSS()` from vite will load and apply PostCSS as well, which leads to bugs/warnings  #578

This PR adds an inline postcss config to prevent loading the postcss config.
It also contains one dummy postcss plugin, this triggers the code inside vite to fix the sourcemapping, preventing

`Sourcemap for "path/to/file.svelte" points to missing source files` warnings