### PR TITLE
chore: update cjs vite config to esm

### DIFF
--- a/packages/playground/big/package.json
+++ b/packages/playground/big/package.json
@@ -2,6 +2,7 @@
   "name": "playground-big",
   "private": true,
   "version": "0.0.0",
+  "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/packages/playground/big/vite.config.js
+++ b/packages/playground/big/vite.config.js
@@ -1,12 +1,6 @@
-const { svelte } = require('@sveltejs/vite-plugin-svelte');
-const { defineConfig } = require('vite');
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+import { defineConfig } from 'vite';
 
-module.exports = defineConfig(({ command, mode }) => {
-	const isProduction = mode === 'production';
-	return {
-		plugins: [svelte()],
-		build: {
-			minify: isProduction
-		}
-	};
+export default defineConfig({
+	plugins: [svelte()]
 });

--- a/packages/playground/windicss/package.json
+++ b/packages/playground/windicss/package.json
@@ -2,6 +2,7 @@
   "name": "playground-windicss",
   "private": true,
   "version": "0.0.0",
+  "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/packages/playground/windicss/vite.config.js
+++ b/packages/playground/windicss/vite.config.js
@@ -1,16 +1,10 @@
-const { svelte } = require('@sveltejs/vite-plugin-svelte');
-const { defineConfig } = require('vite');
-const vitePluginWindicss = require('vite-plugin-windicss').default;
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+import { defineConfig } from 'vite';
+import vitePluginWindicss from 'vite-plugin-windicss';
 
-module.exports = defineConfig(({ command, mode }) => {
-	const isProduction = mode === 'production';
-	return {
-		plugins: [
-			svelte({ experimental: { generateMissingPreprocessorSourcemaps: true } }),
-			vitePluginWindicss()
-		],
-		build: {
-			minify: isProduction
-		}
-	};
+export default defineConfig({
+	plugins: [
+		svelte({ experimental: { generateMissingPreprocessorSourcemaps: true } }),
+		vitePluginWindicss()
+	]
 });


### PR DESCRIPTION
Convert `vite.config.js` to ESM so they can be run.