### PR TITLE
refactor: use generic namespace for logging instead of hardcoded stats

### DIFF
--- a/packages/vite-plugin-svelte/src/utils/log.ts
+++ b/packages/vite-plugin-svelte/src/utils/log.ts
@@ -3,15 +3,11 @@ import { cyan, yellow, red } from 'kleur/colors';
 import debug from 'debug';
 import { ResolvedOptions, Warning } from './options';
 import { SvelteRequest } from './id';
-
 const levels: string[] = ['debug', 'info', 'warn', 'error', 'silent'];
 const prefix = 'vite-plugin-svelte';
 const loggers: { [key: string]: any } = {
 	debug: {
-		log: {
-			default: debug(`vite:${prefix}`),
-			stats: debug(`vite:${prefix}:stats`)
-		},
+		log: debug(`vite:${prefix}`),
 		enabled: false,
 		isDebug: true
 	},
@@ -56,10 +52,16 @@ function _log(logger: any, message: string, payload?: any, namespace?: string) {
 		return;
 	}
 	if (logger.isDebug) {
-		const log = logger.log[namespace || 'default'];
+		const log = namespace ? logger.log.extend(namespace) : logger.log;
 		payload !== undefined ? log(message, payload) : log(message);
 	} else {
-		logger.log(logger.color(`${new Date().toLocaleTimeString()} [${prefix}] ${message}`));
+		logger.log(
+			logger.color(
+				`${new Date().toLocaleTimeString()} [${prefix}${
+					namespace ? `:${namespace}` : ''
+				}] ${message}`
+			)
+		);
 		if (payload) {
 			logger.log(payload);
 		}
@@ -212,4 +214,8 @@ export function buildExtendedLogMessage(w: Warning) {
 		parts.push(w.message);
 	}
 	return parts.join('');
+}
+
+export function isDebugNamespaceEnabled(namespace: string) {
+	return debug.enabled(`vite:${prefix}:${namespace}`);
 }

--- a/packages/vite-plugin-svelte/src/utils/options.ts
+++ b/packages/vite-plugin-svelte/src/utils/options.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-vars */
 import { ConfigEnv, ResolvedConfig, UserConfig, ViteDevServer, normalizePath } from 'vite';
-import { log } from './log';
+import { isDebugNamespaceEnabled, log } from './log';
 import { loadSvelteConfig } from './load-svelte-config';
 import {
 	SVELTE_EXPORT_CONDITIONS,
@@ -206,7 +206,7 @@ export function resolveOptions(
 	enforceOptionsForHmr(merged);
 	enforceOptionsForProduction(merged);
 	// mergeConfigs would mangle functions on the stats class, so do this afterwards
-	if (log.debug.enabled) {
+	if (log.debug.enabled && isDebugNamespaceEnabled('stats')) {
 		merged.stats = new VitePluginSvelteStats();
 	}
 	return merged;


### PR DESCRIPTION
more generic version for namespaced log/debug, including an improved check if the stats namespace has been enabled by the user