### PR TITLE
fix imports `"moduleResolution": "nodenext"`

### DIFF
--- a/packages/vite-plugin-svelte/src/utils/id.ts
+++ b/packages/vite-plugin-svelte/src/utils/id.ts
@@ -4,7 +4,7 @@ import { Arrayable, ResolvedOptions } from './options';
 import { normalizePath } from 'vite';
 import * as fs from 'fs';
 //eslint-disable-next-line node/no-missing-import
-import { CompileOptions } from 'svelte/types/compiler/interfaces';
+import { CompileOptions } from 'svelte/compiler';
 import { log } from './log';
 
 const VITE_FS_PREFIX = '/@fs/';

--- a/packages/vite-plugin-svelte/src/utils/options.ts
+++ b/packages/vite-plugin-svelte/src/utils/options.ts
@@ -9,15 +9,14 @@ import {
 	SVELTE_RESOLVE_MAIN_FIELDS,
 	VITE_RESOLVE_MAIN_FIELDS
 } from './constants';
-// eslint-disable-next-line node/no-missing-import
-import type { CompileOptions, Warning } from 'svelte/types/compiler/interfaces';
 import type {
+	CompileOptions,
 	MarkupPreprocessor,
 	Preprocessor,
 	PreprocessorGroup,
 	Processed
 	// eslint-disable-next-line node/no-missing-import
-} from 'svelte/types/compiler/preprocess';
+} from 'svelte/compiler';
 
 import path from 'path';
 import { esbuildSveltePlugin, facadeEsbuildSveltePluginName } from './esbuild';

--- a/packages/vite-plugin-svelte/tsconfig.json
+++ b/packages/vite-plugin-svelte/tsconfig.json
@@ -5,7 +5,7 @@
     "outDir": "dist",
     "target": "ES2020",
     "module": "ES2020",
-    "moduleResolution": "node",
+    "moduleResolution": "nodenext",
     "strict": true,
     "declaration": true,
     "sourceMap": true,

--- a/packages/vite-plugin-svelte/tsconfig.json
+++ b/packages/vite-plugin-svelte/tsconfig.json
@@ -5,7 +5,7 @@
     "outDir": "dist",
     "target": "ES2020",
     "module": "ES2020",
-    "moduleResolution": "nodenext",
+    "moduleResolution": "bundler",
     "strict": true,
     "declaration": true,
     "sourceMap": true,


### PR DESCRIPTION
fixes #619 

this doesn't really work though because svelte doesn't expose all of these types in its `package.json` `exports`. are they intended to be imported by downstream projects like this one? if so, i can make a PR on https://github.com/sveltejs/svelte exposing them