### PR TITLE
fix: Sourcemap for "/path/to/Component.svelte" points to missing source files

### DIFF
--- a/.changeset/real-jokes-help.md
+++ b/.changeset/real-jokes-help.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+fixed Sourcemap for "Component.svelte" points to missing source files

--- a/packages/e2e-tests/css-dev-sourcemap/__tests__/__snapshots__/css-dev-sourcemap.spec.ts.snap
+++ b/packages/e2e-tests/css-dev-sourcemap/__tests__/__snapshots__/css-dev-sourcemap.spec.ts.snap
@@ -1,0 +1,6 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`should generate sourcemap 1`] = `
+"#test.s-XsEmFtvddWTw{color:red}.s-XsEmFtvddWTw{}
+/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiQXBwLnN2ZWx0ZSIsIm1hcHBpbmdzIjoiQUFJRSxvQkFBQSxDQUNDLEtBQUEsQ0FBQSIsIm5hbWVzIjpbXSwic291cmNlcyI6WyJBcHAuc3ZlbHRlIl0sInNvdXJjZXNDb250ZW50IjpbIjxkaXYgaWQ9XCJ0ZXN0XCI+cmVkPC9kaXY+XG5cbjxzdHlsZSBsYW5nPVwic2Nzc1wiPlxuXHQjdGVzdCB7XG5cdFx0JiB7XG5cdFx0XHRjb2xvcjogcmVkO1xuXHRcdH1cblx0fVxuPC9zdHlsZT5cbiJdfQ== */"
+`;

--- a/packages/e2e-tests/css-dev-sourcemap/__tests__/css-dev-sourcemap.spec.ts
+++ b/packages/e2e-tests/css-dev-sourcemap/__tests__/css-dev-sourcemap.spec.ts
@@ -1,0 +1,18 @@
+import { browserLogs, getColor, getText, isBuild } from '~utils';
+
+test('should not have failed requests', async () => {
+	browserLogs.forEach((msg) => {
+		expect(msg).not.toMatch('404');
+	});
+});
+
+test('should apply css compiled from scss', async () => {
+	expect(await getText('#test')).toBe('red');
+	expect(await getColor('#test')).toBe('red');
+});
+
+if (!isBuild) {
+	test('should generate sourcemap', async () => {
+		expect(await getText('style')).toMatchSnapshot();
+	});
+}

--- a/packages/e2e-tests/css-dev-sourcemap/index.html
+++ b/packages/e2e-tests/css-dev-sourcemap/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
+
+		<title>Svelte app</title>
+
+		<script type="module" src="/src/main.js"></script>
+	</head>
+
+	<body></body>
+</html>

--- a/packages/e2e-tests/css-dev-sourcemap/package.json
+++ b/packages/e2e-tests/css-dev-sourcemap/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "e2e-tests-css-dev-sourcemap",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "@sveltejs/vite-plugin-svelte": "workspace:^",
+    "svelte": "^3.58.0",
+    "vite": "^4.2.1",
+    "sass": "^1.61.0"
+  }
+}

--- a/packages/e2e-tests/css-dev-sourcemap/src/App.svelte
+++ b/packages/e2e-tests/css-dev-sourcemap/src/App.svelte
@@ -1,0 +1,9 @@
+<div id="test">red</div>
+
+<style lang="scss">
+	#test {
+		& {
+			color: red;
+		}
+	}
+</style>

--- a/packages/e2e-tests/css-dev-sourcemap/src/main.js
+++ b/packages/e2e-tests/css-dev-sourcemap/src/main.js
@@ -1,0 +1,7 @@
+import App from './App.svelte';
+
+const app = new App({
+	target: document.body
+});
+
+export default app;

--- a/packages/e2e-tests/css-dev-sourcemap/src/vite-env.d.ts
+++ b/packages/e2e-tests/css-dev-sourcemap/src/vite-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="svelte" />
+/// <reference types="vite/client" />

--- a/packages/e2e-tests/css-dev-sourcemap/svelte.config.js
+++ b/packages/e2e-tests/css-dev-sourcemap/svelte.config.js
@@ -1,0 +1,5 @@
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+
+export default {
+	preprocess: [vitePreprocess()]
+};

--- a/packages/e2e-tests/css-dev-sourcemap/vite.config.js
+++ b/packages/e2e-tests/css-dev-sourcemap/vite.config.js
@@ -1,0 +1,8 @@
+import { build, defineConfig } from 'vite';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+	plugins: [svelte({})],
+	css: { devSourcemap: true }
+});

--- a/packages/vite-plugin-svelte/src/preprocess.ts
+++ b/packages/vite-plugin-svelte/src/preprocess.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import { preprocessCSS, resolveConfig, transformWithEsbuild } from 'vite';
 import type { ESBuildOptions, InlineConfig, ResolvedConfig } from 'vite';
 // eslint-disable-next-line node/no-missing-import
@@ -74,9 +75,19 @@ function viteStyle(config: InlineConfig | ResolvedConfig = {}): {
 		}
 		const moduleId = `${filename}.${lang}`;
 		const { code, map } = await transform(content, moduleId);
-
 		mapSourcesToRelative(map, moduleId);
-
+		const baseModuleId = path.basename(moduleId);
+		const baseFilename = path.basename(filename);
+		if (map?.file === moduleId) {
+			map.file = filename;
+		} else if (map?.file === baseModuleId) {
+			map.file = baseFilename;
+		}
+		if (map?.sources?.map) {
+			map.sources = map.sources.map((source: string) =>
+				source === baseModuleId ? baseFilename : source
+			);
+		}
 		return {
 			code,
 			map: map ?? undefined

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,6 +185,18 @@ importers:
       svelte-preprocess: 5.0.3_svelte@3.58.0
       vite: 4.2.1
 
+  packages/e2e-tests/css-dev-sourcemap:
+    specifiers:
+      '@sveltejs/vite-plugin-svelte': workspace:^
+      sass: ^1.61.0
+      svelte: ^3.58.0
+      vite: ^4.2.1
+    devDependencies:
+      '@sveltejs/vite-plugin-svelte': link:../../vite-plugin-svelte
+      sass: 1.61.0
+      svelte: 3.58.0
+      vite: 4.2.1_sass@1.61.0
+
   packages/e2e-tests/css-none:
     specifiers:
       '@sveltejs/vite-plugin-svelte': workspace:^


### PR DESCRIPTION
When using Vite's [css.devSourcemap: true](https://vitejs.dev/config/shared-options.html#css-devsourcemap) and using `<style lang="scss">` processed with `vitePreprocess` will result in broken source maps for the css.

Example vite log:
```
Sourcemap for "/Volumes/Sites/svelte-project/src/routes/+page.svelte" points to missing source files
```

This is caused by the the fake filename that is passed to the `transform` function (which is needed so vite will select the appropriate transformation).

This PR repairs the SourceMap to use the original filename.