### PR TITLE
Skip Vite resolve workaround on Vite 4.1+ or Svelte 4+

### DIFF
--- a/.changeset/chilled-tigers-flash.md
+++ b/.changeset/chilled-tigers-flash.md
@@ -2,4 +2,4 @@
 '@sveltejs/vite-plugin-svelte': patch
 ---
 
-Skip Vite resolve workaround on Vite 4.1+
+Skip Vite resolve workaround on Vite 4.1+ or Svelte 4+

--- a/.changeset/chilled-tigers-flash.md
+++ b/.changeset/chilled-tigers-flash.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+Skip Vite resolve workaround on Vite 4.1+

--- a/packages/vite-plugin-svelte/src/index.ts
+++ b/packages/vite-plugin-svelte/src/index.ts
@@ -1,5 +1,13 @@
 import fs from 'fs';
-import { HmrContext, ModuleNode, Plugin, ResolvedConfig, UserConfig, version as viteVersion } from 'vite';
+import { VERSION as svelteVersion } from 'svelte/compiler';
+import {
+	HmrContext,
+	ModuleNode,
+	Plugin,
+	ResolvedConfig,
+	UserConfig,
+	version as viteVersion
+} from 'vite';
 // eslint-disable-next-line node/no-missing-import
 import { isDepExcluded } from 'vitefu';
 import { handleHotUpdate } from './handle-hot-update';
@@ -135,8 +143,13 @@ export function svelte(inlineOptions?: Partial<Options>): Plugin[] {
 					}
 				}
 
-				// TODO: remove this after bumping peerDep on Vite to at least 4.1
-				if (viteVersion.startsWith('4.0') && ssr && importee === 'svelte') {
+				// TODO: remove this after bumping peerDep on Vite to 4.1+ or Svelte to 4.0+
+				if (
+					viteVersion.startsWith('4.0') &&
+					svelteVersion.startsWith('3') &&
+					ssr &&
+					importee === 'svelte'
+				) {
 					if (!resolvedSvelteSSR) {
 						resolvedSvelteSSR = this.resolve('svelte/ssr', undefined, { skipSelf: true }).then(
 							(svelteSSR) => {

--- a/packages/vite-plugin-svelte/src/index.ts
+++ b/packages/vite-plugin-svelte/src/index.ts
@@ -137,7 +137,7 @@ export function svelte(inlineOptions?: Partial<Options>): Plugin[] {
 
 				// TODO: remove this after bumping peerDep on Vite to at least 4.1
 				const vers = version.split('.').map((s) => parseInt(s));
-				if (vers[0] === 4 && vers[1] === 0 && ssr && importee === 'svelte') {
+				if (viteVersion.startsWith('4.0') && ssr && importee === 'svelte') {
 					if (!resolvedSvelteSSR) {
 						resolvedSvelteSSR = this.resolve('svelte/ssr', undefined, { skipSelf: true }).then(
 							(svelteSSR) => {

--- a/packages/vite-plugin-svelte/src/index.ts
+++ b/packages/vite-plugin-svelte/src/index.ts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import { HmrContext, ModuleNode, Plugin, ResolvedConfig, UserConfig, version } from 'vite';
+import { HmrContext, ModuleNode, Plugin, ResolvedConfig, UserConfig, version as viteVersion } from 'vite';
 // eslint-disable-next-line node/no-missing-import
 import { isDepExcluded } from 'vitefu';
 import { handleHotUpdate } from './handle-hot-update';

--- a/packages/vite-plugin-svelte/src/index.ts
+++ b/packages/vite-plugin-svelte/src/index.ts
@@ -43,6 +43,9 @@ interface PluginAPI {
 	// TODO expose compile cache here so other utility plugins can use it
 }
 
+const isVite4_0 = viteVersion.startsWith('4.0');
+const isSvelte3 = svelteVersion.startsWith('3');
+
 export function svelte(inlineOptions?: Partial<Options>): Plugin[] {
 	if (process.env.DEBUG != null) {
 		log.setLevel('debug');
@@ -144,12 +147,7 @@ export function svelte(inlineOptions?: Partial<Options>): Plugin[] {
 				}
 
 				// TODO: remove this after bumping peerDep on Vite to 4.1+ or Svelte to 4.0+
-				if (
-					viteVersion.startsWith('4.0') &&
-					svelteVersion.startsWith('3') &&
-					ssr &&
-					importee === 'svelte'
-				) {
+				if (isVite4_0 && isSvelte3 && ssr && importee === 'svelte') {
 					if (!resolvedSvelteSSR) {
 						resolvedSvelteSSR = this.resolve('svelte/ssr', undefined, { skipSelf: true }).then(
 							(svelteSSR) => {

--- a/packages/vite-plugin-svelte/src/index.ts
+++ b/packages/vite-plugin-svelte/src/index.ts
@@ -136,7 +136,6 @@ export function svelte(inlineOptions?: Partial<Options>): Plugin[] {
 				}
 
 				// TODO: remove this after bumping peerDep on Vite to at least 4.1
-				const vers = version.split('.').map((s) => parseInt(s));
 				if (viteVersion.startsWith('4.0') && ssr && importee === 'svelte') {
 					if (!resolvedSvelteSSR) {
 						resolvedSvelteSSR = this.resolve('svelte/ssr', undefined, { skipSelf: true }).then(

--- a/packages/vite-plugin-svelte/src/index.ts
+++ b/packages/vite-plugin-svelte/src/index.ts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import { HmrContext, ModuleNode, Plugin, ResolvedConfig, UserConfig } from 'vite';
+import { HmrContext, ModuleNode, Plugin, ResolvedConfig, UserConfig, version } from 'vite';
 // eslint-disable-next-line node/no-missing-import
 import { isDepExcluded } from 'vitefu';
 import { handleHotUpdate } from './handle-hot-update';
@@ -135,7 +135,9 @@ export function svelte(inlineOptions?: Partial<Options>): Plugin[] {
 					}
 				}
 
-				if (ssr && importee === 'svelte') {
+				// TODO: remove this after bumping peerDep on Vite to at least 4.1
+				const vers = version.split('.').map((s) => parseInt(s));
+				if (vers[0] === 4 && vers[1] === 0 && ssr && importee === 'svelte') {
 					if (!resolvedSvelteSSR) {
 						resolvedSvelteSSR = this.resolve('svelte/ssr', undefined, { skipSelf: true }).then(
 							(svelteSSR) => {


### PR DESCRIPTION
[according to @dominikg](https://github.com/sveltejs/svelte/pull/8497#issuecomment-1506354874):

> latest vite does not need the custom resolve for it in v-p-s anymore, but early vite 4 versions did

I think we can safely remove this. People who are on old versions of Vite 4 may get larger apps if they upgrade `vite-plugin-svelte` without upgrading Vite, but that's relatively safe as nothing will break.

There's some nice benefits to removing this including simplifying the `vite-plugin-svelte` code and eventually paving the way for us to stop exporting `svelte/ssr` in Svelte core