### PR TITLE
Allow pnpm 7 or 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "packageManager": "pnpm@7.30.0",
   "engines": {
-    "pnpm": "^7.13.0",
+    "pnpm": ">= 7.13.0",
     "yarn": "forbidden, use pnpm",
     "npm": "forbidden, use pnpm",
     "node": "^14.18.0 || >= 16"


### PR DESCRIPTION
This is a simpler alternative to https://github.com/sveltejs/vite-plugin-svelte/pull/618, which would unblock people immediately without needing to address any of the test compatibility issues with pnpm 8 and avoids the CI complication of using different versions of pnpm with different versions of Node