### PR TITLE
feat: svelte inspector updates and promote from experimental

### DIFF
--- a/.changeset/bright-fans-count.md
+++ b/.changeset/bright-fans-count.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': minor
+---
+
+feat(inspector): Promote experimental.inspector to regular option

--- a/.changeset/cold-tips-lay.md
+++ b/.changeset/cold-tips-lay.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': minor
+---
+
+feat(inspector): allow configuration via environment SVELTE_INSPECTOR_OPTIONS or SVELTE_INSPECTOR_TOGGLE

--- a/.changeset/fluffy-monkeys-boil.md
+++ b/.changeset/fluffy-monkeys-boil.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': minor
+---
+
+feat(inspector): Enable svelte inspector by default

--- a/.changeset/fluffy-monkeys-boil.md
+++ b/.changeset/fluffy-monkeys-boil.md
@@ -1,5 +1,0 @@
----
-'@sveltejs/vite-plugin-svelte': minor
----
-
-feat(inspector): Enable svelte inspector by default

--- a/.changeset/funny-suits-grin.md
+++ b/.changeset/funny-suits-grin.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+fix(inspector): prepend vite base when calling \_\_openInEditor

--- a/.changeset/green-rats-cry.md
+++ b/.changeset/green-rats-cry.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+fix(inspector): after a file has been opened, automatically disable inspector on leaving browser

--- a/.changeset/orange-lobsters-cross.md
+++ b/.changeset/orange-lobsters-cross.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+fix(inspector): use control-shift as default keycombo on linux to avoid problems in firefox

--- a/.changeset/perfect-nails-rescue.md
+++ b/.changeset/perfect-nails-rescue.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': minor
+---
+
+feat(inspector): enable holdMode by default

--- a/.changeset/weak-crabs-type.md
+++ b/.changeset/weak-crabs-type.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+fix(svelte-inspector): mount outside body to avoid hydration claiming body removing it

--- a/docs/config.md
+++ b/docs/config.md
@@ -307,6 +307,27 @@ A [picomatch pattern](https://github.com/micromatch/picomatch), or array of patt
   });
   ```
 
+#### Customizing Inspector options via environment
+
+Svelte Inspector toggle keys and other options are personal preferences. As such it isn't always convenient to define them in a shared svelte config file.
+To allow you to use your own setup, svelte inspector can be configured via environment variables, both from shell and dotenv files.
+
+```shell
+# just keycombo, unquoted string
+SVELTE_INSPECTOR_TOGGLE=control-shift
+
+# options object as json, all options except appendTo are supported
+SVELTE_INSPECTOR_OPTIONS='{"holdMode": false, "toggleButtonPos": "bottom-left"}'
+
+# disable completely
+SVELTE_INSPECTOR_OPTIONS=false
+
+# force default options
+SVELTE_INSPECTOR_OPTIONS=true
+```
+
+> Inspector options set on the environment take precedence over values set in svelte config
+
 ## Experimental options
 
 These options are considered experimental and breaking changes to them can occur in any release! Specify them under the `experimental` option.

--- a/docs/config.md
+++ b/docs/config.md
@@ -221,7 +221,7 @@ A [picomatch pattern](https://github.com/micromatch/picomatch), or array of patt
   interface InspectorOptions {
     /**
      * define a key combo to toggle inspector,
-     * @default 'control-shift' on windows, 'meta-shift' on other os
+     * @default 'meta-shift' on mac, 'control-shift' on other os
      *
      * any number of modifiers `control` `shift` `alt` `meta` followed by zero or one regular key, separated by -
      * examples: control-shift, control-o, control-alt-s  meta-x control-meta
@@ -253,7 +253,7 @@ A [picomatch pattern](https://github.com/micromatch/picomatch), or array of patt
 
     /**
      * inspector is automatically disabled when releasing toggleKeyCombo after holding it for a longpress
-     * @default false
+     * @default true
      */
     holdMode?: boolean;
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -212,75 +212,10 @@ A [picomatch pattern](https://github.com/micromatch/picomatch), or array of patt
 
   See the [FAQ](./faq.md#what-is-going-on-with-vite-and-pre-bundling-dependencies) for details and how to fine-tune it for huge libraries.
 
-## Experimental options
-
-These options are considered experimental and breaking changes to them can occur in any release! Specify them under the `experimental` option.
-
-Either in Vite config:
-
-```js
-// vite.config.js
-export default defineConfig({
-  plugins: [
-    svelte({
-      experimental: {
-        // experimental options
-      }
-    })
-  ]
-});
-```
-
-or in Svelte config:
-
-```js
-// svelte.config.js
-export default {
-  vitePlugin: {
-    experimental: {
-      // experimental options
-    }
-  }
-};
-```
-
-### dynamicCompileOptions
-
-- **Type:**
-
-  ```ts
-  type DynamicCompileOptions = (data: {
-    filename: string; // The file to be compiled
-    code: string; // The preprocessed Svelte code
-    compileOptions: Partial<CompileOptions>; // The current compiler options
-  }) => Promise<Partial<CompileOptions> | void> | Partial<CompileOptions> | void;
-  ```
-
-  A function to update the `compilerOptions` before compilation. To change part of the compiler options, return an object with the changes you need.
-
-  **Example:**
-
-  ```js
-  // vite.config.js
-  export default defineConfig({
-    plugins: [
-      svelte({
-        experimental: {
-          dynamicCompileOptions({ filename, compileOptions }) {
-            // Dynamically set hydration per Svelte file
-            if (compileWithHydratable(filename) && !compileOptions.hydratable) {
-              return { hydratable: true };
-            }
-          }
-        }
-      })
-    ]
-  });
-  ```
-
 ### inspector
 
 - **Type:**`InspectorOptions | boolean`
+- **Default:** `true` for dev, always `false` for build
 
   ```ts
   interface InspectorOptions {
@@ -350,9 +285,73 @@ export default {
   }
   ```
 
-  Set to `true` or customized `InspectorOptions` to enable svelte inspector during development.
+  Set to `false` to disable svelte inspector during development.
 
-  When enabled, inspector mode shows you the file location where the element under cursor is defined and you can click to quickly open your code editor at this location.
+  Inspector mode shows you the file location where the element under cursor is defined and you can click to quickly open your code editor at this location.
+
+  **Example:**
+
+  ```js
+  // vite.config.js
+  export default defineConfig({
+    plugins: [
+      svelte({
+        inspector: {
+          toggleKeyCombo: 'meta-shift',
+          holdMode: true,
+          showToggleButton: 'always',
+          toggleButtonPos: 'bottom-right'
+        }
+      })
+    ]
+  });
+  ```
+
+## Experimental options
+
+These options are considered experimental and breaking changes to them can occur in any release! Specify them under the `experimental` option.
+
+Either in Vite config:
+
+```js
+// vite.config.js
+export default defineConfig({
+  plugins: [
+    svelte({
+      experimental: {
+        // experimental options
+      }
+    })
+  ]
+});
+```
+
+or in Svelte config:
+
+```js
+// svelte.config.js
+export default {
+  vitePlugin: {
+    experimental: {
+      // experimental options
+    }
+  }
+};
+```
+
+### dynamicCompileOptions
+
+- **Type:**
+
+  ```ts
+  type DynamicCompileOptions = (data: {
+    filename: string; // The file to be compiled
+    code: string; // The preprocessed Svelte code
+    compileOptions: Partial<CompileOptions>; // The current compiler options
+  }) => Promise<Partial<CompileOptions> | void> | Partial<CompileOptions> | void;
+  ```
+
+  A function to update the `compilerOptions` before compilation. To change part of the compiler options, return an object with the changes you need.
 
   **Example:**
 
@@ -362,11 +361,11 @@ export default {
     plugins: [
       svelte({
         experimental: {
-          inspector: {
-            toggleKeyCombo: 'meta-shift',
-            holdMode: true,
-            showToggleButton: 'always',
-            toggleButtonPos: 'bottom-right'
+          dynamicCompileOptions({ filename, compileOptions }) {
+            // Dynamically set hydration per Svelte file
+            if (compileWithHydratable(filename) && !compileOptions.hydratable) {
+              return { hydratable: true };
+            }
           }
         }
       })

--- a/docs/config.md
+++ b/docs/config.md
@@ -215,7 +215,7 @@ A [picomatch pattern](https://github.com/micromatch/picomatch), or array of patt
 ### inspector
 
 - **Type:**`InspectorOptions | boolean`
-- **Default:** `true` for dev, always `false` for build
+- **Default:** `unset` for dev, always `false` for build
 
   ```ts
   interface InspectorOptions {
@@ -285,7 +285,7 @@ A [picomatch pattern](https://github.com/micromatch/picomatch), or array of patt
   }
   ```
 
-  Set to `false` to disable svelte inspector during development.
+  Set to `true` or options object to enable svelte inspector during development.
 
   Inspector mode shows you the file location where the element under cursor is defined and you can click to quickly open your code editor at this location.
 
@@ -326,7 +326,7 @@ SVELTE_INSPECTOR_OPTIONS=false
 SVELTE_INSPECTOR_OPTIONS=true
 ```
 
-> Inspector options set on the environment take precedence over values set in svelte config
+> Inspector options set on the environment take precedence over values set in svelte config and automatically enable svelte inspector during dev.
 
 ## Experimental options
 

--- a/packages/e2e-tests/css-dev-sourcemap/__tests__/css-dev-sourcemap.spec.ts
+++ b/packages/e2e-tests/css-dev-sourcemap/__tests__/css-dev-sourcemap.spec.ts
@@ -16,7 +16,7 @@ test('should apply css compiled from scss', async () => {
 
 if (!isBuild) {
 	test('should generate sourcemap', async () => {
-		const style = await getText('style');
+		const style = await getText('style[data-vite-dev-id*="App.svelte"]');
 		const lines = style.split(`\n`).map((l) => l.trim());
 		const css = lines[0];
 		const mapComment = lines[1];

--- a/packages/vite-plugin-svelte/src/index.ts
+++ b/packages/vite-plugin-svelte/src/index.ts
@@ -273,12 +273,9 @@ export function svelte(inlineOptions?: Partial<Options>): Plugin[] {
 					);
 				}
 			}
-		}
+		},
+		svelteInspector()
 	];
-	const inspector = svelteInspector();
-	if (inspector) {
-		plugins.push(inspector);
-	}
 	return plugins;
 }
 

--- a/packages/vite-plugin-svelte/src/index.ts
+++ b/packages/vite-plugin-svelte/src/index.ts
@@ -275,8 +275,11 @@ export function svelte(inlineOptions?: Partial<Options>): Plugin[] {
 			}
 		}
 	];
-	plugins.push(svelteInspector());
-	return plugins.filter(Boolean);
+	const inspector = svelteInspector();
+	if (inspector) {
+		plugins.push(inspector);
+	}
+	return plugins;
 }
 
 export { vitePreprocess } from './preprocess';

--- a/packages/vite-plugin-svelte/src/ui/inspector/Inspector.svelte
+++ b/packages/vite-plugin-svelte/src/ui/inspector/Inspector.svelte
@@ -296,7 +296,7 @@
 			if (toggle_combo) {
 				document.body.removeEventListener('keydown', keydown);
 				if (options.holdMode) {
-					document.body.addEventListener('keyup', keyup);
+					document.body.removeEventListener('keyup', keyup);
 				}
 			}
 			document.removeEventListener('visibilitychange', visibilityChange);

--- a/packages/vite-plugin-svelte/src/ui/inspector/Inspector.svelte
+++ b/packages/vite-plugin-svelte/src/ui/inspector/Inspector.svelte
@@ -124,7 +124,7 @@
 	function open_editor(event) {
 		if (file_loc) {
 			stop(event);
-			fetch(`/__open-in-editor?file=${encodeURIComponent(file_loc)}`);
+			fetch(`${options.__internal.base}/__open-in-editor?file=${encodeURIComponent(file_loc)}`);
 			hasOpened = true;
 			if (options.holdMode && is_holding()) {
 				disable();

--- a/packages/vite-plugin-svelte/src/ui/inspector/load-inspector.js
+++ b/packages/vite-plugin-svelte/src/ui/inspector/load-inspector.js
@@ -8,7 +8,7 @@ function create_inspector_host() {
 	}
 	const el = document.createElement('div');
 	el.setAttribute('id', id);
-	document.getElementsByTagName('body')[0].appendChild(el);
+	document.documentElement.appendChild(el);
 	return el;
 }
 

--- a/packages/vite-plugin-svelte/src/ui/inspector/options.ts
+++ b/packages/vite-plugin-svelte/src/ui/inspector/options.ts
@@ -2,7 +2,7 @@ import * as process from 'process';
 import { log } from '../../utils/log';
 import { loadEnv, ResolvedConfig } from 'vite';
 export const defaultInspectorOptions: InspectorOptions = {
-	toggleKeyCombo: process.platform === 'win32' ? 'control-shift' : 'meta-shift',
+	toggleKeyCombo: process.platform === 'darwin' ? 'meta-shift' : 'control-shift',
 	navKeys: { parent: 'ArrowUp', child: 'ArrowDown', next: 'ArrowRight', prev: 'ArrowLeft' },
 	openKey: 'Enter',
 	holdMode: true,
@@ -65,7 +65,7 @@ export function parseEnvironmentOptions(
 export interface InspectorOptions {
 	/**
 	 * define a key combo to toggle inspector,
-	 * @default 'control-shift' on windows, 'meta-shift' on other os
+	 * @default 'meta-shift' on mac, 'control-shift' on other os
 	 *
 	 * any number of modifiers `control` `shift` `alt` `meta` followed by zero or one regular key, separated by -
 	 * examples: control-shift, control-o, control-alt-s  meta-x control-meta

--- a/packages/vite-plugin-svelte/src/ui/inspector/options.ts
+++ b/packages/vite-plugin-svelte/src/ui/inspector/options.ts
@@ -1,3 +1,13 @@
+export const defaultInspectorOptions: InspectorOptions = {
+	toggleKeyCombo: process.platform === 'win32' ? 'control-shift' : 'meta-shift',
+	navKeys: { parent: 'ArrowUp', child: 'ArrowDown', next: 'ArrowRight', prev: 'ArrowLeft' },
+	openKey: 'Enter',
+	holdMode: true,
+	showToggleButton: 'active',
+	toggleButtonPos: 'top-right',
+	customStyles: true
+};
+
 export interface InspectorOptions {
 	/**
 	 * define a key combo to toggle inspector,
@@ -38,7 +48,7 @@ export interface InspectorOptions {
 
 	/**
 	 * inspector is automatically disabled when releasing toggleKeyCombo after holding it for a longpress
-	 * @default false
+	 * @default true
 	 */
 	holdMode?: boolean;
 	/**

--- a/packages/vite-plugin-svelte/src/ui/inspector/options.ts
+++ b/packages/vite-plugin-svelte/src/ui/inspector/options.ts
@@ -76,4 +76,11 @@ export interface InspectorOptions {
 	 * Regular users of vite-plugin-svelte or SvelteKit do not need it
 	 */
 	appendTo?: string;
+	/**
+	 * internal options that are automatically set, not to be set or used by users
+	 */
+	__internal?: {
+		// vite base url
+		base: string;
+	};
 }

--- a/packages/vite-plugin-svelte/src/ui/inspector/options.ts
+++ b/packages/vite-plugin-svelte/src/ui/inspector/options.ts
@@ -1,0 +1,69 @@
+export interface InspectorOptions {
+	/**
+	 * define a key combo to toggle inspector,
+	 * @default 'control-shift' on windows, 'meta-shift' on other os
+	 *
+	 * any number of modifiers `control` `shift` `alt` `meta` followed by zero or one regular key, separated by -
+	 * examples: control-shift, control-o, control-alt-s  meta-x control-meta
+	 * Some keys have native behavior (e.g. alt-s opens history menu on firefox).
+	 * To avoid conflicts or accidentally typing into inputs, modifier only combinations are recommended.
+	 */
+	toggleKeyCombo?: string;
+
+	/**
+	 * define keys to select elements with via keyboard
+	 * @default {parent: 'ArrowUp', child: 'ArrowDown', next: 'ArrowRight', prev: 'ArrowLeft' }
+	 *
+	 * improves accessibility and also helps when you want to select elements that do not have a hoverable surface area
+	 * due to tight wrapping
+	 *
+	 * A note for users of screen-readers:
+	 * If you are using arrow keys to navigate the page itself, change the navKeys to avoid conflicts.
+	 * e.g. navKeys: {parent: 'w', prev: 'a', child: 's', next: 'd'}
+	 *
+	 *
+	 * parent: select closest parent
+	 * child: select first child (or grandchild)
+	 * next: next sibling (or parent if no next sibling exists)
+	 * prev: previous sibling (or parent if no prev sibling exists)
+	 */
+	navKeys?: { parent: string; child: string; next: string; prev: string };
+
+	/**
+	 * define key to open the editor for the currently selected dom node
+	 *
+	 * @default 'Enter'
+	 */
+	openKey?: string;
+
+	/**
+	 * inspector is automatically disabled when releasing toggleKeyCombo after holding it for a longpress
+	 * @default false
+	 */
+	holdMode?: boolean;
+	/**
+	 * when to show the toggle button
+	 * @default 'active'
+	 */
+	showToggleButton?: 'always' | 'active' | 'never';
+
+	/**
+	 * where to display the toggle button
+	 * @default top-right
+	 */
+	toggleButtonPos?: 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left';
+
+	/**
+	 * inject custom styles when inspector is active
+	 */
+	customStyles?: boolean;
+
+	/**
+	 * append an import to the module id ending with `appendTo` instead of adding a script into body
+	 * useful for frameworks that do not support trannsformIndexHtml hook
+	 *
+	 * WARNING: only set this if you know exactly what it does.
+	 * Regular users of vite-plugin-svelte or SvelteKit do not need it
+	 */
+	appendTo?: string;
+}

--- a/packages/vite-plugin-svelte/src/ui/inspector/options.ts
+++ b/packages/vite-plugin-svelte/src/ui/inspector/options.ts
@@ -13,7 +13,7 @@ export const defaultInspectorOptions: InspectorOptions = {
 
 export function parseEnvironmentOptions(
 	config: ResolvedConfig
-): Partial<InspectorOptions> | boolean {
+): Partial<InspectorOptions> | boolean | void {
 	const env = loadEnv(config.mode, config.envDir ?? process.cwd(), 'SVELTE_INSPECTOR');
 	const options = env?.SVELTE_INSPECTOR_OPTIONS;
 	const toggle = env?.SVELTE_INSPECTOR_TOGGLE;
@@ -59,7 +59,6 @@ export function parseEnvironmentOptions(
 		log.debug('loaded environment config', keyConfig, 'inspector');
 		return keyConfig;
 	}
-	return {};
 }
 
 export interface InspectorOptions {

--- a/packages/vite-plugin-svelte/src/ui/inspector/plugin.ts
+++ b/packages/vite-plugin-svelte/src/ui/inspector/plugin.ts
@@ -41,6 +41,10 @@ export function svelteInspector(): Plugin {
 				...defaultInspectorOptions,
 				...options
 			};
+
+			inspectorOptions.__internal = {
+				base: config.base?.replace(/\/$/, '') || ''
+			};
 			const isSvelteKit = config.plugins.some((p) => p.name.startsWith('vite-plugin-sveltekit'));
 			if (isSvelteKit && !inspectorOptions.appendTo) {
 				// this could append twice if a user had a file that ends with /generated/root.svelte

--- a/packages/vite-plugin-svelte/src/ui/inspector/plugin.ts
+++ b/packages/vite-plugin-svelte/src/ui/inspector/plugin.ts
@@ -4,17 +4,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import fs from 'fs';
 import { idToFile } from './utils';
-import { InspectorOptions } from './options';
-
-const defaultInspectorOptions: InspectorOptions = {
-	toggleKeyCombo: process.platform === 'win32' ? 'control-shift' : 'meta-shift',
-	navKeys: { parent: 'ArrowUp', child: 'ArrowDown', next: 'ArrowRight', prev: 'ArrowLeft' },
-	openKey: 'Enter',
-	holdMode: false,
-	showToggleButton: 'active',
-	toggleButtonPos: 'top-right',
-	customStyles: true
-};
+import { defaultInspectorOptions, type InspectorOptions } from './options';
 
 function getInspectorPath() {
 	const pluginPath = normalizePath(path.dirname(fileURLToPath(import.meta.url)));

--- a/packages/vite-plugin-svelte/src/ui/inspector/plugin.ts
+++ b/packages/vite-plugin-svelte/src/ui/inspector/plugin.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import fs from 'fs';
 import { idToFile } from './utils';
-import { defaultInspectorOptions, type InspectorOptions } from './options';
+import { defaultInspectorOptions, type InspectorOptions, parseEnvironmentOptions } from './options';
 
 function getInspectorPath() {
 	const pluginPath = normalizePath(path.dirname(fileURLToPath(import.meta.url)));
@@ -29,19 +29,24 @@ export function svelteInspector(): Plugin {
 				log.warn('vite-plugin-svelte is missing, inspector disabled', undefined, 'inspector');
 				disabled = true;
 			}
-			const options = vps?.api?.options?.inspector ?? defaultInspectorOptions;
-			if (options === false) {
+			const configFileOptions = vps?.api?.options?.inspector;
+			const environmentOptions = parseEnvironmentOptions(config);
+			if (configFileOptions === false || environmentOptions === false) {
 				log.debug('inspector disabled in options', undefined, 'inspector');
 				disabled = true;
 			}
 			if (disabled) {
 				return;
 			}
-			inspectorOptions = {
-				...defaultInspectorOptions,
-				...options
-			};
-
+			if (environmentOptions === true) {
+				inspectorOptions = defaultInspectorOptions;
+			} else {
+				inspectorOptions = {
+					...defaultInspectorOptions,
+					...configFileOptions,
+					...environmentOptions
+				};
+			}
 			inspectorOptions.__internal = {
 				base: config.base?.replace(/\/$/, '') || ''
 			};

--- a/packages/vite-plugin-svelte/src/ui/inspector/plugin.ts
+++ b/packages/vite-plugin-svelte/src/ui/inspector/plugin.ts
@@ -1,10 +1,10 @@
 import { Plugin, normalizePath } from 'vite';
 import { log } from '../../utils/log';
-import { InspectorOptions } from '../../utils/options';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import fs from 'fs';
 import { idToFile } from './utils';
+import { InspectorOptions } from './options';
 
 const defaultInspectorOptions: InspectorOptions = {
 	toggleKeyCombo: process.platform === 'win32' ? 'control-shift' : 'meta-shift',
@@ -35,7 +35,7 @@ export function svelteInspector(): Plugin {
 
 		configResolved(config) {
 			const vps = config.plugins.find((p) => p.name === 'vite-plugin-svelte');
-			const options = vps?.api?.options?.experimental?.inspector;
+			const options = vps?.api?.options?.inspector;
 			if (!vps || !options) {
 				log.debug('inspector disabled, could not find config');
 				disabled = true;

--- a/packages/vite-plugin-svelte/src/ui/inspector/plugin.ts
+++ b/packages/vite-plugin-svelte/src/ui/inspector/plugin.ts
@@ -32,13 +32,17 @@ export function svelteInspector(): Plugin {
 			}
 			const configFileOptions = vps?.api?.options?.inspector;
 			const environmentOptions = parseEnvironmentOptions(config);
-			if (configFileOptions === false || environmentOptions === false) {
-				log.debug('inspector disabled in options', undefined, 'inspector');
+			if (!configFileOptions && !environmentOptions) {
+				log.debug('no options found, inspector disabled', undefined, 'inspector');
 				disabled = true;
 				return;
 			}
 			if (config.command !== 'serve') {
-				log.debug(`inspector disabled for vite command ${config.command}`, undefined, 'inspector');
+				log.debug(
+					`inspector only works for vite 'serve', disabled for '${config.command}'`,
+					undefined,
+					'inspector'
+				);
 				disabled = true;
 				return;
 			}

--- a/packages/vite-plugin-svelte/src/ui/inspector/plugin.ts
+++ b/packages/vite-plugin-svelte/src/ui/inspector/plugin.ts
@@ -11,21 +11,12 @@ function getInspectorPath() {
 	return pluginPath.replace(/\/vite-plugin-svelte\/dist$/, '/vite-plugin-svelte/src/ui/inspector/');
 }
 
-export function svelteInspector(): Plugin | null {
+export function svelteInspector(): Plugin {
 	const inspectorPath = getInspectorPath();
 	log.debug.enabled && log.debug(`svelte inspector path: ${inspectorPath}`);
 	let inspectorOptions: InspectorOptions;
 	let appendTo: string | undefined;
 	let disabled = false;
-
-	if (process?.env?.CI || process?.env?.SVELTE_INSPECTOR_OPTIONS === 'false') {
-		log.debug(
-			process?.env?.CI ? 'disabled in CI env' : 'disabled by user env',
-			undefined,
-			'inspector'
-		);
-		return null; // returning null here results in the Plugin not being added to vite config at all
-	}
 
 	return {
 		name: 'vite-plugin-svelte:inspector',
@@ -37,14 +28,18 @@ export function svelteInspector(): Plugin | null {
 			if (!vps) {
 				log.warn('vite-plugin-svelte is missing, inspector disabled', undefined, 'inspector');
 				disabled = true;
+				return;
 			}
 			const configFileOptions = vps?.api?.options?.inspector;
 			const environmentOptions = parseEnvironmentOptions(config);
 			if (configFileOptions === false || environmentOptions === false) {
 				log.debug('inspector disabled in options', undefined, 'inspector');
 				disabled = true;
+				return;
 			}
-			if (disabled) {
+			if (config.command !== 'serve') {
+				log.debug(`inspector disabled for vite command ${config.command}`, undefined, 'inspector');
+				disabled = true;
 				return;
 			}
 			if (environmentOptions === true) {

--- a/packages/vite-plugin-svelte/src/ui/inspector/plugin.ts
+++ b/packages/vite-plugin-svelte/src/ui/inspector/plugin.ts
@@ -11,12 +11,21 @@ function getInspectorPath() {
 	return pluginPath.replace(/\/vite-plugin-svelte\/dist$/, '/vite-plugin-svelte/src/ui/inspector/');
 }
 
-export function svelteInspector(): Plugin {
+export function svelteInspector(): Plugin | null {
 	const inspectorPath = getInspectorPath();
 	log.debug.enabled && log.debug(`svelte inspector path: ${inspectorPath}`);
 	let inspectorOptions: InspectorOptions;
 	let appendTo: string | undefined;
 	let disabled = false;
+
+	if (process?.env?.CI || process?.env?.SVELTE_INSPECTOR_OPTIONS === 'false') {
+		log.debug(
+			process?.env?.CI ? 'disabled in CI env' : 'disabled by user env',
+			undefined,
+			'inspector'
+		);
+		return null; // returning null here results in the Plugin not being added to vite config at all
+	}
 
 	return {
 		name: 'vite-plugin-svelte:inspector',

--- a/packages/vite-plugin-svelte/src/ui/inspector/plugin.ts
+++ b/packages/vite-plugin-svelte/src/ui/inspector/plugin.ts
@@ -36,15 +36,6 @@ export function svelteInspector(): Plugin {
 				disabled = true;
 				return;
 			}
-			if (config.command !== 'serve') {
-				log.debug(
-					`inspector only works for vite 'serve', disabled for '${config.command}'`,
-					undefined,
-					'inspector'
-				);
-				disabled = true;
-				return;
-			}
 			if (environmentOptions === true) {
 				inspectorOptions = defaultInspectorOptions;
 			} else {

--- a/packages/vite-plugin-svelte/src/ui/inspector/plugin.ts
+++ b/packages/vite-plugin-svelte/src/ui/inspector/plugin.ts
@@ -52,7 +52,7 @@ export function svelteInspector(): Plugin {
 				inspectorOptions = {
 					...defaultInspectorOptions,
 					...configFileOptions,
-					...environmentOptions
+					...(environmentOptions || {})
 				};
 			}
 			inspectorOptions.__internal = {

--- a/packages/vite-plugin-svelte/src/ui/inspector/plugin.ts
+++ b/packages/vite-plugin-svelte/src/ui/inspector/plugin.ts
@@ -35,10 +35,16 @@ export function svelteInspector(): Plugin {
 
 		configResolved(config) {
 			const vps = config.plugins.find((p) => p.name === 'vite-plugin-svelte');
-			const options = vps?.api?.options?.inspector;
-			if (!vps || !options) {
-				log.debug('inspector disabled, could not find config');
+			if (!vps) {
+				log.warn('vite-plugin-svelte is missing, inspector disabled', undefined, 'inspector');
 				disabled = true;
+			}
+			const options = vps?.api?.options?.inspector ?? defaultInspectorOptions;
+			if (options === false) {
+				log.debug('inspector disabled in options', undefined, 'inspector');
+				disabled = true;
+			}
+			if (disabled) {
 				return;
 			}
 			inspectorOptions = {
@@ -62,7 +68,8 @@ export function svelteInspector(): Plugin {
 				return importee;
 			} else if (importee.startsWith('virtual:svelte-inspector-path:')) {
 				const resolved = importee.replace('virtual:svelte-inspector-path:', inspectorPath);
-				log.debug.enabled && log.debug(`resolved ${importee} with ${resolved}`);
+				log.debug.enabled &&
+					log.debug(`resolved ${importee} with ${resolved}`, undefined, 'inspector');
 				return resolved;
 			}
 		},
@@ -79,7 +86,11 @@ export function svelteInspector(): Plugin {
 				if (fs.existsSync(file)) {
 					return await fs.promises.readFile(file, 'utf-8');
 				} else {
-					log.error(`failed to find file for svelte-inspector: ${file}, referenced by id ${id}.`);
+					log.error(
+						`failed to find file for svelte-inspector: ${file}, referenced by id ${id}.`,
+						undefined,
+						'inspector'
+					);
 				}
 			}
 		},

--- a/packages/vite-plugin-svelte/src/utils/options.ts
+++ b/packages/vite-plugin-svelte/src/utils/options.ts
@@ -655,7 +655,7 @@ export interface PluginOptions {
 	/**
 	 * toggle/configure Svelte Inspector
 	 *
-	 * @default false
+	 * @default true
 	 */
 	inspector?: InspectorOptions | boolean;
 

--- a/packages/vite-plugin-svelte/src/utils/options.ts
+++ b/packages/vite-plugin-svelte/src/utils/options.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-unused-vars */
-import { ConfigEnv, ResolvedConfig, UserConfig, ViteDevServer, normalizePath } from 'vite';
+import { ConfigEnv, normalizePath, ResolvedConfig, UserConfig, ViteDevServer } from 'vite';
 import { isDebugNamespaceEnabled, log } from './log';
 import { loadSvelteConfig } from './load-svelte-config';
 import {
@@ -35,6 +35,7 @@ import {
 import { isCommonDepWithoutSvelteField } from './dependencies';
 import { VitePluginSvelteStats } from './vite-plugin-svelte-stats';
 import { VitePluginSvelteCache } from './vite-plugin-svelte-cache';
+import type { InspectorOptions } from '../ui/inspector/options';
 
 const allowedPluginOptions = new Set([
 	'include',
@@ -44,6 +45,7 @@ const allowedPluginOptions = new Set([
 	'ignorePluginPreprocessors',
 	'disableDependencyReinclusion',
 	'prebundleSvelteLibraries',
+	'inspector',
 	'experimental'
 ]);
 
@@ -301,14 +303,21 @@ function addSvelteKitOptions(options: ResolvedOptions) {
 }
 
 function handleDeprecatedOptions(options: ResolvedOptions) {
-	if ((options.experimental as any)?.prebundleSvelteLibraries) {
-		options.prebundleSvelteLibraries = (options.experimental as any)?.prebundleSvelteLibraries;
-		log.warn(
-			'experimental.prebundleSvelteLibraries is no longer experimental and has moved to prebundleSvelteLibraries'
-		);
-	}
-	if ((options.experimental as any)?.generateMissingPreprocessorSourcemaps) {
-		log.warn('experimental.generateMissingPreprocessorSourcemaps has been removed.');
+	const experimental = options.experimental as any;
+	if (experimental) {
+		for (const promoted of ['prebundleSvelteLibraries', 'inspector']) {
+			if (experimental[promoted]) {
+				//@ts-expect-error untyped assign
+				options[promoted] = experimental[promoted];
+				delete experimental[promoted];
+				log.warn(
+					`Option "vitePlugin.experimental.${promoted}" is no longer experimental and has moved to "vitePlugin.${promoted}". Please update your svelte config.`
+				);
+			}
+		}
+		if (experimental.generateMissingPreprocessorSourcemaps) {
+			log.warn('experimental.generateMissingPreprocessorSourcemaps has been removed.');
+		}
 	}
 }
 
@@ -644,6 +653,13 @@ export interface PluginOptions {
 	prebundleSvelteLibraries?: boolean;
 
 	/**
+	 * toggle/configure Svelte Inspector
+	 *
+	 * @default false
+	 */
+	inspector?: InspectorOptions | boolean;
+
+	/**
 	 * These options are considered experimental and breaking changes to them can occur in any release
 	 */
 	experimental?: ExperimentalOptions;
@@ -714,11 +730,6 @@ export interface ExperimentalOptions {
 	}) => Promise<Partial<CompileOptions> | void> | Partial<CompileOptions> | void;
 
 	/**
-	 * enable svelte inspector
-	 */
-	inspector?: InspectorOptions | boolean;
-
-	/**
 	 * send a websocket message with svelte compiler warnings during dev
 	 *
 	 */
@@ -730,76 +741,6 @@ export interface ExperimentalOptions {
 	 * @default false
 	 */
 	disableSvelteResolveWarnings?: boolean;
-}
-
-export interface InspectorOptions {
-	/**
-	 * define a key combo to toggle inspector,
-	 * @default 'control-shift' on windows, 'meta-shift' on other os
-	 *
-	 * any number of modifiers `control` `shift` `alt` `meta` followed by zero or one regular key, separated by -
-	 * examples: control-shift, control-o, control-alt-s  meta-x control-meta
-	 * Some keys have native behavior (e.g. alt-s opens history menu on firefox).
-	 * To avoid conflicts or accidentally typing into inputs, modifier only combinations are recommended.
-	 */
-	toggleKeyCombo?: string;
-
-	/**
-	 * define keys to select elements with via keyboard
-	 * @default {parent: 'ArrowUp', child: 'ArrowDown', next: 'ArrowRight', prev: 'ArrowLeft' }
-	 *
-	 * improves accessibility and also helps when you want to select elements that do not have a hoverable surface area
-	 * due to tight wrapping
-	 *
-	 * A note for users of screen-readers:
-	 * If you are using arrow keys to navigate the page itself, change the navKeys to avoid conflicts.
-	 * e.g. navKeys: {parent: 'w', prev: 'a', child: 's', next: 'd'}
-	 *
-	 *
-	 * parent: select closest parent
-	 * child: select first child (or grandchild)
-	 * next: next sibling (or parent if no next sibling exists)
-	 * prev: previous sibling (or parent if no prev sibling exists)
-	 */
-	navKeys?: { parent: string; child: string; next: string; prev: string };
-
-	/**
-	 * define key to open the editor for the currently selected dom node
-	 *
-	 * @default 'Enter'
-	 */
-	openKey?: string;
-
-	/**
-	 * inspector is automatically disabled when releasing toggleKeyCombo after holding it for a longpress
-	 * @default false
-	 */
-	holdMode?: boolean;
-	/**
-	 * when to show the toggle button
-	 * @default 'active'
-	 */
-	showToggleButton?: 'always' | 'active' | 'never';
-
-	/**
-	 * where to display the toggle button
-	 * @default top-right
-	 */
-	toggleButtonPos?: 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left';
-
-	/**
-	 * inject custom styles when inspector is active
-	 */
-	customStyles?: boolean;
-
-	/**
-	 * append an import to the module id ending with `appendTo` instead of adding a script into body
-	 * useful for frameworks that do not support trannsformIndexHtml hook
-	 *
-	 * WARNING: only set this if you know exactly what it does.
-	 * Regular users of vite-plugin-svelte or SvelteKit do not need it
-	 */
-	appendTo?: string;
 }
 
 export interface PreResolvedOptions extends Options {


### PR DESCRIPTION
We have received some Feedback for svelte-inspector and this PR aims to address most of it.

#### Adresses open issues and PRs:
fixes #434  by moving inspector ui outside of `<body>`
fixes #518  by automatically disabling inspector when user leaves the browser window after opening a file
fixes #551  by prepending configured base path to __openInEditor request
fixes #555  by changing default combo on linux to control-shift
fixes #559  by enabling holdMode by default

#### New Feature: Set options via environment.
```shell
# only set toggle
SVELTE_INSPECTOR_TOGGLE=control-shift

# or use complete config json
SVELTE_INSPECTOR_OPTIONS='{"holdMode": false}'
```

#### No longer experimental

Move your inspector config to the root of `vitePlugin`.
```diff
// svelte.config.js
export default {
  vitePlugin:{
    experimental:{
-      inspector: {...}
    },
+   inspector: {...}
  }
}
```
