### PR TITLE
feat: remove SvelteKit specific handling

### DIFF
--- a/.changeset/smooth-llamas-reflect.md
+++ b/.changeset/smooth-llamas-reflect.md
@@ -1,0 +1,9 @@
+---
+'@sveltejs/vite-plugin-svelte': minor
+---
+
+Remove internal SvelteKit specific handling
+
+- Disallow `kit` prop in inline options
+- Remove default `hydratable: true` option for SvelteKit
+- Inspector code mounts on `/@vite/client` to be framework agnostic

--- a/.changeset/smooth-llamas-reflect.md
+++ b/.changeset/smooth-llamas-reflect.md
@@ -3,7 +3,3 @@
 ---
 
 Remove internal SvelteKit specific handling
-
-- Disallow `kit` prop in inline options
-- Remove default `hydratable: true` option for SvelteKit
-- Inspector code mounts on `/@vite/client` to be framework agnostic

--- a/docs/config.md
+++ b/docs/config.md
@@ -338,15 +338,6 @@ export default {
      * inject custom styles when inspector is active
      */
     customStyles?: boolean;
-
-    /**
-     * append an import to the module id ending with `appendTo` instead of adding a script into body
-     * useful for frameworks that do not support trannsformIndexHtml hook
-     *
-     * WARNING: only set this if you know exactly what it does.
-     * Regular users of vite-plugin-svelte or SvelteKit do not need it
-     */
-    appendTo?: string;
   }
   ```
 

--- a/packages/e2e-tests/inspector-kit/__tests__/inspector.kit.spec.ts
+++ b/packages/e2e-tests/inspector-kit/__tests__/inspector.kit.spec.ts
@@ -1,4 +1,4 @@
-import { getEl, getText, isBuild } from '~utils';
+import { getEl, getText, isBuild, page } from '~utils';
 
 describe('inspector-kit', () => {
 	it('should render page', async () => {
@@ -6,6 +6,7 @@ describe('inspector-kit', () => {
 	});
 	if (!isBuild) {
 		it('should show inspector toggle during dev', async () => {
+			await page.waitForLoadState('networkidle');
 			expect(await getEl('#svelte-inspector-toggle')).not.toBe(null);
 		});
 	} else {

--- a/packages/vite-plugin-svelte/src/ui/inspector/plugin.ts
+++ b/packages/vite-plugin-svelte/src/ui/inspector/plugin.ts
@@ -76,7 +76,10 @@ export function svelteInspector(): Plugin {
 			}
 		},
 
-		transform(code: string, id: string) {
+		transform(code, id, options) {
+			if (options?.ssr || disabled) {
+				return;
+			}
 			if (id.includes('vite/dist/client/client.mjs')) {
 				return { code: `${code}\nimport('virtual:svelte-inspector-path:load-inspector.js')` };
 			}

--- a/packages/vite-plugin-svelte/src/utils/options.ts
+++ b/packages/vite-plugin-svelte/src/utils/options.ts
@@ -791,15 +791,6 @@ export interface InspectorOptions {
 	 * inject custom styles when inspector is active
 	 */
 	customStyles?: boolean;
-
-	/**
-	 * append an import to the module id ending with `appendTo` instead of adding a script into body
-	 * useful for frameworks that do not support trannsformIndexHtml hook
-	 *
-	 * WARNING: only set this if you know exactly what it does.
-	 * Regular users of vite-plugin-svelte or SvelteKit do not need it
-	 */
-	appendTo?: string;
 }
 
 export interface PreResolvedOptions extends Options {

--- a/packages/vite-plugin-svelte/src/utils/options.ts
+++ b/packages/vite-plugin-svelte/src/utils/options.ts
@@ -203,7 +203,6 @@ export function resolveOptions(
 
 	removeIgnoredOptions(merged);
 	handleDeprecatedOptions(merged);
-	addSvelteKitOptions(merged);
 	addExtraPreprocessors(merged, viteConfig);
 	enforceOptionsForHmr(merged);
 	enforceOptionsForProduction(merged);
@@ -288,15 +287,6 @@ function removeIgnoredOptions(options: ResolvedOptions) {
 			// @ts-expect-error string access
 			delete options.compilerOptions[ignored];
 		});
-	}
-}
-
-// some SvelteKit options need compilerOptions to work, so set them here.
-function addSvelteKitOptions(options: ResolvedOptions) {
-	// @ts-expect-error kit is not typed to avoid dependency on sveltekit
-	if (options?.kit != null && options.compilerOptions.hydratable == null) {
-		log.debug(`Setting compilerOptions.hydratable = true for SvelteKit`);
-		options.compilerOptions.hydratable = true;
 	}
 }
 

--- a/packages/vite-plugin-svelte/src/utils/options.ts
+++ b/packages/vite-plugin-svelte/src/utils/options.ts
@@ -49,12 +49,7 @@ const allowedPluginOptions = new Set([
 
 const knownRootOptions = new Set(['extensions', 'compilerOptions', 'preprocess', 'onwarn']);
 
-const allowedInlineOptions = new Set([
-	'configFile',
-	'kit', // only for internal use by sveltekit
-	...allowedPluginOptions,
-	...knownRootOptions
-]);
+const allowedInlineOptions = new Set(['configFile', ...allowedPluginOptions, ...knownRootOptions]);
 
 export function validateInlineOptions(inlineOptions?: Partial<Options>) {
 	const invalidKeys = Object.keys(inlineOptions || {}).filter(


### PR DESCRIPTION
Per changeset:

Remove internal SvelteKit specific handling

- Disallow `kit` prop in inline options
- Remove default `hydratable: true` option for SvelteKit
- Inspector code mounts on `/@vite/client` to be framework agnostic

Re no1, I'm not sure how we're using that today, but seems safe to me to remove the runtime validation for it.

Re no2, SvelteKit has set it by itself for quite a while now: https://github.com/sveltejs/kit/blob/fb68c253a59402df2b2b1b5db7a54fad504cdd32/packages/kit/src/exports/vite/index.js#L136

Re no3, this removes the need for the `inspector.appendTo` option so we don't need kit specific handling for it. Makes way for https://github.com/sveltejs/vite-plugin-svelte/pull/631