### PR TITLE
fix(inspector): add vite as dev dep

### DIFF
--- a/packages/vite-plugin-svelte-inspector/package.json
+++ b/packages/vite-plugin-svelte-inspector/package.json
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "@types/debug": "^4.1.7",
-    "svelte": "^3.59.1"
+    "svelte": "^3.59.1",
+    "vite": "^4.3.5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -796,9 +796,6 @@ importers:
       debug:
         specifier: ^4.3.4
         version: 4.3.4
-      vite:
-        specifier: ^4.0.0
-        version: 4.3.5(@types/node@18.16.8)(sass@1.62.1)(stylus@0.59.0)
     devDependencies:
       '@types/debug':
         specifier: ^4.1.7
@@ -806,6 +803,9 @@ importers:
       svelte:
         specifier: ^3.59.1
         version: 3.59.1
+      vite:
+        specifier: ^4.3.5
+        version: 4.3.5(@types/node@18.16.8)(sass@1.62.1)(stylus@0.59.0)
 
 packages:
 


### PR DESCRIPTION
Add `vite` as dev dep in `packages/vite-plugin-svelte-inspector` so that it uses the Vite overrides too.