### PR TITLE
fix: silence type error

### DIFF
--- a/packages/vite-plugin-svelte/src/utils/compile.ts
+++ b/packages/vite-plugin-svelte/src/utils/compile.ts
@@ -157,7 +157,7 @@ const _createCompileSvelte = (makeHot: Function) => {
 			}
 		}
 
-		compiled.js.dependencies = dependencies;
+		(compiled.js as any).dependencies = dependencies;
 
 		return {
 			filename,


### PR DESCRIPTION
Svelte 4 has more correct typings of the `js` property of the result of `svelte.compile`, which makes a type cast necessary