### PR TITLE
refactor: update jsdoc syntax

### DIFF
--- a/packages/vite-plugin-svelte/src/handle-hot-update.ts
+++ b/packages/vite-plugin-svelte/src/handle-hot-update.ts
@@ -8,7 +8,7 @@ import { toRollupError } from './utils/error.js';
  * @param {import('vite').HmrContext} ctx
  * @param {import('./types/id.d.ts').SvelteRequest} svelteRequest
  * @param {import('./utils/vite-plugin-svelte-cache').VitePluginSvelteCache} cache
- * @param options {import('./types/options.d.ts').ResolvedOptions}
+ * @param {import('./types/options.d.ts').ResolvedOptions} options
  * @returns {Promise<import('vite').ModuleNode[] | void>}
  */
 export async function handleHotUpdate(compileSvelte, ctx, svelteRequest, cache, options) {
@@ -71,8 +71,8 @@ export async function handleHotUpdate(compileSvelte, ctx, svelteRequest, cache, 
 }
 
 /**
- * @param {import('./types/compile.d.ts').Code=} prev
- * @param {import('./types/compile.d.ts').Code=} next
+ * @param {import('./types/compile.d.ts').Code} [prev]
+ * @param {import('./types/compile.d.ts').Code} [next]
  * @returns {boolean}
  */
 function cssChanged(prev, next) {
@@ -80,9 +80,9 @@ function cssChanged(prev, next) {
 }
 
 /**
- * @param {import('./types/compile.d.ts').Code=} prev
- * @param {import('./types/compile.d.ts').Code=} next
- * @param {string=} filename
+ * @param {import('./types/compile.d.ts').Code} [prev]
+ * @param {import('./types/compile.d.ts').Code} [next]
+ * @param {string} [filename]
  * @returns {boolean}
  */
 function jsChanged(prev, next, filename) {
@@ -102,8 +102,8 @@ function jsChanged(prev, next, filename) {
 }
 
 /**
- * @param {string=} prev
- * @param {string=} next
+ * @param {string} [prev]
+ * @param {string} [next]
  * @returns {boolean}
  */
 function isCodeEqual(prev, next) {
@@ -121,7 +121,8 @@ function isCodeEqual(prev, next) {
  *
  * 1) add_location() calls. These add location metadata to elements, only used by some dev tools
  * 2) ... maybe more (or less) in the future
- * @param {string=} code
+ *
+ * @param {string} [code]
  * @returns {string | undefined}
  */
 function normalizeJsCode(code) {

--- a/packages/vite-plugin-svelte/src/index.d.ts
+++ b/packages/vite-plugin-svelte/src/index.d.ts
@@ -1,12 +1,10 @@
-import { InlineConfig, ResolvedConfig, UserConfig, Plugin } from 'vite';
-
-import { CompileOptions, Warning } from 'svelte/types/compiler/interfaces';
-
-import { PreprocessorGroup } from 'svelte/types/compiler/preprocess';
-
+import type { InlineConfig, ResolvedConfig, UserConfig, Plugin } from 'vite';
+import type { CompileOptions, Warning } from 'svelte/types/compiler/interfaces';
+import type { PreprocessorGroup } from 'svelte/types/compiler/preprocess';
 import type { Options as InspectorOptions } from '@sveltejs/vite-plugin-svelte-inspector';
 
 type Options = Omit<SvelteOptions, 'vitePlugin'> & PluginOptionsInline;
+
 interface PluginOptionsInline extends PluginOptions {
 	/**
 	 * Path to a svelte config file, either absolute or relative to Vite root
@@ -17,6 +15,7 @@ interface PluginOptionsInline extends PluginOptions {
 	 */
 	configFile?: string | false;
 }
+
 interface PluginOptions {
 	/**
 	 * A `picomatch` pattern, or array of patterns, which specifies the files the plugin should
@@ -100,6 +99,7 @@ interface PluginOptions {
 	 */
 	experimental?: ExperimentalOptions;
 }
+
 interface SvelteOptions {
 	/**
 	 * A list of file extensions to be compiled by Svelte
@@ -130,6 +130,7 @@ interface SvelteOptions {
 	 */
 	vitePlugin?: PluginOptions;
 }
+
 /**
  * These options are considered experimental and breaking changes to them can occur in any release
  */
@@ -170,6 +171,7 @@ interface ExperimentalOptions {
 	 */
 	disableSvelteResolveWarnings?: boolean;
 }
+
 type ModuleFormat = NonNullable<CompileOptions['format']>;
 type CssHashGetter = NonNullable<CompileOptions['cssHash']>;
 type Arrayable<T> = T | T[];

--- a/packages/vite-plugin-svelte/src/index.ts
+++ b/packages/vite-plugin-svelte/src/index.ts
@@ -29,11 +29,7 @@ import { FAQ_LINK_CONFLICTS_IN_SVELTE_RESOLVE } from './utils/constants.js';
 const isVite4_0 = viteVersion.startsWith('4.0');
 const isSvelte3 = svelteVersion.startsWith('3');
 
-/**
- *
- * @param {Partial<import('./index.d.ts').Options>=} inlineOptions
- * @returns {import('vite').Plugin[]}
- */
+/** @type {import('./index.d.ts').svelte} */
 export function svelte(inlineOptions) {
 	if (process.env.DEBUG != null) {
 		log.setLevel('debug');

--- a/packages/vite-plugin-svelte/src/preprocess.ts
+++ b/packages/vite-plugin-svelte/src/preprocess.ts
@@ -1,18 +1,18 @@
 import { preprocessCSS, resolveConfig, transformWithEsbuild } from 'vite';
 import { mapToRelative, removeLangSuffix } from './utils/sourcemaps.js';
 
+/**
+ * @typedef {(code: string, filename: string) => Promise<{ code: string; map?: any; deps?: Set<string> }>} CssTransform
+ */
+
 const supportedStyleLangs = ['css', 'less', 'sass', 'scss', 'styl', 'stylus', 'postcss', 'sss'];
 const supportedScriptLangs = ['ts'];
 
 export const lang_sep = '.vite-preprocess.';
 
-/**
- *
- * @param {import('./index.d.ts').VitePreprocessOptions=} opts
- * @returns {import('svelte/types/compiler/preprocess').PreprocessorGroup}
- */
+/** @type {import('./index.d.ts').vitePreprocess} */
 export function vitePreprocess(opts) {
-	/**@type {import('svelte/types/compiler/preprocess').PreprocessorGroup} */
+	/** @type {import('svelte/types/compiler/preprocess').PreprocessorGroup} */
 	const preprocessor = {};
 	if (opts?.script !== false) {
 		preprocessor.script = viteScript().script;
@@ -25,8 +25,7 @@ export function vitePreprocess(opts) {
 }
 
 /**
- *
- * @returns {{script:import('svelte/types/compiler/preprocess').Preprocessor}}
+ * @returns {{ script: import('svelte/types/compiler/preprocess').Preprocessor }}
  */
 function viteScript() {
 	return {
@@ -57,12 +56,12 @@ function viteScript() {
 
 /**
  * @param {import('vite').ResolvedConfig | import('vite').InlineConfig} config
- * @returns {{style:import('svelte/types/compiler/preprocess').Preprocessor}}
+ * @returns {{ style: import('svelte/types/compiler/preprocess').Preprocessor }}
  */
 function viteStyle(config = {}) {
-	/** @type import('./types/preprocess.d.ts').CssTransform */
+	/** @type {CssTransform} */
 	let transform;
-	/** @type import('svelte/types/compiler/preprocess').Preprocessor */
+	/** @type {import('svelte/types/compiler/preprocess').Preprocessor} */
 	const style = async ({ attributes, content, filename = '' }) => {
 		const lang = /** @type {string} */ (attributes.lang);
 		if (!supportedStyleLangs.includes(lang)) return;
@@ -102,13 +101,14 @@ function viteStyle(config = {}) {
 
 /**
  * @param {import('vite').ResolvedConfig} config
- * @returns {import('./types/preprocess.d.ts').CssTransform}
+ * @returns {CssTransform}
  */
 function getCssTransformFn(config) {
 	return async (code, filename) => {
 		return preprocessCSS(code, filename, config);
 	};
 }
+
 /**
  * @param {any} config
  * @returns {config is import('vite').ResolvedConfig}

--- a/packages/vite-plugin-svelte/src/types/compile.d.ts
+++ b/packages/vite-plugin-svelte/src/types/compile.d.ts
@@ -1,6 +1,7 @@
 import type { Processed } from 'svelte/types/compiler/preprocess';
 import type { SvelteRequest } from './id.d.ts';
 import type { ResolvedOptions } from './options.d.ts';
+
 export type CompileSvelte = (
 	svelteRequest: SvelteRequest,
 	code: string,

--- a/packages/vite-plugin-svelte/src/types/dependencies.d.ts
+++ b/packages/vite-plugin-svelte/src/types/dependencies.d.ts
@@ -1,4 +1,0 @@
-export interface DependencyData {
-	dir: string;
-	pkg: Record<string, any>;
-}

--- a/packages/vite-plugin-svelte/src/types/esbuild.d.ts
+++ b/packages/vite-plugin-svelte/src/types/esbuild.d.ts
@@ -1,3 +1,0 @@
-import type { DepOptimizationOptions } from 'vite';
-export type EsbuildOptions = NonNullable<DepOptimizationOptions['esbuildOptions']>;
-export type EsbuildPlugin = NonNullable<EsbuildOptions['plugins']>[number];

--- a/packages/vite-plugin-svelte/src/types/options.d.ts
+++ b/packages/vite-plugin-svelte/src/types/options.d.ts
@@ -1,8 +1,6 @@
 import type { CompileOptions } from 'svelte/types/compiler/interfaces';
 import type { ViteDevServer } from 'vite';
 import { VitePluginSvelteStats } from '../utils/vite-plugin-svelte-stats.js';
-
-import type { Options as InspectorOptions } from '@sveltejs/vite-plugin-svelte-inspector';
 import type { Options } from '../index.d.ts';
 
 export interface PreResolvedOptions extends Options {

--- a/packages/vite-plugin-svelte/src/types/preprocess.d.ts
+++ b/packages/vite-plugin-svelte/src/types/preprocess.d.ts
@@ -1,6 +1,0 @@
-import type { InlineConfig, ResolvedConfig } from 'vite';
-export type CssTransform = (
-	code: string,
-
-	filename: string
-) => Promise<{ code: string; map?: any; deps?: Set<string> }>;

--- a/packages/vite-plugin-svelte/src/types/sourcemaps.d.ts
+++ b/packages/vite-plugin-svelte/src/types/sourcemaps.d.ts
@@ -1,5 +1,0 @@
-export interface SourceMapFileRefs {
-	file?: string;
-	sources?: string[];
-	sourceRoot?: string;
-}

--- a/packages/vite-plugin-svelte/src/types/vite-plugin-svelte-cache.d.ts
+++ b/packages/vite-plugin-svelte/src/types/vite-plugin-svelte-cache.d.ts
@@ -1,6 +1,0 @@
-export interface PackageInfo {
-	name: string;
-	version: string;
-	svelte?: string;
-	path: string;
-}

--- a/packages/vite-plugin-svelte/src/types/vite-plugin-svelte-stats.d.ts
+++ b/packages/vite-plugin-svelte/src/types/vite-plugin-svelte-stats.d.ts
@@ -26,6 +26,5 @@ export interface PackageStats {
 
 export interface CollectionOptions {
 	logInProgress: (collection: StatCollection, now: number) => boolean;
-
 	logResult: (collection: StatCollection) => boolean;
 }

--- a/packages/vite-plugin-svelte/src/utils/compile.ts
+++ b/packages/vite-plugin-svelte/src/utils/compile.ts
@@ -10,15 +10,14 @@ import { mapToRelative } from './sourcemaps.js';
 const scriptLangRE = /<script [^>]*lang=["']?([^"' >]+)["']?[^>]*>/;
 
 /**
- *
- * @param {Function=} makeHot
+ * @param {Function} [makeHot]
  * @returns {import('../types/compile.d.ts').CompileSvelte}
  */
 export const _createCompileSvelte = (makeHot) => {
 	/** @type {import('../types/vite-plugin-svelte-stats.d.ts').StatCollection | undefined} */
 	let stats;
 	const devStylePreprocessor = createInjectScopeEverythingRulePreprocessorGroup();
-	/**@type {import('../types/compile.d.ts').CompileSvelte} */
+	/** @type {import('../types/compile.d.ts').CompileSvelte} */
 	return async function compileSvelte(svelteRequest, code, options) {
 		const { filename, normalizedFilename, cssId, ssr, raw } = svelteRequest;
 		const { emitCss = true } = options;
@@ -95,8 +94,8 @@ export const _createCompileSvelte = (makeHot) => {
 			mapToRelative(preprocessed?.map, filename);
 		}
 		if (raw && svelteRequest.query.type === 'preprocessed') {
-			// shortcut
-			return /**@type {import('../types/compile.d.ts').CompileData} */ {
+			// @ts-expect-error shortcut
+			return /** @type {import('../types/compile.d.ts').CompileData} */ {
 				preprocessed: preprocessed ?? { code }
 			};
 		}
@@ -168,10 +167,10 @@ export const _createCompileSvelte = (makeHot) => {
 		};
 	};
 };
+
 /**
- *
  * @param {import('../types/options.d.ts').ResolvedOptions} options
- * @returns {Function|undefined}
+ * @returns {Function | undefined}
  */
 function buildMakeHot(options) {
 	const needsMakeHot = options.hot !== false && options.isServe && !options.isProduction;
@@ -184,12 +183,12 @@ function buildMakeHot(options) {
 			walk,
 			hotApi,
 			adapter,
-			hotOptions: { noOverlay: true, .../** @type {object} */ options.hot }
+			hotOptions: { noOverlay: true, .../** @type {object} */ (options.hot) }
 		});
 	}
 }
+
 /**
- *
  * @param {import('../types/options.d.ts').ResolvedOptions} options
  * @returns {import('../types/compile.d.ts').CompileSvelte}
  */

--- a/packages/vite-plugin-svelte/src/utils/dependencies.ts
+++ b/packages/vite-plugin-svelte/src/utils/dependencies.ts
@@ -1,13 +1,18 @@
 import path from 'path';
 import fs from 'fs/promises';
-
 import { findDepPkgJsonPath } from 'vitefu';
 
 /**
- *
+ * @typedef {{
+ *  dir: string;
+ *	pkg: Record<string, any>;
+ * }} DependencyData
+ */
+
+/**
  * @param {string} dep
  * @param {string} parent
- * @returns {Promise<import('../types/dependencies.d.ts').DependencyData|undefined>}
+ * @returns {Promise<DependencyData | undefined>}
  */
 export async function resolveDependencyData(dep, parent) {
 	const depDataPath = await findDepPkgJsonPath(dep, parent);

--- a/packages/vite-plugin-svelte/src/utils/error.ts
+++ b/packages/vite-plugin-svelte/src/utils/error.ts
@@ -2,13 +2,13 @@ import { buildExtendedLogMessage } from './log.js';
 
 /**
  * convert an error thrown by svelte.compile to a RollupError so that vite displays it in a user friendly way
- * @param {import('../index.d.ts').Warning & Error} error a svelte compiler error, which is a mix of Warning and an error
+ * @param {import('svelte/types/compiler/interfaces').Warning & Error} error a svelte compiler error, which is a mix of Warning and an error
  * @param {import('../types/options.d.ts').ResolvedOptions} options
  * @returns {import('rollup').RollupError} the converted error
  */
 export function toRollupError(error, options) {
 	const { filename, frame, start, code, name, stack } = error;
-	/** @type  {import('rollup').RollupError} */
+	/** @type {import('rollup').RollupError} */
 	const rollupError = {
 		name, // needed otherwise sveltekit coalesce_to_error turns it into a string
 		id: filename,
@@ -29,7 +29,7 @@ export function toRollupError(error, options) {
 
 /**
  * convert an error thrown by svelte.compile to an esbuild PartialMessage
- * @param {import('../index.d.ts').Warning & Error} error a svelte compiler error, which is a mix of Warning and an error
+ * @param {import('svelte/types/compiler/interfaces').Warning & Error} error a svelte compiler error, which is a mix of Warning and an error
  * @param {import('../types/options.d.ts').ResolvedOptions} options
  * @returns {import('esbuild').PartialMessage} the converted error
  */
@@ -57,7 +57,7 @@ export function toESBuildError(error, options) {
  * extract line with number from codeframe
  *
  * @param {number} lineNo
- * @param {string=} frame
+ * @param {string} [frame]
  * @returns {string}
  */
 function lineFromFrame(lineNo, frame) {
@@ -88,8 +88,8 @@ function lineFromFrame(lineNo, frame) {
  *  3 | baz
  * ```
  * @see https://github.com/vitejs/vite/blob/96591bf9989529de839ba89958755eafe4c445ae/packages/vite/src/client/overlay.ts#L116
- * @param {string=} frame
- * @returns string
+ * @param {string} [frame]
+ * @returns {string}
  */
 function formatFrameForVite(frame) {
 	if (!frame) {

--- a/packages/vite-plugin-svelte/src/utils/esbuild.ts
+++ b/packages/vite-plugin-svelte/src/utils/esbuild.ts
@@ -3,12 +3,16 @@ import { compile, preprocess } from 'svelte/compiler';
 import { log } from './log.js';
 import { toESBuildError } from './error.js';
 
+/**
+ * @typedef {NonNullable<import('vite').DepOptimizationOptions['esbuildOptions']>} EsbuildOptions
+ * @typedef {NonNullable<EsbuildOptions['plugins']>[number]} EsbuildPlugin
+ */
+
 export const facadeEsbuildSveltePluginName = 'vite-plugin-svelte:facade';
 
 /**
- *
  * @param {import('../types/options.d.ts').ResolvedOptions} options
- * @returns {import('../types/esbuild.d.ts').EsbuildPlugin}
+ * @returns {EsbuildPlugin}
  */
 export function esbuildSveltePlugin(options) {
 	return {
@@ -44,10 +48,9 @@ export function esbuildSveltePlugin(options) {
 }
 
 /**
- *
  * @param {import('../types/options.d.ts').ResolvedOptions} options
  * @param {{ filename: string; code: string }} input
- * @param {import('../types/vite-plugin-svelte-stats.d.ts').StatCollection=} statsCollection
+ * @param {import('../types/vite-plugin-svelte-stats.d.ts').StatCollection} [statsCollection]
  * @returns {Promise<string>}
  */
 async function compileSvelte(options, { filename, code }, statsCollection) {
@@ -96,10 +99,7 @@ async function compileSvelte(options, { filename, code }, statsCollection) {
 		  }
 		: compileOptions;
 	const endStat = statsCollection?.start(filename);
-	const compiled = /** @type {import('../types/compile.d.ts').Compiled}*/ compile(
-		finalCode,
-		finalCompileOptions
-	);
+	const compiled = compile(finalCode, finalCompileOptions);
 	if (endStat) {
 		endStat();
 	}

--- a/packages/vite-plugin-svelte/src/utils/hash.ts
+++ b/packages/vite-plugin-svelte/src/utils/hash.ts
@@ -25,7 +25,7 @@ export function safeBase64Hash(input) {
 	return hash;
 }
 
-/** @type {Record<string,string>} */
+/** @type {Record<string, string>} */
 const replacements = {
 	'+': '-',
 	'/': '_',
@@ -35,7 +35,6 @@ const replacements = {
 const replaceRE = new RegExp(`[${Object.keys(replacements).join('')}]`, 'g');
 
 /**
- *
  * @param {string} base64
  * @returns {string}
  */

--- a/packages/vite-plugin-svelte/src/utils/id.ts
+++ b/packages/vite-plugin-svelte/src/utils/id.ts
@@ -1,6 +1,5 @@
 import { createFilter, normalizePath } from 'vite';
 import * as fs from 'fs';
-
 import { log } from './log.js';
 
 const VITE_FS_PREFIX = '/@fs/';
@@ -18,9 +17,8 @@ const SUPPORTED_COMPILER_OPTIONS = [
 const TYPES_WITH_COMPILER_OPTIONS = ['style', 'script', 'all'];
 
 /**
- *
  * @param {string} id
- * @returns {{filename: string, rawQuery: string}}
+ * @returns {{ filename: string, rawQuery: string }}
  */
 function splitId(id) {
 	const parts = id.split(`?`, 2);
@@ -30,7 +28,6 @@ function splitId(id) {
 }
 
 /**
- *
  * @param {string} id
  * @param {string} filename
  * @param {string} rawQuery
@@ -63,7 +60,6 @@ function parseToSvelteRequest(id, filename, rawQuery, root, timestamp, ssr) {
 }
 
 /**
- *
  * @param {string} filename
  * @param {string} root
  * @param {import('../types/id.d.ts').SvelteQueryTypes} type
@@ -86,7 +82,6 @@ function createVirtualImportId(filename, root, type) {
 }
 
 /**
- *
  * @param {string} rawQuery
  * @returns {import('../types/id.d.ts').RequestQuery}
  */
@@ -141,7 +136,6 @@ function normalize(filename, normalizedRoot) {
 }
 
 /**
- *
  * @param {string} filename
  * @param {string} root
  * @returns {boolean}
@@ -154,7 +148,6 @@ function existsInRoot(filename, root) {
 }
 
 /**
- *
  * @param {string} normalizedFilename
  * @param {string} normalizedRoot
  * @returns {string}
@@ -166,11 +159,10 @@ function stripRoot(normalizedFilename, normalizedRoot) {
 }
 
 /**
- *
  * @param {import('../index.d.ts').Arrayable<string> | undefined} include
  * @param {import('../index.d.ts').Arrayable<string> | undefined} exclude
  * @param {string[]} extensions
- * @returns {(filename:string)=>boolean}
+ * @returns {(filename: string) => boolean}
  */
 function buildFilter(include, exclude, extensions) {
 	const rollupFilter = createFilter(include, exclude);
@@ -178,14 +170,13 @@ function buildFilter(include, exclude, extensions) {
 }
 
 /**
- *
  * @param {import('../types/options.d.ts').ResolvedOptions} options
  * @returns {import('../types/id.d.ts').IdParser}
  */
 export function buildIdParser(options) {
 	const { include, exclude, extensions, root } = options;
 	const normalizedRoot = normalizePath(root);
-	const filter = buildFilter(include, exclude, /**@type {string[]} */ extensions);
+	const filter = buildFilter(include, exclude, extensions ?? []);
 	return (id, ssr, timestamp = Date.now()) => {
 		const { filename, rawQuery } = splitId(id);
 		if (filter(filename)) {

--- a/packages/vite-plugin-svelte/src/utils/load-svelte-config.ts
+++ b/packages/vite-plugin-svelte/src/utils/load-svelte-config.ts
@@ -25,12 +25,7 @@ const dynamicImportDefault = new Function(
 	'return import(path + "?t=" + timestamp).then(m => m.default)'
 );
 
-/**
- *
- * @param {import('vite').UserConfig | undefined} viteConfig
- * @param {Partial<import('../index.d.ts').Options>} inlineOptions
- * @returns {Promise<Partial<import('../index.d.ts').SvelteOptions> | undefined>}
- */
+/** @type {import('../index.d.ts').loadSvelteConfig} */
 export async function loadSvelteConfig(viteConfig, inlineOptions) {
 	if (inlineOptions?.configFile === false) {
 		return;
@@ -90,7 +85,6 @@ export async function loadSvelteConfig(viteConfig, inlineOptions) {
 }
 
 /**
- *
  * @param {import('vite').UserConfig | undefined} viteConfig
  * @param {Partial<import('../index.d.ts').Options> | undefined} inlineOptions
  * @returns {string | undefined}

--- a/packages/vite-plugin-svelte/src/utils/log.ts
+++ b/packages/vite-plugin-svelte/src/utils/log.ts
@@ -5,7 +5,7 @@ import debug from 'debug';
 /** @type {import('../types/log.d.ts').LogLevel[]} */
 const levels = ['debug', 'info', 'warn', 'error', 'silent'];
 const prefix = 'vite-plugin-svelte';
-/** @type {Record<import('../types/log.d.ts').LogLevel,any>} */
+/** @type {Record<import('../types/log.d.ts').LogLevel, any>} */
 const loggers = {
 	debug: {
 		log: debug(`vite:${prefix}`),
@@ -35,7 +35,6 @@ const loggers = {
 /** @type {import('../types/log.d.ts').LogLevel} */
 let _level = 'info';
 /**
- *
  * @param {import('../types/log.d.ts').LogLevel} level
  * @returns {void}
  */
@@ -55,11 +54,10 @@ function setLevel(level) {
 }
 
 /**
- *
  * @param {any} logger
  * @param {string} message
- * @param {any=} payload
- * @param {string=} namespace
+ * @param {any} [payload]
+ * @param {string} [namespace]
  * @returns
  */
 function _log(logger, message, payload, namespace) {
@@ -84,16 +82,15 @@ function _log(logger, message, payload, namespace) {
 }
 
 /**
- *
  * @param {import('../types/log.d.ts').LogLevel} level
  * @returns {import('../types/log.d.ts').LogFn}
  */
 function createLogger(level) {
 	const logger = loggers[level];
-	const logFn = /** @type {import('../types/log.d.ts').LogFn}*/ _log.bind(null, logger);
-	/**@type {Set<string>} */
+	const logFn = /** @type {import('../types/log.d.ts').LogFn} */ (_log.bind(null, logger));
+	/** @type {Set<string>} */
 	const logged = new Set();
-	/**@type {import('../types/log.d.ts').SimpleLogFn} */
+	/** @type {import('../types/log.d.ts').SimpleLogFn} */
 	const once = function (message, payload, namespace) {
 		if (!logger.enabled || logged.has(message)) {
 			return;
@@ -111,7 +108,7 @@ function createLogger(level) {
 			return once;
 		}
 	});
-	return /** @type {import('../types/log.d.ts').LogFn}*/ logFn;
+	return logFn;
 }
 
 export const log = {
@@ -123,23 +120,22 @@ export const log = {
 };
 
 /**
- *
  * @param {import('../types/id.d.ts').SvelteRequest} svelteRequest
- * @param {import('../index.d.ts').Warning[]} warnings
+ * @param {import('svelte/types/compiler/interfaces').Warning[]} warnings
  * @param {import('../types/options.d.ts').ResolvedOptions} options
  */
 export function logCompilerWarnings(svelteRequest, warnings, options) {
 	const { emitCss, onwarn, isBuild } = options;
 	const sendViaWS = !isBuild && options.experimental?.sendWarningsToBrowser;
 	let warn = isBuild ? warnBuild : warnDev;
-	/** @type {import('../index.d.ts').Warning[]} */
+	/** @type {import('svelte/types/compiler/interfaces').Warning[]} */
 	const handledByDefaultWarn = [];
 	const notIgnored = warnings?.filter((w) => !ignoreCompilerWarning(w, isBuild, emitCss));
 	const extra = buildExtraWarnings(warnings, isBuild);
 	const allWarnings = [...notIgnored, ...extra];
 	if (sendViaWS) {
 		const _warn = warn;
-		/** @type {(w:import('../index.d.ts').Warning ) => void} */
+		/** @type {(w: import('svelte/types/compiler/interfaces').Warning) => void} */
 		warn = (w) => {
 			handledByDefaultWarn.push(w);
 			_warn(w);
@@ -169,11 +165,10 @@ export function logCompilerWarnings(svelteRequest, warnings, options) {
 }
 
 /**
- *
- * @param {import('../index.d.ts').Warning} warning
+ * @param {import('svelte/types/compiler/interfaces').Warning} warning
  * @param {boolean} isBuild
- * @param {boolean=} emitCss
- * @returns
+ * @param {boolean} [emitCss]
+ * @returns {boolean}
  */
 function ignoreCompilerWarning(warning, isBuild, emitCss) {
 	return (
@@ -184,7 +179,7 @@ function ignoreCompilerWarning(warning, isBuild, emitCss) {
 
 /**
  *
- * @param {import('../index.d.ts').Warning} warning
+ * @param {import('svelte/types/compiler/interfaces').Warning} warning
  * @returns {boolean}
  */
 function isNoScopableElementWarning(warning) {
@@ -194,9 +189,9 @@ function isNoScopableElementWarning(warning) {
 
 /**
  *
- * @param {import('../index.d.ts').Warning[]} warnings
+ * @param {import('svelte/types/compiler/interfaces').Warning[]} warnings
  * @param {boolean} isBuild
- * @returns {import('../index.d.ts').Warning[]}
+ * @returns {import('svelte/types/compiler/interfaces').Warning[]}
  */
 function buildExtraWarnings(warnings, isBuild) {
 	const extraWarnings = [];
@@ -217,24 +212,21 @@ function buildExtraWarnings(warnings, isBuild) {
 }
 
 /**
- *
- * @param {import('../index.d.ts').Warning} w
+ * @param {import('svelte/types/compiler/interfaces').Warning} w
  */
 function warnDev(w) {
 	log.info.enabled && log.info(buildExtendedLogMessage(w));
 }
 
 /**
- *
- * @param {import('../index.d.ts').Warning} w
+ * @param {import('svelte/types/compiler/interfaces').Warning} w
  */
 function warnBuild(w) {
 	log.warn.enabled && log.warn(buildExtendedLogMessage(w), w.frame);
 }
 
 /**
- *
- * @param {import('../index.d.ts').Warning} w
+ * @param {import('svelte/types/compiler/interfaces').Warning} w
  */
 export function buildExtendedLogMessage(w) {
 	const parts = [];
@@ -254,7 +246,6 @@ export function buildExtendedLogMessage(w) {
 }
 
 /**
- *
  * @param {string} namespace
  * @returns {boolean}
  */

--- a/packages/vite-plugin-svelte/src/utils/optimizer.ts
+++ b/packages/vite-plugin-svelte/src/utils/optimizer.ts
@@ -40,12 +40,11 @@ export async function saveSvelteMetadata(cacheDir, options) {
 }
 
 /**
- *
  * @param {import('../types/options.d.ts').ResolvedOptions} options
  * @returns {Partial<import('../types/options.d.ts').ResolvedOptions>}
  */
 function generateSvelteMetadata(options) {
-	/** @type {Record<string,any>} */
+	/** @type {Record<string, any>} */
 	const metadata = {};
 	for (const key of PREBUNDLE_SENSITIVE_OPTIONS) {
 		metadata[key] = options[key];

--- a/packages/vite-plugin-svelte/src/utils/options.ts
+++ b/packages/vite-plugin-svelte/src/utils/options.ts
@@ -43,8 +43,7 @@ const knownRootOptions = new Set(['extensions', 'compilerOptions', 'preprocess',
 const allowedInlineOptions = new Set(['configFile', ...allowedPluginOptions, ...knownRootOptions]);
 
 /**
- *
- * @param {Partial<import('../index.d.ts').Options>=} inlineOptions
+ * @param {Partial<import('../index.d.ts').Options>} [inlineOptions]
  */
 export function validateInlineOptions(inlineOptions) {
 	const invalidKeys = Object.keys(inlineOptions || {}).filter(
@@ -54,9 +53,9 @@ export function validateInlineOptions(inlineOptions) {
 		log.warn(`invalid plugin options "${invalidKeys.join(', ')}" in inline config`, inlineOptions);
 	}
 }
+
 /**
- *
- * @param {Partial<import('../index.d.ts').SvelteOptions>=} config
+ * @param {Partial<import('../index.d.ts').SvelteOptions>} [config]
  * @returns {Partial<import('../index.d.ts').Options> | undefined}
  */
 function convertPluginOptions(config) {
@@ -152,11 +151,8 @@ export async function preResolveOptions(inlineOptions, viteUserConfig, viteEnv) 
 		isDebug: process.env.DEBUG != null
 	};
 
-	const merged = /** @type {import('../types/options.d.ts').PreResolvedOptions}*/ mergeConfigs(
-		defaultOptions,
-		svelteConfig,
-		inlineOptions,
-		extraOptions
+	const merged = /** @type {import('../types/options.d.ts').PreResolvedOptions} */ (
+		mergeConfigs(defaultOptions, svelteConfig, inlineOptions, extraOptions)
 	);
 	// configFile of svelteConfig contains the absolute path it was loaded from,
 	// prefer it over the possibly relative inline path
@@ -175,7 +171,7 @@ function mergeConfigs(...configs) {
 	/** @type {Partial<T>} */
 	let result = {};
 	for (const config of configs.filter((x) => x != null)) {
-		result = deepmerge(result, /**@type {Partial<T>} */ config, {
+		result = deepmerge(result, /** @type {Partial<T>} */ (config), {
 			// replace arrays
 			arrayMerge: (target, source) => source ?? target
 		});
@@ -211,10 +207,8 @@ export function resolveOptions(preResolveOptions, viteConfig, cache) {
 		root: viteConfig.root,
 		isProduction: viteConfig.isProduction
 	};
-	const merged = /** @type {import('../types/options.d.ts').ResolvedOptions}*/ mergeConfigs(
-		defaultOptions,
-		preResolveOptions,
-		extraOptions
+	const merged = /** @type {import('../types/options.d.ts').ResolvedOptions}*/ (
+		mergeConfigs(defaultOptions, preResolveOptions, extraOptions)
 	);
 
 	removeIgnoredOptions(merged);
@@ -319,7 +313,7 @@ function removeIgnoredOptions(options) {
  * @param {import('../types/options.d.ts').ResolvedOptions} options
  */
 function handleDeprecatedOptions(options) {
-	const experimental = /** @type {Record<string,any>} */ options.experimental;
+	const experimental = /** @type {Record<string, any>} */ (options.experimental);
 	if (experimental) {
 		for (const promoted of ['prebundleSvelteLibraries', 'inspector']) {
 			if (experimental[promoted]) {
@@ -344,14 +338,13 @@ function handleDeprecatedOptions(options) {
  * @see https://github.com/vitejs/vite/blob/43c957de8a99bb326afd732c962f42127b0a4d1e/packages/vite/src/node/config.ts#L293
  *
  * @param {import('vite').UserConfig} viteConfig
- * @returns {string|undefined}
+ * @returns {string | undefined}
  */
 function resolveViteRoot(viteConfig) {
 	return normalizePath(viteConfig.root ? path.resolve(viteConfig.root) : process.cwd());
 }
 
 /**
- *
  * @param {import('../types/options.d.ts').PreResolvedOptions} options
  * @param {import('vite').UserConfig} config
  * @returns {Promise<Partial<import('vite').UserConfig>>}
@@ -443,7 +436,6 @@ export async function buildExtraViteConfig(options, config) {
 }
 
 /**
- *
  * @param {Partial<import('vite').UserConfig>} extraViteConfig
  * @param {import('vite').UserConfig} config
  * @param {import('../types/options.d.ts').PreResolvedOptions} options
@@ -453,7 +445,7 @@ function validateViteConfig(extraViteConfig, config, options) {
 	if (prebundleSvelteLibraries) {
 		/** @type {(option: 'dev' | 'build' | boolean)=> boolean} */
 		const isEnabled = (option) => option !== true && option !== (isBuild ? 'build' : 'dev');
-		/** @type {(name: string,value: 'dev' | 'build' | boolean, recommendation: string)=> void} */
+		/** @type {(name: string, value: 'dev' | 'build' | boolean, recommendation: string)=> void} */
 		const logWarning = (name, value, recommendation) =>
 			log.warn.once(
 				`Incompatible options: \`prebundleSvelteLibraries: true\` and vite \`${name}: ${JSON.stringify(
@@ -483,7 +475,6 @@ function validateViteConfig(extraViteConfig, config, options) {
 }
 
 /**
- *
  * @param {import('../types/options.d.ts').PreResolvedOptions} options
  * @param {import('vite').UserConfig} config
  * @returns {Promise<import('vitefu').CrawlFrameworkPkgsResult>}
@@ -560,7 +551,6 @@ async function buildExtraConfigForDependencies(options, config) {
 }
 
 /**
- *
  * @param {import('vite').UserConfig} config
  * @returns {import('vite').UserConfig & { optimizeDeps: { include: string[], exclude:string[] }, ssr: { noExternal:(string|RegExp)[], external: string[] } } }
  */
@@ -578,7 +568,7 @@ function buildExtraConfigForSvelte(config) {
 	} else {
 		log.debug('"svelte" is excluded in optimizeDeps.exclude, skipped adding it to include.');
 	}
-	/** @type {(string|RegExp)[]} */
+	/** @type {(string | RegExp)[]} */
 	const noExternal = [];
 	/** @type {string[]} */
 	const external = [];
@@ -591,7 +581,6 @@ function buildExtraConfigForSvelte(config) {
 }
 
 /**
- *
  * @param {import('vite').ResolvedConfig} viteConfig
  * @param {import('../types/options.d.ts').ResolvedOptions} options
  */
@@ -615,7 +604,7 @@ export function patchResolvedViteConfig(viteConfig, options) {
 
 /**
  * @template T
- * @param {T|T[]} value
+ * @param {T | T[]} value
  * @returns {T[]}
  */
 function arraify(value) {

--- a/packages/vite-plugin-svelte/src/utils/preprocess.ts
+++ b/packages/vite-plugin-svelte/src/utils/preprocess.ts
@@ -8,7 +8,7 @@ import path from 'path';
  *
  * only used during dev with enabled css hmr
  *
- * @returns {import('../index.d.ts').PreprocessorGroup}
+ * @returns {import('svelte/types/compiler/preprocess').PreprocessorGroup}
  */
 export function createInjectScopeEverythingRulePreprocessorGroup() {
 	return {
@@ -27,15 +27,17 @@ export function createInjectScopeEverythingRulePreprocessorGroup() {
 }
 
 /**
- *
  * @param {import('../types/options.d.ts').ResolvedOptions} options
  * @param {import('vite').ResolvedConfig} config
- * @returns {{ prependPreprocessors:import('../index.d.ts').PreprocessorGroup[], appendPreprocessors:import('../index.d.ts').PreprocessorGroup[] }}
+ * @returns {{
+ * 	prependPreprocessors: import('svelte/types/compiler/preprocess').PreprocessorGroup[],
+ * 	appendPreprocessors: import('svelte/types/compiler/preprocess').PreprocessorGroup[]
+ * }}
  */
 function buildExtraPreprocessors(options, config) {
-	/** @type {import('../index.d.ts').PreprocessorGroup[]} */
+	/** @type {import('svelte/types/compiler/preprocess').PreprocessorGroup[]} */
 	const prependPreprocessors = [];
-	/** @type {import('../index.d.ts').PreprocessorGroup[]} */
+	/** @type {import('svelte/types/compiler/preprocess').PreprocessorGroup[]} */
 	const appendPreprocessors = [];
 
 	// @ts-ignore
@@ -98,7 +100,6 @@ function buildExtraPreprocessors(options, config) {
 }
 
 /**
- *
  * @param {import('../types/options.d.ts').ResolvedOptions} options
  * @param {import('vite').ResolvedConfig} config
  */

--- a/packages/vite-plugin-svelte/src/utils/resolve.ts
+++ b/packages/vite-plugin-svelte/src/utils/resolve.ts
@@ -4,11 +4,10 @@ import { resolveDependencyData, isCommonDepWithoutSvelteField } from './dependen
 import { normalizePath } from 'vite';
 
 /**
- *
  * @param {string} importee
- * @param {string|undefined} importer
+ * @param {string | undefined} importer
  * @param {import('./vite-plugin-svelte-cache').VitePluginSvelteCache} cache
- * @returns {Promise<string|void>}
+ * @returns {Promise<string | void>}
  */
 export async function resolveViaPackageJsonSvelte(importee, importer, cache) {
 	if (
@@ -34,7 +33,6 @@ export async function resolveViaPackageJsonSvelte(importee, importer, cache) {
 }
 
 /**
- *
  * @param {string} importee
  * @returns {boolean}
  */
@@ -43,7 +41,6 @@ function isNodeInternal(importee) {
 }
 
 /**
- *
  * @param {string} importee
  * @returns {boolean}
  */

--- a/packages/vite-plugin-svelte/src/utils/sourcemaps.ts
+++ b/packages/vite-plugin-svelte/src/utils/sourcemaps.ts
@@ -1,12 +1,21 @@
 import path from 'path';
+
 const IS_WINDOWS = process.platform === 'win32';
+
+/**
+ * @typedef {{
+ *  file?: string;
+ *  sources?: string[];
+ *  sourceRoot?: string;
+ * }} SourceMapFileRefs
+ */
 
 /**
  * convert absolute paths in sourcemap file refs to their relative equivalents to avoid leaking fs info
  *
  * map is modified in place.
  *
- * @param {import('../types/sourcemaps.d.ts').SourceMapFileRefs | undefined} map sourcemap
+ * @param {SourceMapFileRefs | undefined} map sourcemap
  * @param {string} filename absolute path to file the sourcemap is for
  */
 export function mapToRelative(map, filename) {
@@ -16,7 +25,7 @@ export function mapToRelative(map, filename) {
 	const sourceRoot = map.sourceRoot;
 	const dirname = path.dirname(filename);
 
-	/** @type {(s:string)=> string} */
+	/** @type {(s: string) => string} */
 	const toRelative = (s) => {
 		if (!s) {
 			return s;
@@ -54,7 +63,7 @@ export function mapToRelative(map, filename) {
  *
  * map is modified in place.
  *
- * @param {import('../types/sourcemaps.d.ts').SourceMapFileRefs | undefined} map the output sourcemap
+ * @param {SourceMapFileRefs | undefined} map the output sourcemap
  * @param {string} suffix the suffix to remove
  */
 export function removeLangSuffix(map, suffix) {

--- a/packages/vite-plugin-svelte/src/utils/svelte-version.ts
+++ b/packages/vite-plugin-svelte/src/utils/svelte-version.ts
@@ -2,7 +2,6 @@ import { VERSION } from 'svelte/compiler';
 const svelteVersion = parseVersion(VERSION);
 
 /**
- *
  * @param {string} version
  * @returns {number[]}
  */
@@ -17,8 +16,9 @@ export function parseVersion(version) {
 /**
  * compare version with current svelte, only takes major.minor.patch into account.
  * If you don't pass all three, values will be filled with 0, ie `3` is equal to `3.0.0`
+ *
  * @param {string} version
- * @returns {1|0|-1} 1 if passed version is larger than current, 0 if it is equal and -1 if it is lower
+ * @returns {1 | 0 | -1} 1 if passed version is larger than current, 0 if it is equal and -1 if it is lower
  */
 export function compareToSvelte(version) {
 	const parsedVersion = parseVersion(version);
@@ -37,7 +37,6 @@ export function compareToSvelte(version) {
 }
 
 /**
- *
  * @param {string} version
  * @returns {boolean}
  */

--- a/packages/vite-plugin-svelte/src/utils/vite-plugin-svelte-cache.ts
+++ b/packages/vite-plugin-svelte/src/utils/vite-plugin-svelte-cache.ts
@@ -4,22 +4,31 @@ import { findClosestPkgJsonPath } from 'vitefu';
 import { normalizePath } from 'vite';
 
 /**
+ * @typedef {{
+ * 	name: string;
+ * 	version: string;
+ * 	svelte?: string;
+ * 	path: string;
+ * }} PackageInfo
+ */
+
+/**
  * @class
  */
 export class VitePluginSvelteCache {
-	/**@type {Map<string,import('../types/compile.d.ts').Code>} */
+	/** @type {Map<string, import('../types/compile.d.ts').Code>} */
 	#css = new Map();
-	/**@type {Map<string,import('../types/compile.d.ts').Code>} */
+	/** @type {Map<string, import('../types/compile.d.ts').Code>} */
 	#js = new Map();
-	/**@type {Map<string, string[]>} */
+	/** @type {Map<string, string[]>} */
 	#dependencies = new Map();
-	/**@type {Map<string, Set<string>>} */
+	/** @type {Map<string, Set<string>>} */
 	#dependants = new Map();
-	/**@type {Map<string, string>} */
+	/** @type {Map<string, string>} */
 	#resolvedSvelteFields = new Map();
-	/**@type {Map<string, any>} */
+	/** @type {Map<string, any>} */
 	#errors = new Map();
-	/**@type {import('../types/vite-plugin-svelte-cache.d.ts').PackageInfo[]} */
+	/** @type {PackageInfo[]} */
 	#packageInfos = [];
 
 	/**
@@ -33,7 +42,6 @@ export class VitePluginSvelteCache {
 	}
 
 	/**
-	 *
 	 * @param {import('../types/id.d.ts').SvelteRequest} svelteRequest
 	 * @returns {boolean}
 	 */
@@ -43,7 +51,6 @@ export class VitePluginSvelteCache {
 	}
 
 	/**
-	 *
 	 * @param {import('../types/id.d.ts').SvelteRequest} svelteRequest
 	 * @param {any} error
 	 */
@@ -85,17 +92,16 @@ export class VitePluginSvelteCache {
 			if (!this.#dependants.has(d)) {
 				this.#dependants.set(d, new Set());
 			}
-			/** @type {Set<string>} */ this.#dependants.get(d).add(compileData.filename);
+			/** @type {Set<string>} */ (this.#dependants.get(d)).add(compileData.filename);
 		});
 		removed.forEach((d) => {
-			/** @type {Set<string>} */ this.#dependants.get(d).delete(compileData.filename);
+			/** @type {Set<string>} */ (this.#dependants.get(d)).delete(compileData.filename);
 		});
 	}
 
 	/**
-	 *
 	 * @param {import('../types/id.d.ts').SvelteRequest} svelteRequest
-	 * @param {boolean=} keepDependencies
+	 * @param {boolean} [keepDependencies]
 	 * @returns {boolean}
 	 */
 	remove(svelteRequest, keepDependencies = false) {
@@ -164,7 +170,7 @@ export class VitePluginSvelteCache {
 
 	/**
 	 * @param {string} name
-	 * @param {string=} importer
+	 * @param {string} [importer]
 	 * @returns {string|void}
 	 */
 	getResolvedSvelteField(name, importer) {
@@ -173,7 +179,7 @@ export class VitePluginSvelteCache {
 
 	/**
 	 * @param {string} name
-	 * @param {string=} importer
+	 * @param {string} [importer]
 	 * @returns {boolean}
 	 */
 	hasResolvedSvelteField(name, importer) {
@@ -203,7 +209,7 @@ export class VitePluginSvelteCache {
 
 	/**
 	 * @param {string} file
-	 * @returns {Promise<import('../types/vite-plugin-svelte-cache.d.ts').PackageInfo>}
+	 * @returns {Promise<PackageInfo>}
 	 */
 	async getPackageInfo(file) {
 		let info = this.#packageInfos.find((pi) => file.startsWith(pi.path));
@@ -219,10 +225,10 @@ export class VitePluginSvelteCache {
  * utility to get some info from the closest package.json with a "name" set
  *
  * @param {string} file to find info for
- * @returns {Promise<import('../types/vite-plugin-svelte-cache.d.ts').PackageInfo>}
+ * @returns {Promise<PackageInfo>}
  */
 async function findPackageInfo(file) {
-	/** @type {import('../types/vite-plugin-svelte-cache.d.ts').PackageInfo} */
+	/** @type {PackageInfo} */
 	const info = {
 		name: '$unknown',
 		version: '0.0.0-unknown',

--- a/packages/vite-plugin-svelte/src/utils/vite-plugin-svelte-stats.ts
+++ b/packages/vite-plugin-svelte/src/utils/vite-plugin-svelte-stats.ts
@@ -11,7 +11,6 @@ const defaultCollectionOptions = {
 };
 
 /**
- *
  * @param {number} n
  * @returns
  */
@@ -21,7 +20,6 @@ function humanDuration(n) {
 }
 
 /**
- *
  * @param {import('../types/vite-plugin-svelte-stats.d.ts').PackageStats[]} pkgStats
  * @returns {string}
  */
@@ -70,17 +68,17 @@ export class VitePluginSvelteStats {
 	#cache;
 	/** @type {import('../types/vite-plugin-svelte-stats.d.ts').StatCollection[]} */
 	#collections = [];
+
 	/**
-	 *
 	 * @param {import('./vite-plugin-svelte-cache.js').VitePluginSvelteCache} cache
 	 */
 	constructor(cache) {
 		this.#cache = cache;
 	}
+
 	/**
-	 *
 	 * @param {string} name
-	 * @param {Partial<import('../types/vite-plugin-svelte-stats.d.ts').CollectionOptions>=} opts
+	 * @param {Partial<import('../types/vite-plugin-svelte-stats.d.ts').CollectionOptions>} [opts]
 	 * @returns {import('../types/vite-plugin-svelte-stats.d.ts').StatCollection}
 	 */
 	startCollection(name, opts) {
@@ -131,7 +129,6 @@ export class VitePluginSvelteStats {
 	}
 
 	/**
-	 *
 	 * @param {import('../types/vite-plugin-svelte-stats.d.ts').StatCollection} collection
 	 */
 	async #finish(collection) {
@@ -170,7 +167,6 @@ export class VitePluginSvelteStats {
 	}
 
 	/**
-	 *
 	 * @param {import('../types/vite-plugin-svelte-stats.d.ts').StatCollection} collection
 	 */
 	async #aggregateStatsResult(collection) {
@@ -180,7 +176,7 @@ export class VitePluginSvelteStats {
 		}
 
 		// group stats
-		/** @type {Record<string,import('../types/vite-plugin-svelte-stats.d.ts').PackageStats>} */
+		/** @type {Record<string, import('../types/vite-plugin-svelte-stats.d.ts').PackageStats>} */
 		const grouped = {};
 		stats.forEach((stat) => {
 			const pkg = /** @type {string} */ (stat.pkg);

--- a/packages/vite-plugin-svelte/src/utils/watch.ts
+++ b/packages/vite-plugin-svelte/src/utils/watch.ts
@@ -4,11 +4,10 @@ import { knownSvelteConfigNames } from './load-svelte-config.js';
 import path from 'path';
 
 /**
- *
  * @param {import('../types/options.d.ts').ResolvedOptions} options
  * @param {import('./vite-plugin-svelte-cache').VitePluginSvelteCache} cache
  * @param {import('../types/id.d.ts').IdParser} requestParser
- * @returns
+ * @returns {void}
  */
 export function setupWatchers(options, cache, requestParser) {
 	const { server, configFile: svelteConfigFile } = options;
@@ -17,7 +16,7 @@ export function setupWatchers(options, cache, requestParser) {
 	}
 	const { watcher, ws } = server;
 	const { root, server: serverConfig } = server.config;
-	/**@type {(filename: string)=>void} */
+	/** @type {(filename: string) => void} */
 	const emitChangeEventOnDependants = (filename) => {
 		const dependants = cache.getDependants(filename);
 		dependants.forEach((dependant) => {
@@ -29,7 +28,7 @@ export function setupWatchers(options, cache, requestParser) {
 			}
 		});
 	};
-	/**@type {(filename: string)=>void} */
+	/** @type {(filename: string) => void} */
 	const removeUnlinkedFromCache = (filename) => {
 		const svelteRequest = requestParser(filename, false);
 		if (svelteRequest) {
@@ -39,7 +38,7 @@ export function setupWatchers(options, cache, requestParser) {
 			}
 		}
 	};
-	/**@type {(filename: string)=>void} */
+	/** @type {(filename: string) => void} */
 	const triggerViteRestart = (filename) => {
 		if (serverConfig.middlewareMode) {
 			// in middlewareMode we can't restart the server automatically
@@ -58,7 +57,7 @@ export function setupWatchers(options, cache, requestParser) {
 	};
 
 	// collection of watcher listeners by event
-	/** @type {Record<string,Function[]>} */
+	/** @type {Record<string, Function[]>} */
 	const listenerCollection = {
 		add: [],
 		change: [emitChangeEventOnDependants],
@@ -68,14 +67,14 @@ export function setupWatchers(options, cache, requestParser) {
 	if (svelteConfigFile !== false) {
 		// configFile false means we ignore the file and external process is responsible
 		const possibleSvelteConfigs = knownSvelteConfigNames.map((cfg) => path.join(root, cfg));
-		/**@type {(filename: string)=>void} */
+		/** @type {(filename: string) => void} */
 		const restartOnConfigAdd = (filename) => {
 			if (possibleSvelteConfigs.includes(filename)) {
 				triggerViteRestart(filename);
 			}
 		};
 
-		/**@type {(filename: string)=>void} */
+		/** @type {(filename: string) => void} */
 		const restartOnConfigChange = (filename) => {
 			if (filename === svelteConfigFile) {
 				triggerViteRestart(filename);
@@ -102,7 +101,7 @@ export function setupWatchers(options, cache, requestParser) {
  * @param {import('vite').FSWatcher} watcher
  * @param {string | null} file
  * @param {string} root
- * @returns void
+ * @returns {void}
  */
 export function ensureWatchedFile(watcher, file, root) {
 	if (


### PR DESCRIPTION
some jsdocs nits:

- space things up
- use `[paramName]` instead of `{type=}` for optional params
- use `@typedef` for one-off types in a file
- fix jsdoc typecast not working in vscode