### PR TITLE
update to svelte-hmr 0.15.2

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+pnpm-lock.yaml

--- a/packages/vite-plugin-svelte/package.json
+++ b/packages/vite-plugin-svelte/package.json
@@ -43,7 +43,7 @@
     "deepmerge": "^4.3.1",
     "kleur": "^4.1.5",
     "magic-string": "^0.30.0",
-    "svelte-hmr": "^0.15.1",
+    "svelte-hmr": "^0.15.2",
     "vitefu": "^0.2.4"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,8 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 overrides:
   '@sveltejs/vite-plugin-svelte': workspace:^
@@ -765,8 +769,8 @@ importers:
         specifier: ^0.30.0
         version: 0.30.0
       svelte-hmr:
-        specifier: ^0.15.1
-        version: 0.15.1(svelte@3.59.1)
+        specifier: ^0.15.2
+        version: 0.15.2(svelte@3.59.1)
       vitefu:
         specifier: ^0.2.4
         version: 0.2.4(vite@4.3.5)
@@ -5349,11 +5353,11 @@ packages:
       - sugarss
     dev: true
 
-  /svelte-hmr@0.15.1(svelte@3.59.1):
-    resolution: {integrity: sha512-BiKB4RZ8YSwRKCNVdNxK/GfY+r4Kjgp9jCLEy0DuqAKfmQtpL38cQK3afdpjw4sqSs4PLi3jIPJIFp259NkZtA==}
+  /svelte-hmr@0.15.2(svelte@3.59.1):
+    resolution: {integrity: sha512-q/bAruCvFLwvNbeE1x3n37TYFb3mTBJ6TrCq6p2CoFbSTNhDE9oAtEfpy+wmc9So8AG0Tja+X0/mJzX9tSfvIg==}
     engines: {node: ^12.20 || ^14.13.1 || >= 16}
     peerDependencies:
-      svelte: '>=3.19.0'
+      svelte: ^3.19.0 || ^4.0.0-next.0
     dependencies:
       svelte: 3.59.1
     dev: false


### PR DESCRIPTION
We should update `svelte-hmr` and do a new release to ensure users are updated to a compatible version of `svelte-hmr`. If we don't touch this then the lockfile will leave the last version of `svelte-hmr` used (i.e. `0.15.1`)