### PR TITLE
fix: remove pure comments only for Svelte 3

### DIFF
--- a/.changeset/long-dodos-report.md
+++ b/.changeset/long-dodos-report.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+fix: remove pure comments only for Svelte 3

--- a/packages/vite-plugin-svelte/src/utils/compile.js
+++ b/packages/vite-plugin-svelte/src/utils/compile.js
@@ -125,13 +125,15 @@ export const _createCompileSvelte = (makeHot) => {
 		const endStat = stats?.start(filename);
 		const compiled = compile(finalCode, finalCompileOptions);
 
-		// prevent dangling pure comments
-		// see https://github.com/sveltejs/kit/issues/9492#issuecomment-1487704985
-		// uses regex replace with whitespace to keep sourcemap/character count unmodified
-		compiled.js.code = compiled.js.code.replace(
-			/\/\* [@#]__PURE__ \*\/(\s*)$/gm,
-			'               $1'
-		);
+		if (isSvelte3) {
+			// prevent dangling pure comments
+			// see https://github.com/sveltejs/kit/issues/9492#issuecomment-1487704985
+			// uses regex replace with whitespace to keep sourcemap/character count unmodified
+			compiled.js.code = compiled.js.code.replace(
+				/\/\* [@#]__PURE__ \*\/(\s*)$/gm,
+				'               $1'
+			);
+		}
 		if (endStat) {
 			endStat();
 		}


### PR DESCRIPTION
depends on https://github.com/sveltejs/svelte/pull/8719 getting merged for Svelte 4