### PR TITLE
fix: add svelte/internal/disclose-version  to optimizeDeps.include

### DIFF
--- a/.changeset/dirty-carrots-clap.md
+++ b/.changeset/dirty-carrots-clap.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+add svelte/internal/disclose-version to vite config optimizeDeps.include by default

--- a/packages/vite-plugin-svelte/src/utils/constants.js
+++ b/packages/vite-plugin-svelte/src/utils/constants.js
@@ -6,6 +6,7 @@ export const SVELTE_IMPORTS = [
 	'svelte/animate',
 	'svelte/easing',
 	'svelte/internal',
+	'svelte/internal/disclose-version',
 	'svelte/motion',
 	'svelte/ssr',
 	'svelte/store',

--- a/packages/vite-plugin-svelte/src/utils/constants.js
+++ b/packages/vite-plugin-svelte/src/utils/constants.js
@@ -1,3 +1,5 @@
+import { isSvelte3 } from './svelte-version.js';
+
 export const VITE_RESOLVE_MAIN_FIELDS = ['module', 'jsnext:main', 'jsnext'];
 
 export const SVELTE_RESOLVE_MAIN_FIELDS = ['svelte'];
@@ -6,13 +8,16 @@ export const SVELTE_IMPORTS = [
 	'svelte/animate',
 	'svelte/easing',
 	'svelte/internal',
-	'svelte/internal/disclose-version',
 	'svelte/motion',
 	'svelte/ssr',
 	'svelte/store',
 	'svelte/transition',
 	'svelte'
 ];
+// TODO add to global list after dropping svelte 3
+if (!isSvelte3) {
+	SVELTE_IMPORTS.push('svelte/internal/disclose-version');
+}
 
 export const SVELTE_HMR_IMPORTS = [
 	'svelte-hmr/runtime/hot-api-esm.js',


### PR DESCRIPTION
it's used internally by svelte4, but vite dynamically discovering it leads to

```
9:33:40 PM [vite] ✨ new dependencies optimized: svelte/internal/disclose-version
9:33:40 PM [vite] ✨ optimized dependencies changed. reloading
```

so add it to our internal list thats used to generate optimizeDeps.include