### PR TITLE
fix: ignore @sveltejs/package and svelte2tsx for generated vite config

### DIFF
--- a/.changeset/six-cherries-hear.md
+++ b/.changeset/six-cherries-hear.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+fix(config): ignore @sveltejs/package and svelte2tsx for optimizeDeps.include and ssr.noExternal generated config

--- a/packages/e2e-tests/kit-node/__tests__/kit.spec.ts
+++ b/packages/e2e-tests/kit-node/__tests__/kit.spec.ts
@@ -16,7 +16,7 @@ import {
 
 import glob from 'tiny-glob';
 import path from 'path';
-import { describe, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 describe('kit-node', () => {
 	describe('index route', () => {
@@ -108,144 +108,140 @@ describe('kit-node', () => {
 			});
 		}
 
-		if (!isBuild) {
-			describe('hmr', () => {
-				const updatePage = editFileAndWaitForHmrComplete.bind(null, 'src/routes/+page.svelte');
+		describe.runIf(!isBuild)('hmr', () => {
+			const updatePage = editFileAndWaitForHmrComplete.bind(null, 'src/routes/+page.svelte');
 
+			it('should render additional html', async () => {
+				// add div 1
+				expect(await getEl('#hmr-test')).toBe(null);
+				await updatePage((content) =>
+					content.replace(
+						'<!-- HMR-TEMPLATE-INJECT -->',
+						'<div id="hmr-test">foo</div>\n<!-- HMR-TEMPLATE-INJECT -->'
+					)
+				);
+				expect(await getText(`#hmr-test`)).toBe('foo');
+
+				// add div 2
+				expect(await getEl('#hmr-test2')).toBe(null);
+				await updatePage((content) =>
+					content.replace(
+						'<!-- HMR-TEMPLATE-INJECT -->',
+						'<div id="hmr-test2">bar</div>\n<!-- HMR-TEMPLATE-INJECT -->'
+					)
+				);
+				expect(await getText(`#hmr-test`)).toBe('foo');
+				expect(await getText(`#hmr-test2`)).toBe('bar');
+				// remove div 1
+				await updatePage((content) => content.replace('<div id="hmr-test">foo</div>\n', ''));
+				expect(await getText(`#hmr-test`)).toBe(null);
+				expect(await getText(`#hmr-test2`)).toBe('bar');
+			});
+
+			it('should render additional child components', async () => {
+				let buttons = await page.$$('button');
+				expect(buttons).toHaveLength(1);
+				expect(await getText(buttons[0])).toBe('Clicks: 0');
+				await updatePage((content) =>
+					content.replace(
+						'<!-- HMR-TEMPLATE-INJECT -->',
+						'<Counter id="hmr-test-counter"/>\n<!-- HMR-TEMPLATE-INJECT -->'
+					)
+				);
+				buttons = await page.$$('button');
+				expect(buttons).toHaveLength(2);
+				expect(await getText(buttons[0])).toBe('Clicks: 0');
+				expect(await getText(buttons[1])).toBe('Clicks: 0');
+				await buttons[1].click();
+				expect(await getText(buttons[0])).toBe('Clicks: 0');
+				expect(await getText(buttons[1])).toBe('Clicks: 1');
+				await updatePage((content) => content.replace('<Counter id="hmr-test-counter"/>\n', ''));
+				buttons = await page.$$('button');
+				expect(buttons).toHaveLength(1);
+				expect(await getText(buttons[0])).toBe('Clicks: 0');
+			});
+
+			it('should apply changed styles', async () => {
+				expect(await getColor(`h1`)).toBe('rgb(255, 62, 0)');
+				await updatePage((content) => content.replace('color: #ff3e00', 'color: blue'));
+				expect(await getColor(`h1`)).toBe('blue');
+				await updatePage((content) => content.replace('color: blue', 'color: green'));
+				expect(await getColor(`h1`)).toBe('green');
+			});
+
+			it('should serve changes even after page reload', async () => {
+				expect(await getColor(`h1`)).toBe('green');
+				expect(await getText(`#hmr-test2`)).toBe('bar');
+				await reloadPage();
+				expect(await getColor(`h1`)).toBe('green');
+				expect(await getText(`#hmr-test2`)).toBe('bar');
+			});
+
+			describe('child component update', () => {
+				const updateChild = editFileAndWaitForHmrComplete.bind(null, 'src/lib/Child.svelte');
+				const updateCounter = editFileAndWaitForHmrComplete.bind(null, 'src/lib/Counter.svelte');
+				it('should preserve dom order', async () => {
+					expect(await getText('#before-child')).toBe('before-child');
+					expect(await getText('#test-child')).toBe('test-child');
+					expect(await getText('#after-child')).toBe('after-child');
+					expect(await getEl('#before-child + #test-child')).not.toBe(null);
+					expect(await getEl('#test-child + #after-child')).not.toBe(null);
+					await updateChild((content) =>
+						content.replace('<!-- HMR-TEMPLATE-INJECT -->', '-foo<!-- HMR-TEMPLATE-INJECT -->')
+					);
+					// for some reason the update takes longer to materialize, so wait for it to avoid subsequent errors
+					await page.getByText('test-child-foo').waitFor({ state: 'attached' });
+
+					expect(await getText('#before-child')).toBe('before-child');
+					expect(await getText('#test-child')).toBe('test-child-foo');
+					expect(await getText('#after-child')).toBe('after-child');
+					expect(await getEl('#before-child + #test-child')).not.toBe(null);
+					expect(await getEl('#test-child + #after-child')).not.toBe(null);
+				});
 				it('should render additional html', async () => {
 					// add div 1
-					expect(await getEl('#hmr-test')).toBe(null);
-					await updatePage((content) =>
+					expect(await getEl('#hmr-test3')).toBe(null);
+					await updateCounter((content) =>
 						content.replace(
 							'<!-- HMR-TEMPLATE-INJECT -->',
-							'<div id="hmr-test">foo</div>\n<!-- HMR-TEMPLATE-INJECT -->'
+							'<div id="hmr-test3">foo</div>\n<!-- HMR-TEMPLATE-INJECT -->'
 						)
 					);
-					expect(await getText(`#hmr-test`)).toBe('foo');
+					expect(await getText(`#hmr-test3`)).toBe('foo');
 
 					// add div 2
-					expect(await getEl('#hmr-test2')).toBe(null);
-					await updatePage((content) =>
+					expect(await getEl('#hmr-test4')).toBe(null);
+					await updateCounter((content) =>
 						content.replace(
 							'<!-- HMR-TEMPLATE-INJECT -->',
-							'<div id="hmr-test2">bar</div>\n<!-- HMR-TEMPLATE-INJECT -->'
+							'<div id="hmr-test4">bar</div>\n<!-- HMR-TEMPLATE-INJECT -->'
 						)
 					);
-					expect(await getText(`#hmr-test`)).toBe('foo');
-					expect(await getText(`#hmr-test2`)).toBe('bar');
+					expect(await getText(`#hmr-test3`)).toBe('foo');
+					expect(await getText(`#hmr-test4`)).toBe('bar');
 					// remove div 1
-					await updatePage((content) => content.replace('<div id="hmr-test">foo</div>\n', ''));
-					expect(await getText(`#hmr-test`)).toBe(null);
-					expect(await getText(`#hmr-test2`)).toBe('bar');
-				});
-
-				it('should render additional child components', async () => {
-					let buttons = await page.$$('button');
-					expect(buttons).toHaveLength(1);
-					expect(await getText(buttons[0])).toBe('Clicks: 0');
-					await updatePage((content) =>
-						content.replace(
-							'<!-- HMR-TEMPLATE-INJECT -->',
-							'<Counter id="hmr-test-counter"/>\n<!-- HMR-TEMPLATE-INJECT -->'
-						)
-					);
-					buttons = await page.$$('button');
-					expect(buttons).toHaveLength(2);
-					expect(await getText(buttons[0])).toBe('Clicks: 0');
-					expect(await getText(buttons[1])).toBe('Clicks: 0');
-					await buttons[1].click();
-					expect(await getText(buttons[0])).toBe('Clicks: 0');
-					expect(await getText(buttons[1])).toBe('Clicks: 1');
-					await updatePage((content) => content.replace('<Counter id="hmr-test-counter"/>\n', ''));
-					buttons = await page.$$('button');
-					expect(buttons).toHaveLength(1);
-					expect(await getText(buttons[0])).toBe('Clicks: 0');
+					await updateCounter((content) => content.replace('<div id="hmr-test3">foo</div>\n', ''));
+					expect(await getText(`#hmr-test3`)).toBe(null);
+					expect(await getText(`#hmr-test4`)).toBe('bar');
 				});
 
 				it('should apply changed styles', async () => {
-					expect(await getColor(`h1`)).toBe('rgb(255, 62, 0)');
-					await updatePage((content) => content.replace('color: #ff3e00', 'color: blue'));
-					expect(await getColor(`h1`)).toBe('blue');
-					await updatePage((content) => content.replace('color: blue', 'color: green'));
-					expect(await getColor(`h1`)).toBe('green');
+					expect(await getColor(`button`)).toBe('rgb(255, 62, 0)');
+					await updateCounter((content) => content.replace('color: #ff3e00', 'color: blue'));
+					expect(await getColor(`button`)).toBe('blue');
+					await updateCounter((content) => content.replace('color: blue', 'color: green'));
+					expect(await getColor(`button`)).toBe('green');
 				});
 
-				it('should serve changes even after page reload', async () => {
-					expect(await getColor(`h1`)).toBe('green');
-					expect(await getText(`#hmr-test2`)).toBe('bar');
-					await reloadPage();
-					expect(await getColor(`h1`)).toBe('green');
-					expect(await getText(`#hmr-test2`)).toBe('bar');
-				});
-
-				describe('child component update', () => {
-					const updateChild = editFileAndWaitForHmrComplete.bind(null, 'src/lib/Child.svelte');
-					const updateCounter = editFileAndWaitForHmrComplete.bind(null, 'src/lib/Counter.svelte');
-					it('should preserve dom order', async () => {
-						expect(await getText('#before-child')).toBe('before-child');
-						expect(await getText('#test-child')).toBe('test-child');
-						expect(await getText('#after-child')).toBe('after-child');
-						expect(await getEl('#before-child + #test-child')).not.toBe(null);
-						expect(await getEl('#test-child + #after-child')).not.toBe(null);
-						await updateChild((content) =>
-							content.replace('<!-- HMR-TEMPLATE-INJECT -->', '-foo<!-- HMR-TEMPLATE-INJECT -->')
-						);
-						// for some reason the update takes longer to materialize, so wait for it to avoid subsequent errors
-						await page.getByText('test-child-foo').waitFor({ state: 'attached' });
-
-						expect(await getText('#before-child')).toBe('before-child');
-						expect(await getText('#test-child')).toBe('test-child-foo');
-						expect(await getText('#after-child')).toBe('after-child');
-						expect(await getEl('#before-child + #test-child')).not.toBe(null);
-						expect(await getEl('#test-child + #after-child')).not.toBe(null);
-					});
-					it('should render additional html', async () => {
-						// add div 1
-						expect(await getEl('#hmr-test3')).toBe(null);
-						await updateCounter((content) =>
-							content.replace(
-								'<!-- HMR-TEMPLATE-INJECT -->',
-								'<div id="hmr-test3">foo</div>\n<!-- HMR-TEMPLATE-INJECT -->'
-							)
-						);
-						expect(await getText(`#hmr-test3`)).toBe('foo');
-
-						// add div 2
-						expect(await getEl('#hmr-test4')).toBe(null);
-						await updateCounter((content) =>
-							content.replace(
-								'<!-- HMR-TEMPLATE-INJECT -->',
-								'<div id="hmr-test4">bar</div>\n<!-- HMR-TEMPLATE-INJECT -->'
-							)
-						);
-						expect(await getText(`#hmr-test3`)).toBe('foo');
-						expect(await getText(`#hmr-test4`)).toBe('bar');
-						// remove div 1
-						await updateCounter((content) =>
-							content.replace('<div id="hmr-test3">foo</div>\n', '')
-						);
-						expect(await getText(`#hmr-test3`)).toBe(null);
-						expect(await getText(`#hmr-test4`)).toBe('bar');
-					});
-
-					it('should apply changed styles', async () => {
-						expect(await getColor(`button`)).toBe('rgb(255, 62, 0)');
-						await updateCounter((content) => content.replace('color: #ff3e00', 'color: blue'));
-						expect(await getColor(`button`)).toBe('blue');
-						await updateCounter((content) => content.replace('color: blue', 'color: green'));
-						expect(await getColor(`button`)).toBe('green');
-					});
-
-					it('should apply changed initial state', async () => {
-						expect(await getText('button')).toBe('Clicks: 0');
-						await updateCounter((content) => content.replace('let count = 0', 'let count = 2'));
-						expect(await getText('button')).toBe('Clicks: 2');
-						await updateCounter((content) => content.replace('let count = 2', 'let count = 0'));
-						expect(await getText('button')).toBe('Clicks: 0');
-					});
+				it('should apply changed initial state', async () => {
+					expect(await getText('button')).toBe('Clicks: 0');
+					await updateCounter((content) => content.replace('let count = 0', 'let count = 2'));
+					expect(await getText('button')).toBe('Clicks: 2');
+					await updateCounter((content) => content.replace('let count = 2', 'let count = 0'));
+					expect(await getText('button')).toBe('Clicks: 0');
 				});
 			});
-		}
+		});
 	});
 	describe('resolved config', () => {
 		it('should have generated values', async () => {
@@ -351,22 +347,21 @@ describe('kit-node', () => {
 			}
 		});
 	});
-	if (isBuild) {
-		describe('output', () => {
-			it('should produce hermetic build', async () => {
-				const outputFiles = await glob('./build/**/*', { cwd: testDir, filesOnly: true });
-				expect(outputFiles.length).toBeGreaterThan(10);
-				const dir = path.basename(testDir);
-				const leakingFiles = outputFiles.filter(
-					(f) => !f.endsWith('.png') && readFileContent(f).includes(dir)
+
+	describe.runIf(isBuild)('output', () => {
+		it('should produce hermetic build', async () => {
+			const outputFiles = await glob('./build/**/*', { cwd: testDir, filesOnly: true });
+			expect(outputFiles.length).toBeGreaterThan(10);
+			const dir = path.basename(testDir);
+			const leakingFiles = outputFiles.filter(
+				(f) => !f.endsWith('.png') && readFileContent(f).includes(dir)
+			);
+			if (leakingFiles.length > 0) {
+				console.error(
+					`These build output files leak parent dir: "${dir}"\n\t${leakingFiles.join('\n\t')}`
 				);
-				if (leakingFiles.length > 0) {
-					console.error(
-						`These build output files leak parent dir: "${dir}"\n\t${leakingFiles.join('\n\t')}`
-					);
-				}
-				expect(leakingFiles).toEqual([]);
-			});
+			}
+			expect(leakingFiles).toEqual([]);
 		});
-	}
+	});
 });

--- a/packages/e2e-tests/kit-node/package.json
+++ b/packages/e2e-tests/kit-node/package.json
@@ -7,11 +7,13 @@
     "build": "vite build",
     "preview": "vite preview",
     "check": "svelte-check --tsconfig ./jsconfig.json",
-    "check:watch": "svelte-check --tsconfig ./jsconfig.json --watch"
+    "check:watch": "svelte-check --tsconfig ./jsconfig.json --watch",
+    "package": "svelte-package && echo just here for testing, don't remove svelte-package!"
   },
   "devDependencies": {
     "@sveltejs/adapter-node": "^1.3.1",
     "@sveltejs/kit": "^1.22.4",
+    "@sveltejs/package": "^2.2.0",
     "e2e-test-dep-svelte-api-only": "file:../_test_dependencies/svelte-api-only",
     "e2e-test-dep-vite-plugins": "file:../_test_dependencies/vite-plugins",
     "svelte": "^4.1.2",

--- a/packages/e2e-tests/kit-node/vite.config.js
+++ b/packages/e2e-tests/kit-node/vite.config.js
@@ -1,5 +1,5 @@
 import { sveltekit } from '@sveltejs/kit/vite';
-import { transformValidation } from 'e2e-test-dep-vite-plugins';
+import { transformValidation, writeResolvedConfig } from 'e2e-test-dep-vite-plugins';
 
 /** @type {import('vite').UserConfig} */
 const config = {
@@ -15,7 +15,7 @@ const config = {
 		minify: false,
 		sourcemap: true // must be true for hermetic build test!
 	},
-	plugins: [transformValidation(), sveltekit()],
+	plugins: [transformValidation(), sveltekit(), writeResolvedConfig()],
 	optimizeDeps: {
 		// eagerly include these, otherwise vite optimizer might interfere with restarting while the test is running
 		include: ['svelte-i18n', 'e2e-test-dep-svelte-api-only']

--- a/packages/vite-plugin-svelte/src/utils/dependencies.js
+++ b/packages/vite-plugin-svelte/src/utils/dependencies.js
@@ -30,8 +30,9 @@ export async function resolveDependencyData(dep, parent) {
 const COMMON_DEPENDENCIES_WITHOUT_SVELTE_FIELD = [
 	'@lukeed/uuid',
 	'@playwright/test',
-	'@sveltejs/vite-plugin-svelte',
 	'@sveltejs/kit',
+	'@sveltejs/package',
+	'@sveltejs/vite-plugin-svelte',
 	'autoprefixer',
 	'cookie',
 	'dotenv',
@@ -43,6 +44,7 @@ const COMMON_DEPENDENCIES_WITHOUT_SVELTE_FIELD = [
 	'postcss',
 	'prettier',
 	'svelte',
+	'svelte2tsx',
 	'svelte-check',
 	'svelte-hmr',
 	'svelte-preprocess',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -365,6 +365,9 @@ importers:
       '@sveltejs/kit':
         specifier: ^1.22.4
         version: 1.22.4(svelte@4.1.2)(vite@4.4.8)
+      '@sveltejs/package':
+        specifier: ^2.2.0
+        version: 2.2.0(svelte@4.1.2)(typescript@5.1.6)
       e2e-test-dep-svelte-api-only:
         specifier: file:../_test_dependencies/svelte-api-only
         version: file:packages/e2e-tests/_test_dependencies/svelte-api-only
@@ -1519,6 +1522,23 @@ packages:
       vite: 4.4.8(@types/node@18.17.3)(sass@1.64.2)(stylus@0.59.0)
     dev: true
 
+  /@sveltejs/package@2.2.0(svelte@4.1.2)(typescript@5.1.6):
+    resolution: {integrity: sha512-TXbrzsk+T5WNcSzrU41D8P32vU5guo96lVS11/R+rpLhZBH5sORh0Qp6r68Jg4O5vcdS3JLwpwcpe8VFbT/QeA==}
+    engines: {node: ^16.14 || >=18}
+    hasBin: true
+    peerDependencies:
+      svelte: ^3.44.0 || ^4.0.0
+    dependencies:
+      chokidar: 3.5.3
+      kleur: 4.1.5
+      sade: 1.8.1
+      semver: 7.5.4
+      svelte: 4.1.2
+      svelte2tsx: 0.6.19(svelte@4.1.2)(typescript@5.1.6)
+    transitivePeerDependencies:
+      - typescript
+    dev: true
+
   /@svitejs/changesets-changelog-github-compact@1.1.0:
     resolution: {integrity: sha512-qhUGGDHcpbY2zpjW3SwqchuW8J/5EzlPFud7xNntHKA7f3a/mx5+g+ruJKFHSAiVZYo30PALt+AyhmPUNKH/Og==}
     engines: {node: ^14.13.1 || ^16.0.0 || >=18}
@@ -2496,6 +2516,10 @@ packages:
   /decamelize@6.0.0:
     resolution: {integrity: sha512-Fv96DCsdOgB6mdGl67MT5JaTNKRzrzill5OH5s8bjYJXVlcXyPYGyPsUkWyGV5p1TXI5esYIYMMeDJL0hEIwaA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dev: true
+
+  /dedent-js@1.0.1:
+    resolution: {integrity: sha512-OUepMozQULMLUmhxS95Vudo0jb0UchLimi3+pQ2plj61Fcy8axbP9hbiD4Sz6DPqn6XG3kfmziVfQ1rSys5AJQ==}
     dev: true
 
   /deep-eql@4.1.3:
@@ -4063,6 +4087,12 @@ packages:
       get-func-name: 2.0.0
     dev: true
 
+  /lower-case@2.0.2:
+    resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
+    dependencies:
+      tslib: 2.6.0
+    dev: true
+
   /lru-cache@4.1.5:
     resolution: {integrity: sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==}
     dependencies:
@@ -4320,6 +4350,13 @@ packages:
 
   /nice-try@1.0.5:
     resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
+    dev: true
+
+  /no-case@3.0.4:
+    resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
+    dependencies:
+      lower-case: 2.0.2
+      tslib: 2.6.0
     dev: true
 
   /node-domexception@1.0.0:
@@ -4599,6 +4636,13 @@ packages:
   /parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
+
+  /pascal-case@3.1.2:
+    resolution: {integrity: sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==}
+    dependencies:
+      no-case: 3.0.4
+      tslib: 2.6.0
+    dev: true
 
   /path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -5679,6 +5723,18 @@ packages:
       strip-indent: 3.0.0
       svelte: 4.1.2
       typescript: 4.9.5
+    dev: true
+
+  /svelte2tsx@0.6.19(svelte@4.1.2)(typescript@5.1.6):
+    resolution: {integrity: sha512-h3b5OtcO8zyVL/RiB2zsDwCopeo/UH+887uyhgb2mjnewOFwiTxu+4IGuVwrrlyuh2onM2ktfUemNrNmQwXONQ==}
+    peerDependencies:
+      svelte: ^3.55 || ^4.0.0-next.0 || ^4.0
+      typescript: ^4.9.4 || ^5.0.0
+    dependencies:
+      dedent-js: 1.0.1
+      pascal-case: 3.1.2
+      svelte: 4.1.2
+      typescript: 5.1.6
     dev: true
 
   /svelte@4.1.2:


### PR DESCRIPTION
fixes #710 

our vitefu setup detected `@sveltejs/package` as a library that uses svelte because of it's peer dep on svelte. But in this case it isn't used when building the actual application, so we have to ignore it here.

