### PR TITLE
chore(changesets): prevent bumping inspector dependency on patches

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -9,5 +9,6 @@
 	"access": "public",
 	"baseBranch": "main",
 	"bumpVersionsWithWorkspaceProtocolOnly": true,
+	"updateInternalDependencies": "minor",
 	"ignore": ["!(@sveltejs/*)"]
 }

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   "pnpm": {
     "overrides": {
       "@sveltejs/vite-plugin-svelte": "workspace:^",
+      "@sveltejs/vite-plugin-svelte-inspector": "workspace:^",
       "semver@<7.5.2": ">=7.5.2",
       "svelte": "$svelte",
       "vite": "$vite"

--- a/packages/vite-plugin-svelte/package.json
+++ b/packages/vite-plugin-svelte/package.json
@@ -38,7 +38,7 @@
   },
   "homepage": "https://github.com/sveltejs/vite-plugin-svelte#readme",
   "dependencies": {
-    "@sveltejs/vite-plugin-svelte-inspector": "workspace:^",
+    "@sveltejs/vite-plugin-svelte-inspector": "^1.0.3",
     "debug": "^4.3.4",
     "deepmerge": "^4.3.1",
     "kleur": "^4.1.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   '@sveltejs/vite-plugin-svelte': workspace:^
+  '@sveltejs/vite-plugin-svelte-inspector': workspace:^
   semver@<7.5.2: '>=7.5.2'
   svelte: ^4.1.2
   vite: ^4.4.9


### PR DESCRIPTION
use updateInternalDependencies:  'minor' and hide  the "workspace:^" selector from changesets by applying it in an override.