### PR TITLE
chore: match svelte and kit eslint config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,7 +11,7 @@ module.exports = {
 		Atomics: 'readonly',
 		SharedArrayBuffer: 'readonly'
 	},
-	plugins: ['@typescript-eslint', 'html', 'markdown'],
+	plugins: ['@typescript-eslint', 'html', 'markdown', 'unicorn'],
 	parser: '@typescript-eslint/parser',
 	parserOptions: {
 		sourceType: 'module',
@@ -56,7 +56,9 @@ module.exports = {
 		],
 		'n/no-unpublished-import': 'off',
 		'n/no-unpublished-require': 'off',
-		'no-process-exit': 'off'
+		'no-process-exit': 'off',
+		quotes: ['error', 'single', { avoidEscape: true }],
+		'unicorn/prefer-node-protocol': 'error'
 	},
 	overrides: [
 		{

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "eslint-plugin-n": "^16.0.1",
     "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-svelte": "^2.32.4",
+    "eslint-plugin-unicorn": "^48.0.1",
     "execa": "^7.2.0",
     "fs-extra": "^11.1.1",
     "husky": "^8.0.3",

--- a/packages/e2e-tests/_test_dependencies/vite-plugins/index.js
+++ b/packages/e2e-tests/_test_dependencies/vite-plugins/index.js
@@ -1,5 +1,5 @@
-const path = require('path');
-const fs = require('fs');
+const path = require('node:path');
+const fs = require('node:fs');
 /**
  * Ensure transform flow is not interrupted
  * @returns {import('vite').Plugin[]}
@@ -68,7 +68,7 @@ function writeResolvedConfig() {
 				fs.mkdirSync(dir);
 			}
 			const filename = path.join(dir, `vite.config.${cmd}${config.build.ssr ? '.ssr' : ''}.json`);
-			fs.writeFileSync(filename, JSON.stringify(serializableConfig, replacer, `\t`), 'utf-8');
+			fs.writeFileSync(filename, JSON.stringify(serializableConfig, replacer, '\t'), 'utf-8');
 		}
 	};
 }

--- a/packages/e2e-tests/autoprefixer-browerslist/svelte.config.js
+++ b/packages/e2e-tests/autoprefixer-browerslist/svelte.config.js
@@ -1,6 +1,6 @@
 import sveltePreprocess from 'svelte-preprocess';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 export default {
 	preprocess: sveltePreprocess({

--- a/packages/e2e-tests/configfile-custom/__tests__/configfile-custom.spec.ts
+++ b/packages/e2e-tests/configfile-custom/__tests__/configfile-custom.spec.ts
@@ -13,7 +13,7 @@ if (!isBuild) {
 	// TODO split into different tests
 	it('should load custom cjs config and work', async () => {
 		await editViteConfig((c) =>
-			c.replace(/svelte\([^)]*\)/, `svelte({configFile:'svelte.config.custom.cjs'})`)
+			c.replace(/svelte\([^)]*\)/, "svelte({configFile:'svelte.config.custom.cjs'})")
 		);
 		expect(e2eServer.logs.server.out).toContain('custom svelte config loaded cjs');
 		expect(await page.textContent('h1')).toMatch('Hello world!');
@@ -23,7 +23,7 @@ if (!isBuild) {
 
 	it('should not read default config when explicitly disabled', async () => {
 		const currentLogPos = e2eServer.logs.server.out.length;
-		await editViteConfig((c) => c.replace(/svelte\([^)]*\)/, `svelte({configFile: false})`));
+		await editViteConfig((c) => c.replace(/svelte\([^)]*\)/, 'svelte({configFile: false})'));
 		const logsAfterChange = e2eServer.logs.server.out.slice(currentLogPos);
 		expect(logsAfterChange).not.toContain('default svelte config loaded');
 		expect(await page.textContent('h1')).toMatch('Hello world!');

--- a/packages/e2e-tests/configfile-esm/__tests__/configfile-esm.spec.ts
+++ b/packages/e2e-tests/configfile-esm/__tests__/configfile-esm.spec.ts
@@ -9,7 +9,7 @@ it('should load default config and work', async () => {
 
 it('should load custom cjs config and work', async () => {
 	await editViteConfig((c) =>
-		c.replace('svelte()', `svelte({configFile:'svelte.config.custom.cjs'})`)
+		c.replace('svelte()', "svelte({configFile:'svelte.config.custom.cjs'})")
 	);
 	expect(await page.textContent('h1')).toMatch('Hello world!');
 	expect(await page.textContent('#test-child')).toBe('test-child');

--- a/packages/e2e-tests/css-dev-sourcemap/__tests__/css-dev-sourcemap.spec.ts
+++ b/packages/e2e-tests/css-dev-sourcemap/__tests__/css-dev-sourcemap.spec.ts
@@ -17,7 +17,7 @@ test('should apply css compiled from scss', async () => {
 if (!isBuild) {
 	test('should generate sourcemap', async () => {
 		const style = await getText('style[data-vite-dev-id*="App.svelte"]');
-		const lines = style.split(`\n`).map((l) => l.trim());
+		const lines = style.split('\n').map((l) => l.trim());
 		const css = lines[0];
 		const mapComment = lines[1];
 		expect(css).toBe(

--- a/packages/e2e-tests/e2e-server.js
+++ b/packages/e2e-tests/e2e-server.js
@@ -1,8 +1,8 @@
 // script to start package.json dev/build/preview scripts with execa for e2e tests
 import { execa } from 'execa';
 import treeKill from 'tree-kill';
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 const isWin = process.platform === 'win32';
 
 async function startedOnPort(serverProcess, port, timeout) {

--- a/packages/e2e-tests/hmr/__tests__/hmr.spec.ts
+++ b/packages/e2e-tests/hmr/__tests__/hmr.spec.ts
@@ -62,22 +62,22 @@ if (!isBuild) {
 
 		test('should have expected initial state', async () => {
 			// initial state, both counters 0, both labels red
-			expect(await getText(`#hmr-test-1 .counter`)).toBe('0');
-			expect(await getText(`#hmr-test-2 .counter`)).toBe('0');
-			expect(await getText(`#hmr-test-1 .label`)).toBe('hmr-test');
-			expect(await getText(`#hmr-test-2 .label`)).toBe('hmr-test');
-			expect(await getColor(`#hmr-test-1 .label`)).toBe('red');
-			expect(await getColor(`#hmr-test-2 .label`)).toBe('red');
+			expect(await getText('#hmr-test-1 .counter')).toBe('0');
+			expect(await getText('#hmr-test-2 .counter')).toBe('0');
+			expect(await getText('#hmr-test-1 .label')).toBe('hmr-test');
+			expect(await getText('#hmr-test-2 .label')).toBe('hmr-test');
+			expect(await getColor('#hmr-test-1 .label')).toBe('red');
+			expect(await getColor('#hmr-test-2 .label')).toBe('red');
 		});
 
 		test('should have working increment button', async () => {
 			// increment counter of one instance to have local state to verify after hmr updates
-			await (await getEl(`#hmr-test-1 .increment`)).click();
+			await (await getEl('#hmr-test-1 .increment')).click();
 			await sleep(50);
 
 			// counter1 = 1, counter2 = 0
-			expect(await getText(`#hmr-test-1 .counter`)).toBe('1');
-			expect(await getText(`#hmr-test-2 .counter`)).toBe('0');
+			expect(await getText('#hmr-test-1 .counter')).toBe('1');
+			expect(await getText('#hmr-test-2 .counter')).toBe('0');
 		});
 
 		test('should apply css changes in HmrTest.svelte', async () => {
@@ -85,12 +85,12 @@ if (!isBuild) {
 			await updateHmrTest((content) => content.replace('color: red', 'color: green'));
 
 			// counter state should remain
-			expect(await getText(`#hmr-test-1 .counter`)).toBe('1');
-			expect(await getText(`#hmr-test-2 .counter`)).toBe('0');
+			expect(await getText('#hmr-test-1 .counter')).toBe('1');
+			expect(await getText('#hmr-test-2 .counter')).toBe('0');
 
 			// color should have changed
-			expect(await getColor(`#hmr-test-1 .label`)).toBe('green');
-			expect(await getColor(`#hmr-test-2 .label`)).toBe('green');
+			expect(await getColor('#hmr-test-1 .label')).toBe('green');
+			expect(await getColor('#hmr-test-2 .label')).toBe('green');
 		});
 
 		test('should apply js change in HmrTest.svelte ', async () => {
@@ -98,8 +98,8 @@ if (!isBuild) {
 			await updateHmrTest((content) =>
 				content.replace("const label = 'hmr-test'", "const label = 'hmr-test-updated'")
 			);
-			expect(await getText(`#hmr-test-1 .label`)).toBe('hmr-test-updated');
-			expect(await getText(`#hmr-test-2 .label`)).toBe('hmr-test-updated');
+			expect(await getText('#hmr-test-1 .label')).toBe('hmr-test-updated');
+			expect(await getText('#hmr-test-2 .label')).toBe('hmr-test-updated');
 		});
 
 		test('should keep state of external store intact on change of HmrTest.svelte', async () => {
@@ -107,8 +107,8 @@ if (!isBuild) {
 			await updateHmrTest((content) =>
 				content.replace('<!-- HMR-TEMPLATE-INJECT -->', '<span/>\n<!-- HMR-TEMPLATE-INJECT -->')
 			);
-			expect(await getText(`#hmr-test-1 .counter`)).toBe('1');
-			expect(await getText(`#hmr-test-2 .counter`)).toBe('0');
+			expect(await getText('#hmr-test-1 .counter')).toBe('1');
+			expect(await getText('#hmr-test-2 .counter')).toBe('0');
 		});
 
 		test('should preserve state of external store used by HmrTest.svelte when editing App.svelte', async () => {
@@ -120,53 +120,53 @@ if (!isBuild) {
 				)
 			);
 			// counter state is preserved
-			expect(await getText(`#hmr-test-1 .counter`)).toBe('1');
-			expect(await getText(`#hmr-test-2 .counter`)).toBe('0');
+			expect(await getText('#hmr-test-1 .counter')).toBe('1');
+			expect(await getText('#hmr-test-2 .counter')).toBe('0');
 			// a third instance has been added
-			expect(await getText(`#hmr-test-3 .counter`)).toBe('0');
+			expect(await getText('#hmr-test-3 .counter')).toBe('0');
 		});
 
 		test('should preserve state of store when editing hmr-stores.js', async () => {
 			// change state
-			await (await getEl(`#hmr-test-2 .increment`)).click();
+			await (await getEl('#hmr-test-2 .increment')).click();
 			await sleep(50);
 			// update store
 			await updateStore((content) => `${content}\n/*trigger change*/\n`);
 			// counter state is preserved
-			expect(await getText(`#hmr-test-1 .counter`)).toBe('1');
-			expect(await getText(`#hmr-test-2 .counter`)).toBe('1');
+			expect(await getText('#hmr-test-1 .counter')).toBe('1');
+			expect(await getText('#hmr-test-2 .counter')).toBe('1');
 			// a third instance has been added
-			expect(await getText(`#hmr-test-3 .counter`)).toBe('0');
+			expect(await getText('#hmr-test-3 .counter')).toBe('0');
 		});
 
 		test('should work when editing script context="module"', async () => {
-			expect(await getText(`#hmr-with-context`)).toContain('x=0 y=1 slot=1');
-			expect(await getText(`#hmr-without-context`)).toContain('x=0 y=1 slot=');
+			expect(await getText('#hmr-with-context')).toContain('x=0 y=1 slot=1');
+			expect(await getText('#hmr-without-context')).toContain('x=0 y=1 slot=');
 			expect(hmrCount('UsingNamed.svelte'), 'updates for UsingNamed.svelte').toBe(0);
 			expect(hmrCount('UsingDefault.svelte'), 'updates for UsingDefault.svelte').toBe(0);
 			await updateModuleContext((content) => content.replace('y = 1', 'y = 2'));
-			expect(await getText(`#hmr-with-context`)).toContain('x=0 y=2 slot=2');
-			expect(await getText(`#hmr-without-context`)).toContain('x=0 y=2 slot=');
+			expect(await getText('#hmr-with-context')).toContain('x=0 y=2 slot=2');
+			expect(await getText('#hmr-without-context')).toContain('x=0 y=2 slot=');
 			expect(hmrCount('UsingNamed.svelte'), 'updates for UsingNamed.svelte').toBe(1);
 			expect(hmrCount('UsingDefault.svelte'), 'updates for UsingDefault.svelte').toBe(0);
 		});
 
 		test('should work with emitCss: false in vite config', async () => {
 			await editViteConfig((c) => c.replace('svelte()', 'svelte({emitCss:false})'));
-			expect(await getText(`#hmr-test-1 .counter`)).toBe('0');
-			expect(await getColor(`#hmr-test-1 .label`)).toBe('green');
-			await (await getEl(`#hmr-test-1 .increment`)).click();
+			expect(await getText('#hmr-test-1 .counter')).toBe('0');
+			expect(await getColor('#hmr-test-1 .label')).toBe('green');
+			await (await getEl('#hmr-test-1 .increment')).click();
 			await sleep(50);
-			expect(await getText(`#hmr-test-1 .counter`)).toBe('1');
+			expect(await getText('#hmr-test-1 .counter')).toBe('1');
 			await updateHmrTest((content) => content.replace('color: green', 'color: red'));
-			expect(await getColor(`#hmr-test-1 .label`)).toBe('red');
-			expect(await getText(`#hmr-test-1 .counter`)).toBe('1');
+			expect(await getColor('#hmr-test-1 .label')).toBe('red');
+			expect(await getText('#hmr-test-1 .counter')).toBe('1');
 		});
 
 		test('should work with emitCss: false in svelte config', async () => {
-			addFile('svelte.config.cjs', `module.exports={vitePlugin:{emitCss:false}}`);
+			addFile('svelte.config.cjs', 'module.exports={vitePlugin:{emitCss:false}}');
 			await waitForServerRestartAndPageReload();
-			expect(await getColor(`#hmr-test-1 .label`)).toBe('red');
+			expect(await getColor('#hmr-test-1 .label')).toBe('red');
 			removeFile('svelte.config.cjs');
 		});
 
@@ -188,14 +188,14 @@ if (!isBuild) {
 			);
 			await waitForServerRestartAndPageReload();
 			expect(await getText('#preprocess-inject')).toBe('Injected');
-			expect(await getText(`#hmr-test-1 .counter`)).toBe('0');
-			expect(await getColor(`#hmr-test-1 .label`)).toBe('red');
-			await (await getEl(`#hmr-test-1 .increment`)).click();
+			expect(await getText('#hmr-test-1 .counter')).toBe('0');
+			expect(await getColor('#hmr-test-1 .label')).toBe('red');
+			await (await getEl('#hmr-test-1 .increment')).click();
 			await sleep(50);
-			expect(await getText(`#hmr-test-1 .counter`)).toBe('1');
+			expect(await getText('#hmr-test-1 .counter')).toBe('1');
 			await updateHmrTest((content) => content.replace('color: red', 'color: green'));
-			expect(await getColor(`#hmr-test-1 .label`)).toBe('green');
-			expect(await getText(`#hmr-test-1 .counter`)).toBe('1');
+			expect(await getColor('#hmr-test-1 .label')).toBe('green');
+			expect(await getText('#hmr-test-1 .counter')).toBe('1');
 			await editFile('svelte.config.cjs', (content) =>
 				content
 					.replace('preprocess-inject', 'preprocess-inject-2')
@@ -204,20 +204,20 @@ if (!isBuild) {
 			await waitForServerRestartAndPageReload();
 			expect(await getText('#preprocess-inject-2')).toBe('Injected 2');
 			expect(await getEl('#preprocess-inject')).toBe(null);
-			expect(await getColor(`#hmr-test-1 .label`)).toBe('green');
-			expect(await getText(`#hmr-test-1 .counter`)).toBe('0');
-			await (await getEl(`#hmr-test-1 .increment`)).click();
+			expect(await getColor('#hmr-test-1 .label')).toBe('green');
+			expect(await getText('#hmr-test-1 .counter')).toBe('0');
+			await (await getEl('#hmr-test-1 .increment')).click();
 			await sleep(50);
-			expect(await getText(`#hmr-test-1 .counter`)).toBe('1');
+			expect(await getText('#hmr-test-1 .counter')).toBe('1');
 			await updateHmrTest((content) => content.replace('color: green', 'color: red'));
-			expect(await getColor(`#hmr-test-1 .label`)).toBe('red');
-			expect(await getText(`#hmr-test-1 .counter`)).toBe('1');
+			expect(await getColor('#hmr-test-1 .label')).toBe('red');
+			expect(await getText('#hmr-test-1 .counter')).toBe('1');
 			await removeFile('svelte.config.cjs');
 			await waitForServerRestartAndPageReload();
 			expect(await getEl('#preprocess-inject-2')).toBe(null);
 			expect(await getEl('#preprocess-inject')).toBe(null);
-			expect(await getColor(`#hmr-test-1 .label`)).toBe('red');
-			expect(await getText(`#hmr-test-1 .counter`)).toBe('0');
+			expect(await getColor('#hmr-test-1 .label')).toBe('red');
+			expect(await getText('#hmr-test-1 .counter')).toBe('0');
 		});
 	});
 }

--- a/packages/e2e-tests/import-queries/__tests__/import-queries.spec.ts
+++ b/packages/e2e-tests/import-queries/__tests__/import-queries.spec.ts
@@ -39,7 +39,7 @@ describe('raw', () => {
 		expect(result).toMatchFileSnapshot(snapshotFilename('preprocessed'));
 	});
 
-	test(`Dummy.svelte?raw&svelte&type=script`, async () => {
+	test('Dummy.svelte?raw&svelte&type=script', async () => {
 		const result = await getText('#script');
 		expect(normalizeSnapshot(result)).toMatchFileSnapshot(snapshotFilename('script'));
 	});

--- a/packages/e2e-tests/kit-node/__tests__/kit.spec.ts
+++ b/packages/e2e-tests/kit-node/__tests__/kit.spec.ts
@@ -15,7 +15,7 @@ import {
 } from '~utils';
 
 import glob from 'tiny-glob';
-import path from 'path';
+import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 describe('kit-node', () => {
@@ -120,7 +120,7 @@ describe('kit-node', () => {
 						'<div id="hmr-test">foo</div>\n<!-- HMR-TEMPLATE-INJECT -->'
 					)
 				);
-				expect(await getText(`#hmr-test`)).toBe('foo');
+				expect(await getText('#hmr-test')).toBe('foo');
 
 				// add div 2
 				expect(await getEl('#hmr-test2')).toBe(null);
@@ -130,12 +130,12 @@ describe('kit-node', () => {
 						'<div id="hmr-test2">bar</div>\n<!-- HMR-TEMPLATE-INJECT -->'
 					)
 				);
-				expect(await getText(`#hmr-test`)).toBe('foo');
-				expect(await getText(`#hmr-test2`)).toBe('bar');
+				expect(await getText('#hmr-test')).toBe('foo');
+				expect(await getText('#hmr-test2')).toBe('bar');
 				// remove div 1
 				await updatePage((content) => content.replace('<div id="hmr-test">foo</div>\n', ''));
-				expect(await getText(`#hmr-test`)).toBe(null);
-				expect(await getText(`#hmr-test2`)).toBe('bar');
+				expect(await getText('#hmr-test')).toBe(null);
+				expect(await getText('#hmr-test2')).toBe('bar');
 			});
 
 			it('should render additional child components', async () => {
@@ -162,19 +162,19 @@ describe('kit-node', () => {
 			});
 
 			it('should apply changed styles', async () => {
-				expect(await getColor(`h1`)).toBe('rgb(255, 62, 0)');
+				expect(await getColor('h1')).toBe('rgb(255, 62, 0)');
 				await updatePage((content) => content.replace('color: #ff3e00', 'color: blue'));
-				expect(await getColor(`h1`)).toBe('blue');
+				expect(await getColor('h1')).toBe('blue');
 				await updatePage((content) => content.replace('color: blue', 'color: green'));
-				expect(await getColor(`h1`)).toBe('green');
+				expect(await getColor('h1')).toBe('green');
 			});
 
 			it('should serve changes even after page reload', async () => {
-				expect(await getColor(`h1`)).toBe('green');
-				expect(await getText(`#hmr-test2`)).toBe('bar');
+				expect(await getColor('h1')).toBe('green');
+				expect(await getText('#hmr-test2')).toBe('bar');
 				await reloadPage();
-				expect(await getColor(`h1`)).toBe('green');
-				expect(await getText(`#hmr-test2`)).toBe('bar');
+				expect(await getColor('h1')).toBe('green');
+				expect(await getText('#hmr-test2')).toBe('bar');
 			});
 
 			describe('child component update', () => {
@@ -207,7 +207,7 @@ describe('kit-node', () => {
 							'<div id="hmr-test3">foo</div>\n<!-- HMR-TEMPLATE-INJECT -->'
 						)
 					);
-					expect(await getText(`#hmr-test3`)).toBe('foo');
+					expect(await getText('#hmr-test3')).toBe('foo');
 
 					// add div 2
 					expect(await getEl('#hmr-test4')).toBe(null);
@@ -217,20 +217,20 @@ describe('kit-node', () => {
 							'<div id="hmr-test4">bar</div>\n<!-- HMR-TEMPLATE-INJECT -->'
 						)
 					);
-					expect(await getText(`#hmr-test3`)).toBe('foo');
-					expect(await getText(`#hmr-test4`)).toBe('bar');
+					expect(await getText('#hmr-test3')).toBe('foo');
+					expect(await getText('#hmr-test4')).toBe('bar');
 					// remove div 1
 					await updateCounter((content) => content.replace('<div id="hmr-test3">foo</div>\n', ''));
-					expect(await getText(`#hmr-test3`)).toBe(null);
-					expect(await getText(`#hmr-test4`)).toBe('bar');
+					expect(await getText('#hmr-test3')).toBe(null);
+					expect(await getText('#hmr-test4')).toBe('bar');
 				});
 
 				it('should apply changed styles', async () => {
-					expect(await getColor(`button`)).toBe('rgb(255, 62, 0)');
+					expect(await getColor('button')).toBe('rgb(255, 62, 0)');
 					await updateCounter((content) => content.replace('color: #ff3e00', 'color: blue'));
-					expect(await getColor(`button`)).toBe('blue');
+					expect(await getColor('button')).toBe('blue');
 					await updateCounter((content) => content.replace('color: blue', 'color: green'));
-					expect(await getColor(`button`)).toBe('green');
+					expect(await getColor('button')).toBe('green');
 				});
 
 				it('should apply changed initial state', async () => {

--- a/packages/e2e-tests/preprocess-with-vite/__tests__/preprocess-with-vite.spec.ts
+++ b/packages/e2e-tests/preprocess-with-vite/__tests__/preprocess-with-vite.spec.ts
@@ -2,7 +2,7 @@ import { getColor, getText, browserLogs } from '~utils';
 import { expect } from 'vitest';
 
 test('should render App', async () => {
-	expect(await getText('h1.foo')).toBe(`Hello world`);
+	expect(await getText('h1.foo')).toBe('Hello world');
 	expect(await getColor('#app-scss')).toBe('rgb(0, 0, 153)'); // darken($blue, 20)
 	expect(await getText('#foo-title')).toBe('Styles with stylus blub');
 	expect(await getColor('#foo-title')).toBe('magenta');

--- a/packages/e2e-tests/svelte-preprocess/__tests__/svelte-preprocess.spec.ts
+++ b/packages/e2e-tests/svelte-preprocess/__tests__/svelte-preprocess.spec.ts
@@ -12,13 +12,13 @@ import {
 } from '~utils';
 
 test('should render App', async () => {
-	expect(await getText('h1')).toBe(`I'm blue`);
+	expect(await getText('h1')).toBe("I'm blue");
 	expect(await getColor('h1')).toBe('blue');
-	expect(await getText('h2')).toBe(`I'm red`);
+	expect(await getText('h2')).toBe("I'm red");
 	expect(await getColor('h2')).toBe('red');
-	expect(await getText('p')).toBe(`I'm green`);
+	expect(await getText('p')).toBe("I'm green");
 	expect(await getColor('p')).toBe('green');
-	expect(await getText('span')).toBe(`I'm orangered`);
+	expect(await getText('span')).toBe("I'm orangered");
 	expect(await getColor('span')).toBe('orangered');
 });
 
@@ -31,37 +31,37 @@ test('should not have failed requests', async () => {
 if (!isBuild) {
 	describe('hmr', () => {
 		test('should apply updates when editing App.svelte', async () => {
-			expect(await getText('span')).toBe(`I'm orangered`);
+			expect(await getText('span')).toBe("I'm orangered");
 			await editFileAndWaitForHmrComplete('src/App.svelte', (c) =>
-				c.replace(`I'm orangered`, `I'm replaced`)
+				c.replace("I'm orangered", "I'm replaced")
 			);
-			expect(await getText('span')).toBe(`I'm replaced`);
+			expect(await getText('span')).toBe("I'm replaced");
 			expect(await getColor('span')).toBe('orangered');
 			await editFileAndWaitForHmrComplete(
 				'src/App.svelte',
-				(c) => c.replace(`color: orangered`, `color: magenta`),
+				(c) => c.replace('color: orangered', 'color: magenta'),
 				'/src/App.svelte?svelte&type=style&lang.css'
 			);
 			expect(await getColor('span')).toBe('magenta');
 		});
 
 		test('should apply updates when editing MultiFile.html', async () => {
-			expect(await getText('h1')).toBe(`I'm blue`);
-			expect(await getText('h2')).toBe(`I'm red`);
+			expect(await getText('h1')).toBe("I'm blue");
+			expect(await getText('h2')).toBe("I'm red");
 			await editFileAndWaitForHmrComplete(
 				'src/lib/multifile/MultiFile.html',
-				(c) => c.replace(`I'm blue`, `I'm replaced`).replace(`I'm red`, `I'm replaced too`),
+				(c) => c.replace("I'm blue", "I'm replaced").replace("I'm red", "I'm replaced too"),
 				'/src/lib/multifile/MultiFile.svelte'
 			);
-			expect(await getText('h1')).toBe(`I'm replaced`);
-			expect(await getText('h2')).toBe(`I'm replaced too`);
+			expect(await getText('h1')).toBe("I'm replaced");
+			expect(await getText('h2')).toBe("I'm replaced too");
 		});
 
 		test('should apply updates when editing MultiFile.scss', async () => {
 			expect(await getColor('h1')).toBe('blue');
 			await editFileAndWaitForHmrComplete(
 				'src/lib/multifile/MultiFile.scss',
-				(c) => c.replace(`color: blue`, `color: magenta`),
+				(c) => c.replace('color: blue', 'color: magenta'),
 				'/src/lib/multifile/MultiFile.svelte?svelte&type=style&lang.css'
 			);
 			expect(await getColor('h1')).toBe('magenta');
@@ -71,7 +71,7 @@ if (!isBuild) {
 			expect(await getColor('h2')).toBe('red');
 			await editFileAndWaitForHmrComplete(
 				'src/lib/multifile/_someImport.scss',
-				(c) => c.replace(`color: red`, `color: magenta`),
+				(c) => c.replace('color: red', 'color: magenta'),
 				'/src/lib/multifile/MultiFile.svelte?svelte&type=style&lang.css'
 			);
 			expect(await getColor('h2')).toBe('magenta');
@@ -81,7 +81,7 @@ if (!isBuild) {
 			expect(await getColor('h2')).toBe('magenta');
 			await editFileAndWaitForHmrComplete(
 				'src/lib/multifile/MultiFile.scss',
-				(c) => c.replace(`@import 'someImport';`, `/*@import 'someImport';*/`),
+				(c) => c.replace("@import 'someImport';", "/*@import 'someImport';*/"),
 				'/src/lib/multifile/MultiFile.svelte?svelte&type=style&lang.css'
 			);
 			expect(await getColor('h2')).toBe('black');
@@ -93,32 +93,32 @@ if (!isBuild) {
 			expect(await getColor('h2')).toBe('black');
 			await editFileAndWaitForHmrComplete(
 				'src/lib/multifile/MultiFile.scss',
-				(c) => c.replace(`/*@import 'someImport';*/`, `/*@import 'someImport';*/\n@import 'foo';`),
+				(c) => c.replace("/*@import 'someImport';*/", "/*@import 'someImport';*/\n@import 'foo';"),
 				'/src/lib/multifile/MultiFile.svelte?svelte&type=style&lang.css'
 			);
 			expect(await getColor('h2')).toBe('maroon');
 			await editFileAndWaitForHmrComplete(
 				'src/lib/multifile/_foo.scss',
-				(c) => c.replace(`maroon`, `green`),
+				(c) => c.replace('maroon', 'green'),
 				'/src/lib/multifile/MultiFile.svelte?svelte&type=style&lang.css'
 			);
 			expect(await getColor('h2')).toBe('green');
 		});
 
 		test('should apply updates when editing MultiFile.ts', async () => {
-			expect(await getText('p')).toBe(`I'm green`);
+			expect(await getText('p')).toBe("I'm green");
 			await editFileAndWaitForHmrComplete(
 				'src/lib/multifile/MultiFile.ts',
-				(c) => c.replace(`'green'`, `'a replaced value'`),
+				(c) => c.replace("'green'", "'a replaced value'"),
 				'/src/lib/multifile/MultiFile.svelte'
 			);
-			expect(await getText('p')).toBe(`I'm a replaced value`);
+			expect(await getText('p')).toBe("I'm a replaced value");
 		});
 
 		test('should apply updates when editing someother.css', async () => {
 			expect(await getColor('p')).toBe('green');
 			await editFileAndWaitForHmrComplete('src/lib/multifile/someother.css', (c) =>
-				c.replace(`color: green`, `color: magenta`)
+				c.replace('color: green', 'color: magenta')
 			);
 			expect(await getColor('p')).toBe('magenta');
 		});
@@ -135,7 +135,7 @@ if (!isBuild) {
 			expect(errorOverlay2).toBeFalsy();
 			await editFileAndWaitForHmrComplete(
 				'src/lib/multifile/MultiFile.scss',
-				(c) => c.replace(`@import 'foo';`, ``),
+				(c) => c.replace("@import 'foo';", ''),
 				'/src/lib/multifile/MultiFile.svelte?svelte&type=style&lang.css'
 			);
 			expect(await getColor('h2')).toBe('black');

--- a/packages/e2e-tests/testUtils.ts
+++ b/packages/e2e-tests/testUtils.ts
@@ -1,8 +1,8 @@
 // test utils used in e2e tests
 // this can be directly imported in any e2e tests as 'testUtils', e.g.
 // `import { getColor } from 'testUtils'`
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 import colors from 'css-color-names';
 import { ElementHandle } from 'playwright-core';
 import fetch from 'node-fetch';

--- a/packages/e2e-tests/vite-ssr-esm/__tests__/vite-ssr-esm.spec.ts
+++ b/packages/e2e-tests/vite-ssr-esm/__tests__/vite-ssr-esm.spec.ts
@@ -63,17 +63,17 @@ if (!isBuild) {
 					'<div id="hmr-test">foo</div>\n<!-- HMR-TEMPLATE-INJECT -->'
 				)
 			);
-			await untilMatches(() => getText(`#hmr-test`), 'foo', '#hmr-test contains text foo');
+			await untilMatches(() => getText('#hmr-test'), 'foo', '#hmr-test contains text foo');
 		});
 		test('should apply style update', async () => {
-			expect(await getColor(`h1`)).toBe('green');
+			expect(await getColor('h1')).toBe('green');
 			await updateApp((content) => content.replace('color: green', 'color: red'));
 			await untilMatches(() => getColor('h1'), 'red', 'h1 has color red');
 		});
 		test('should not preserve state of updated props', async () => {
-			expect(await getText(`#foo`)).toBe('foo');
+			expect(await getText('#foo')).toBe('foo');
 			await updateApp((content) => content.replace("foo = 'foo'", "foo = 'bar'"));
-			await untilMatches(() => getText(`#foo`), 'bar', '#foo contains text bar');
+			await untilMatches(() => getText('#foo'), 'bar', '#foo contains text bar');
 		});
 	});
 }

--- a/packages/e2e-tests/vite-ssr-esm/server.js
+++ b/packages/e2e-tests/vite-ssr-esm/server.js
@@ -1,7 +1,7 @@
 // @ts-check
-import fs from 'fs';
-import path from 'path';
-import { pathToFileURL } from 'url';
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import express from 'express';
 import compression from 'compression';
 import serveStatic from 'serve-static';
@@ -76,8 +76,8 @@ async function createServer(root = process.cwd(), isProd = process.env.NODE_ENV 
 			const headElements = rendered.head || '';
 			// TODO what do we do with rendered.css here. find out if emitCss was used and vite took care of it
 			const html = template
-				.replace(`<!--head-outlet-->`, headElements)
-				.replace(`<!--app-outlet-->`, appHtml);
+				.replace('<!--head-outlet-->', headElements)
+				.replace('<!--app-outlet-->', appHtml);
 
 			res.status(200).set({ 'Content-Type': 'text/html' }).end(html);
 		} catch (e) {

--- a/packages/e2e-tests/vite-ssr/__tests__/vite-ssr.spec.ts
+++ b/packages/e2e-tests/vite-ssr/__tests__/vite-ssr.spec.ts
@@ -59,17 +59,17 @@ if (!isBuild) {
 					'<div id="hmr-test">foo</div>\n<!-- HMR-TEMPLATE-INJECT -->'
 				)
 			);
-			await untilMatches(() => getText(`#hmr-test`), 'foo', '#hmr-test contains text foo');
+			await untilMatches(() => getText('#hmr-test'), 'foo', '#hmr-test contains text foo');
 		});
 		test('should apply style update', async () => {
-			expect(await getColor(`h1`)).toBe('green');
+			expect(await getColor('h1')).toBe('green');
 			await updateApp((content) => content.replace('color: green', 'color: red'));
 			await untilMatches(() => getColor('h1'), 'red', 'h1 has color red');
 		});
 		test('should not preserve state of updated props', async () => {
-			expect(await getText(`#foo`)).toBe('foo');
+			expect(await getText('#foo')).toBe('foo');
 			await updateApp((content) => content.replace("foo = 'foo'", "foo = 'bar'"));
-			await untilMatches(() => getText(`#foo`), 'bar', '#foo contains text bar');
+			await untilMatches(() => getText('#foo'), 'bar', '#foo contains text bar');
 		});
 	});
 }

--- a/packages/e2e-tests/vite-ssr/server.js
+++ b/packages/e2e-tests/vite-ssr/server.js
@@ -1,6 +1,6 @@
 // @ts-check
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 const express = require('express');
 
 let port = 3000;
@@ -74,8 +74,8 @@ async function createServer(root = process.cwd(), isProd = process.env.NODE_ENV 
 			const headElements = rendered.head || '';
 			// TODO what do we do with rendered.css here. find out if emitCss was used and vite took care of it
 			const html = template
-				.replace(`<!--head-outlet-->`, headElements)
-				.replace(`<!--app-outlet-->`, appHtml);
+				.replace('<!--head-outlet-->', headElements)
+				.replace('<!--app-outlet-->', appHtml);
 
 			res.status(200).set({ 'Content-Type': 'text/html' }).end(html);
 		} catch (e) {

--- a/packages/e2e-tests/vitestGlobalSetup.ts
+++ b/packages/e2e-tests/vitestGlobalSetup.ts
@@ -1,9 +1,9 @@
-import os from 'os';
+import os from 'node:os';
 import fs from 'fs-extra';
-import path from 'path';
+import path from 'node:path';
 import { chromium } from 'playwright-core';
 import { execa } from 'execa';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 
 const tempTestDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', 'temp');
 

--- a/packages/e2e-tests/vitestSetup.ts
+++ b/packages/e2e-tests/vitestSetup.ts
@@ -1,11 +1,11 @@
 import fs from 'fs-extra';
-import path from 'path';
+import path from 'node:path';
 import { chromium } from 'playwright-core';
 import type { Browser, Page } from 'playwright-core';
 import type { File } from 'vitest';
 import { beforeAll } from 'vitest';
-import os from 'os';
-import { fileURLToPath } from 'url';
+import os from 'node:os';
+import { fileURLToPath } from 'node:url';
 
 export const isBuild = !!process.env.TEST_BUILD;
 export const isWin = process.platform === 'win32';

--- a/packages/playground/big-component-library-vite-ssr/server.js
+++ b/packages/playground/big-component-library-vite-ssr/server.js
@@ -53,8 +53,8 @@ app.use('*', async (req, res) => {
 		const rendered = await render(url, ssrManifest);
 
 		const html = template
-			.replace(`<!--app-head-->`, rendered.head ?? '')
-			.replace(`<!--app-html-->`, rendered.html ?? '');
+			.replace('<!--app-head-->', rendered.head ?? '')
+			.replace('<!--app-html-->', rendered.html ?? '');
 
 		res.status(200).set({ 'Content-Type': 'text/html' }).end(html);
 	} catch (e) {

--- a/packages/playground/kit-demo-app/src/routes/sverdle/+page.svelte
+++ b/packages/playground/kit-demo-app/src/routes/sverdle/+page.svelte
@@ -120,7 +120,7 @@
 				<p>the answer was "{data.answer}"</p>
 			{/if}
 			<button data-key="enter" class="restart" formaction="?/restart">
-				{won ? 'you won :)' : `game over :(`} play again?
+				{won ? 'you won :)' : 'game over :('} play again?
 			</button>
 		{:else}
 			<div class="keyboard">

--- a/packages/vite-plugin-svelte-inspector/src/index.js
+++ b/packages/vite-plugin-svelte-inspector/src/index.js
@@ -1,7 +1,7 @@
 import { normalizePath } from 'vite';
-import fs from 'fs';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { debug } from './debug.js';
 import { defaultInspectorOptions, parseEnvironmentOptions } from './options.js';
 import { cleanUrl } from './utils.js';
@@ -35,7 +35,7 @@ export function svelteInspector(options) {
 
 			const environmentOptions = parseEnvironmentOptions(config);
 			if (environmentOptions === false) {
-				debug(`environment options set to false, inspector disabled`);
+				debug('environment options set to false, inspector disabled');
 				disabled = true;
 				return;
 			}
@@ -47,7 +47,7 @@ export function svelteInspector(options) {
 			// vite-plugin-svelte can only pass options through it's `api` instead of `options`.
 			// that means this plugin could be created but should be disabled, so we check this case here.
 			if (vps && !options && !configFileOptions && !environmentOptions) {
-				debug(`vite-plugin-svelte didn't pass options, inspector disabled`);
+				debug("vite-plugin-svelte didn't pass options, inspector disabled");
 				disabled = true;
 				return;
 			}

--- a/packages/vite-plugin-svelte/__tests__/preprocess.spec.js
+++ b/packages/vite-plugin-svelte/__tests__/preprocess.spec.js
@@ -1,8 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import { vitePreprocess } from '../src/preprocess.js';
-import path from 'path';
+import path from 'node:path';
 import { normalizePath } from 'vite';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 
 const fixtureDir = normalizePath(
 	path.join(path.dirname(fileURLToPath(import.meta.url)), 'fixtures', 'preprocess')

--- a/packages/vite-plugin-svelte/__tests__/sourcemaps.spec.js
+++ b/packages/vite-plugin-svelte/__tests__/sourcemaps.spec.js
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { removeLangSuffix, mapToRelative } from '../src/utils/sourcemaps.js';
 import { lang_sep } from '../src/preprocess.js';
 import { normalizePath } from 'vite';
-import path from 'path';
-import { fileURLToPath, pathToFileURL } from 'url';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const fixtureDir = normalizePath(
 	path.join(path.dirname(fileURLToPath(import.meta.url)), 'fixtures', 'preprocess')
@@ -66,7 +66,7 @@ describe('mapToRelative', () => {
 		const map = {
 			file,
 			sourceRoot: './some-path/..',
-			sources: [`foo.scss`, `File.svelte`, `${pathToFileURL(`${fixtureDir}/bar.scss`)}`]
+			sources: ['foo.scss', 'File.svelte', `${pathToFileURL(`${fixtureDir}/bar.scss`)}`]
 		};
 		mapToRelative(map, file);
 		expect(map.file).toBe('File.svelte');

--- a/packages/vite-plugin-svelte/src/index.js
+++ b/packages/vite-plugin-svelte/src/index.js
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'node:fs';
 import { version as viteVersion } from 'vite';
 
 import { svelteInspector } from '@sveltejs/vite-plugin-svelte-inspector';

--- a/packages/vite-plugin-svelte/src/utils/dependencies.js
+++ b/packages/vite-plugin-svelte/src/utils/dependencies.js
@@ -1,5 +1,5 @@
-import path from 'path';
-import fs from 'fs/promises';
+import path from 'node:path';
+import fs from 'node:fs/promises';
 import { findDepPkgJsonPath } from 'vitefu';
 
 /**

--- a/packages/vite-plugin-svelte/src/utils/esbuild.js
+++ b/packages/vite-plugin-svelte/src/utils/esbuild.js
@@ -1,4 +1,4 @@
-import { readFileSync } from 'fs';
+import { readFileSync } from 'node:fs';
 import { compile, preprocess } from 'svelte/compiler';
 import { log } from './log.js';
 import { toESBuildError } from './error.js';
@@ -24,7 +24,7 @@ export function esbuildSveltePlugin(options) {
 			if (build.initialOptions.plugins?.some((v) => v.name === 'vite:dep-scan')) return;
 
 			const svelteExtensions = (options.extensions ?? ['.svelte']).map((ext) => ext.slice(1));
-			const svelteFilter = new RegExp(`\\.(` + svelteExtensions.join('|') + `)(\\?.*)?$`);
+			const svelteFilter = new RegExp('\\.(' + svelteExtensions.join('|') + ')(\\?.*)?$');
 			/** @type {import('../types/vite-plugin-svelte-stats.d.ts').StatCollection | undefined} */
 			let statsCollection;
 			build.onStart(() => {

--- a/packages/vite-plugin-svelte/src/utils/hash.js
+++ b/packages/vite-plugin-svelte/src/utils/hash.js
@@ -1,4 +1,4 @@
-import * as crypto from 'crypto';
+import * as crypto from 'node:crypto';
 
 const hashes = Object.create(null);
 

--- a/packages/vite-plugin-svelte/src/utils/id.js
+++ b/packages/vite-plugin-svelte/src/utils/id.js
@@ -1,5 +1,5 @@
 import { createFilter, normalizePath } from 'vite';
-import * as fs from 'fs';
+import * as fs from 'node:fs';
 import { log } from './log.js';
 
 const VITE_FS_PREFIX = '/@fs/';
@@ -21,7 +21,7 @@ const TYPES_WITH_COMPILER_OPTIONS = ['style', 'script', 'all'];
  * @returns {{ filename: string, rawQuery: string }}
  */
 function splitId(id) {
-	const parts = id.split(`?`, 2);
+	const parts = id.split('?', 2);
 	const filename = parts[0];
 	const rawQuery = parts[1];
 	return { filename, rawQuery };

--- a/packages/vite-plugin-svelte/src/utils/load-raw.js
+++ b/packages/vite-plugin-svelte/src/utils/load-raw.js
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'node:fs';
 import { toRollupError } from './error.js';
 import { log } from './log.js';
 
@@ -126,7 +126,7 @@ function toRawExports(object) {
 			.map(([key, value]) => `export const ${key}=${JSON.stringify(value)}`)
 			.join('\n') + '\n';
 	if (Object.prototype.hasOwnProperty.call(object, 'code')) {
-		exports += `export default code\n`;
+		exports += 'export default code\n';
 	}
 	return exports;
 }

--- a/packages/vite-plugin-svelte/src/utils/load-svelte-config.js
+++ b/packages/vite-plugin-svelte/src/utils/load-svelte-config.js
@@ -1,7 +1,7 @@
-import { createRequire } from 'module';
-import path from 'path';
-import fs from 'fs';
-import { pathToFileURL } from 'url';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import fs from 'node:fs';
+import { pathToFileURL } from 'node:url';
 import { log } from './log.js';
 
 // used to require cjs config in esm.

--- a/packages/vite-plugin-svelte/src/utils/log.js
+++ b/packages/vite-plugin-svelte/src/utils/log.js
@@ -204,7 +204,8 @@ function buildExtraWarnings(warnings, isBuild) {
 			extraWarnings.push({
 				...noScopableElementWarning,
 				code: 'vite-plugin-svelte-css-no-scopable-elements',
-				message: `No scopable elements found in template. If you're using global styles in the style tag, you should move it into an external stylesheet file and import it in JS. See https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#where-should-i-put-my-global-styles.`
+				message:
+					"No scopable elements found in template. If you're using global styles in the style tag, you should move it into an external stylesheet file and import it in JS. See https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#where-should-i-put-my-global-styles."
 			});
 		}
 	}

--- a/packages/vite-plugin-svelte/src/utils/optimizer.js
+++ b/packages/vite-plugin-svelte/src/utils/optimizer.js
@@ -1,5 +1,5 @@
-import { promises as fs } from 'fs';
-import path from 'path';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
 
 // List of options that changes the prebundling result
 /** @type {(keyof import('../types/options.d.ts').ResolvedOptions)[]} */

--- a/packages/vite-plugin-svelte/src/utils/options.js
+++ b/packages/vite-plugin-svelte/src/utils/options.js
@@ -10,7 +10,7 @@ import {
 	VITE_RESOLVE_MAIN_FIELDS
 } from './constants.js';
 
-import path from 'path';
+import path from 'node:path';
 import { esbuildSveltePlugin, facadeEsbuildSveltePluginName } from './esbuild.js';
 import { addExtraPreprocessors } from './preprocess.js';
 import deepmerge from 'deepmerge';

--- a/packages/vite-plugin-svelte/src/utils/preprocess.js
+++ b/packages/vite-plugin-svelte/src/utils/preprocess.js
@@ -1,6 +1,6 @@
 import MagicString from 'magic-string';
 import { log } from './log.js';
-import path from 'path';
+import path from 'node:path';
 
 /**
  * this appends a *{} rule to component styles to force the svelte compiler to add style classes to all nodes

--- a/packages/vite-plugin-svelte/src/utils/resolve.js
+++ b/packages/vite-plugin-svelte/src/utils/resolve.js
@@ -1,5 +1,5 @@
-import path from 'path';
-import { builtinModules } from 'module';
+import path from 'node:path';
+import { builtinModules } from 'node:module';
 import { resolveDependencyData, isCommonDepWithoutSvelteField } from './dependencies.js';
 import { normalizePath } from 'vite';
 

--- a/packages/vite-plugin-svelte/src/utils/sourcemaps.js
+++ b/packages/vite-plugin-svelte/src/utils/sourcemaps.js
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 const IS_WINDOWS = process.platform === 'win32';
 

--- a/packages/vite-plugin-svelte/src/utils/vite-plugin-svelte-cache.js
+++ b/packages/vite-plugin-svelte/src/utils/vite-plugin-svelte-cache.js
@@ -1,5 +1,5 @@
-import { readFileSync } from 'fs';
-import { dirname } from 'path';
+import { readFileSync } from 'node:fs';
+import { dirname } from 'node:path';
 import { findClosestPkgJsonPath } from 'vitefu';
 import { normalizePath } from 'vite';
 

--- a/packages/vite-plugin-svelte/src/utils/vite-plugin-svelte-stats.js
+++ b/packages/vite-plugin-svelte/src/utils/vite-plugin-svelte-stats.js
@@ -1,5 +1,5 @@
 import { log } from './log.js';
-import { performance } from 'perf_hooks';
+import { performance } from 'node:perf_hooks';
 import { normalizePath } from 'vite';
 
 /** @type {import('../types/vite-plugin-svelte-stats.d.ts').CollectionOptions} */

--- a/packages/vite-plugin-svelte/src/utils/watch.js
+++ b/packages/vite-plugin-svelte/src/utils/watch.js
@@ -1,7 +1,7 @@
-import fs from 'fs';
+import fs from 'node:fs';
 import { log } from './log.js';
 import { knownSvelteConfigNames } from './load-svelte-config.js';
-import path from 'path';
+import path from 'node:path';
 
 /**
  * @param {import('../types/options.d.ts').ResolvedOptions} options

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       eslint-plugin-svelte:
         specifier: ^2.32.4
         version: 2.32.4(eslint@8.46.0)(svelte@4.1.2)
+      eslint-plugin-unicorn:
+        specifier: ^48.0.1
+        version: 48.0.1(eslint@8.46.0)
       execa:
         specifier: ^7.2.0
         version: 7.2.0
@@ -830,8 +833,8 @@ packages:
       '@babel/highlight': 7.18.6
     dev: true
 
-  /@babel/helper-validator-identifier@7.19.1:
-    resolution: {integrity: sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==}
+  /@babel/helper-validator-identifier@7.22.5:
+    resolution: {integrity: sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==}
     engines: {node: '>=6.9.0'}
     dev: true
 
@@ -839,7 +842,7 @@ packages:
     resolution: {integrity: sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-validator-identifier': 7.19.1
+      '@babel/helper-validator-identifier': 7.22.5
       chalk: 2.4.2
       js-tokens: 4.0.0
     dev: true
@@ -2286,7 +2289,7 @@ packages:
   /builtins@5.0.1:
     resolution: {integrity: sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==}
     dependencies:
-      semver: 7.5.3
+      semver: 7.5.4
     dev: true
 
   /bundle-name@3.0.0:
@@ -2447,6 +2450,13 @@ packages:
   /ci-info@3.8.0:
     resolution: {integrity: sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==}
     engines: {node: '>=8'}
+    dev: true
+
+  /clean-regexp@1.0.0:
+    resolution: {integrity: sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==}
+    engines: {node: '>=4'}
+    dependencies:
+      escape-string-regexp: 1.0.5
     dev: true
 
   /clean-stack@2.2.0:
@@ -3181,6 +3191,30 @@ packages:
       - ts-node
     dev: true
 
+  /eslint-plugin-unicorn@48.0.1(eslint@8.46.0):
+    resolution: {integrity: sha512-FW+4r20myG/DqFcCSzoumaddKBicIPeFnTrifon2mWIzlfyvzwyqZjqVP7m4Cqr/ZYisS2aiLghkUWaPg6vtCw==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      eslint: '>=8.44.0'
+    dependencies:
+      '@babel/helper-validator-identifier': 7.22.5
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.46.0)
+      ci-info: 3.8.0
+      clean-regexp: 1.0.0
+      eslint: 8.46.0
+      esquery: 1.5.0
+      indent-string: 4.0.0
+      is-builtin-module: 3.2.1
+      jsesc: 3.0.2
+      lodash: 4.17.21
+      pluralize: 8.0.0
+      read-pkg-up: 7.0.1
+      regexp-tree: 0.1.27
+      regjsparser: 0.10.0
+      semver: 7.5.4
+      strip-indent: 3.0.0
+    dev: true
+
   /eslint-scope@7.2.0:
     resolution: {integrity: sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -3195,11 +3229,6 @@ packages:
     dependencies:
       esrecurse: 4.3.0
       estraverse: 5.3.0
-    dev: true
-
-  /eslint-visitor-keys@3.4.1:
-    resolution: {integrity: sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
   /eslint-visitor-keys@3.4.2:
@@ -4163,6 +4192,17 @@ packages:
       argparse: 2.0.1
     dev: true
 
+  /jsesc@0.5.0:
+    resolution: {integrity: sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==}
+    hasBin: true
+    dev: true
+
+  /jsesc@3.0.2:
+    resolution: {integrity: sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==}
+    engines: {node: '>=6'}
+    hasBin: true
+    dev: true
+
   /json-parse-better-errors@1.0.2:
     resolution: {integrity: sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==}
     dev: true
@@ -4320,6 +4360,10 @@ packages:
 
   /lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
+    dev: true
+
+  /lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
     dev: true
 
   /log-update@4.0.0:
@@ -5008,6 +5052,11 @@ packages:
     hasBin: true
     dev: true
 
+  /pluralize@8.0.0:
+    resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
+    engines: {node: '>=4'}
+    dev: true
+
   /postcss-load-config@3.1.4(postcss@8.4.27):
     resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
     engines: {node: '>= 10'}
@@ -5258,6 +5307,11 @@ packages:
     resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
     dev: true
 
+  /regexp-tree@0.1.27:
+    resolution: {integrity: sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==}
+    hasBin: true
+    dev: true
+
   /regexp.prototype.flags@1.5.0:
     resolution: {integrity: sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==}
     engines: {node: '>= 0.4'}
@@ -5265,6 +5319,13 @@ packages:
       call-bind: 1.0.2
       define-properties: 1.2.0
       functions-have-names: 1.2.3
+    dev: true
+
+  /regjsparser@0.10.0:
+    resolution: {integrity: sha512-qx+xQGZVsy55CH0a1hiVwHmqjLryfh7wQyF5HO07XJ9f7dQMY/gPQHhlyDkIzJKC+x2fUCpCcUODUUUFrm7SHA==}
+    hasBin: true
+    dependencies:
+      jsesc: 0.5.0
     dev: true
 
   /require-directory@2.1.1:
@@ -5808,7 +5869,7 @@ packages:
         optional: true
     dependencies:
       eslint-scope: 7.2.0
-      eslint-visitor-keys: 3.4.1
+      eslint-visitor-keys: 3.4.2
       espree: 9.6.0
       postcss: 8.4.27
       postcss-scss: 4.0.6(postcss@8.4.27)

--- a/vitest.config.e2e.ts
+++ b/vitest.config.e2e.ts
@@ -1,8 +1,8 @@
-import * as path from 'path';
-import * as os from 'os';
+import * as path from 'node:path';
+import * as os from 'node:os';
 
 import { defineConfig } from 'vitest/config';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 
 const timeout = process.env.CI ? 50000 : 30000;
 const __dir = path.dirname(fileURLToPath(import.meta.url));


### PR DESCRIPTION
the `node:` prefix is supported in the same versions of Node that `vite-plugin-svelte` supports: https://2ality.com/2021/12/node-protocol-imports.html#support-for-node%3A-imports