### PR TITLE
chore: prefer const

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -57,6 +57,7 @@ module.exports = {
 		'n/no-unpublished-import': 'off',
 		'n/no-unpublished-require': 'off',
 		'no-process-exit': 'off',
+		'prefer-const': ['error', { destructuring: 'all' }],
 		quotes: ['error', 'single', { avoidEscape: true }],
 		'unicorn/prefer-node-protocol': 'error'
 	},

--- a/packages/e2e-tests/e2e-server.js
+++ b/packages/e2e-tests/e2e-server.js
@@ -79,8 +79,8 @@ export async function serve(root, isBuild, port) {
 	if (isBuild) {
 		let buildResult;
 		let hasErr = false;
-		let out = [];
-		let err = [];
+		const out = [];
+		const err = [];
 
 		try {
 			const buildProcess = execa('pnpm', ['build'], {

--- a/packages/e2e-tests/hmr/src/components/partial-hmr/ModuleContext.svelte
+++ b/packages/e2e-tests/hmr/src/components/partial-hmr/ModuleContext.svelte
@@ -1,10 +1,10 @@
 <script context="module">
-	export let y = 1;
+	export const y = 1;
 </script>
 
 <script>
 	export let id;
-	let x = 0;
+	const x = 0;
 </script>
 
 <pre {id}>

--- a/packages/e2e-tests/prebundle-svelte-deps/src/App.svelte
+++ b/packages/e2e-tests/prebundle-svelte-deps/src/App.svelte
@@ -6,7 +6,7 @@
 	import { setSomeContext } from 'e2e-test-dep-svelte-api-only';
 	import { getContext } from 'svelte';
 	setSomeContext();
-	let apiOnlyLoaded = !!getContext('svelte-api-only');
+	const apiOnlyLoaded = !!getContext('svelte-api-only');
 </script>
 
 <main>

--- a/packages/e2e-tests/preprocess-with-vite/src/Foo.svelte
+++ b/packages/e2e-tests/preprocess-with-vite/src/Foo.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	let foo: string = 'stylus';
+	const foo: string = 'stylus';
 	export let bla: string = 'blub';
 	console.log('pure test 1', new Date());
 	console.log('pure test 2');

--- a/packages/e2e-tests/ts-type-import/src/App.svelte
+++ b/packages/e2e-tests/ts-type-import/src/App.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { foobar } from './foobar.js';
-	let s: string = 'world';
+	const s: string = 'world';
 </script>
 
 <div id="hello">Hello {s}</div>

--- a/packages/e2e-tests/vite-ssr-esm/src/components/Foo.svelte
+++ b/packages/e2e-tests/vite-ssr-esm/src/components/Foo.svelte
@@ -1,5 +1,5 @@
 <script>
-	let bar = 'bar';
+	const bar = 'bar';
 </script>
 
 <div class="blue">Foo bar={bar}</div>

--- a/packages/e2e-tests/vite-ssr/src/components/Foo.svelte
+++ b/packages/e2e-tests/vite-ssr/src/components/Foo.svelte
@@ -1,5 +1,5 @@
 <script>
-	let bar = 'bar';
+	const bar = 'bar';
 </script>
 
 <div class="blue">Foo bar={bar}</div>

--- a/packages/playground/optimizedeps-include/vite.config.js
+++ b/packages/playground/optimizedeps-include/vite.config.js
@@ -1,14 +1,6 @@
 import { defineConfig } from 'vite';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
-const SVELTE_IMPORTS = [
-	'svelte/animate',
-	'svelte/easing',
-	'svelte/internal',
-	'svelte/motion',
-	'svelte/store',
-	'svelte/transition',
-	'svelte'
-];
+
 export default defineConfig(({ command, mode }) => {
 	const isProduction = mode === 'production';
 	return {

--- a/packages/vite-plugin-svelte/src/types/compile.d.ts
+++ b/packages/vite-plugin-svelte/src/types/compile.d.ts
@@ -19,7 +19,7 @@ export interface Compiled {
 	css: Code;
 	ast: any; // TODO type
 	warnings: any[]; // TODO type
-	vars: {
+	vars: Array<{
 		name: string;
 		export_name: string;
 		injected: boolean;
@@ -29,7 +29,7 @@ export interface Compiled {
 		referenced: boolean;
 		writable: boolean;
 		referenced_from_script: boolean;
-	}[];
+	}>;
 	stats: {
 		timings: {
 			total: number;


### PR DESCRIPTION
I found one more rule we have in `@sveltejs/eslint-config` that's missing here. I tried to just apply that package as a base config here, but it was too complicated - there's a lot of stuff that's different about this repo like CJS examples, linting of markdown, etc. that we don't have in the other repos at the moment