### PR TITLE
chore: disable workflows for v1 branch, enable workflows for v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,11 @@ on:
   push:
     branches:
       - main
-      - v1
+      - v3
   pull_request:
     branches:
       - main
-      - v1
+      - v3
 env:
   # we call `pnpm playwright install` instead
   PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - v1
+      - v3
 permissions: {}
 
 jobs:


### PR DESCRIPTION
this allows us to publish pre-releases from v3 after entering pre mode there