### PR TITLE
breaking: remove support for 14 and 16

### DIFF
--- a/.changeset/big-items-shave.md
+++ b/.changeset/big-items-shave.md
@@ -1,0 +1,6 @@
+---
+'@sveltejs/vite-plugin-svelte-inspector': major
+'@sveltejs/vite-plugin-svelte': major
+---
+
+breaking: update minimum supported node version to node18

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         # pseudo-matrix for convenience, NEVER use more than a single combination
-        node: [16]
+        node: [18]
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v4
@@ -73,16 +73,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [16]
+        node: [18]
         os: [ubuntu-latest, macos-latest, windows-latest]
         svelte: [4]
         include:
-          - node: 14
-            os: ubuntu-latest
-            svelte: 3
-          - node: 18
-            os: ubuntu-latest
-            svelte: 4
           - node: 20
             os: ubuntu-latest
             svelte: 4
@@ -92,17 +86,11 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - name: install pnpm
-        if: matrix.node != 14
         shell: bash
         run: |
           PNPM_VER=$(jq -r '.packageManager | if .[0:5] == "pnpm@" then .[5:] else "packageManager in package.json does not start with pnpm@\n" | halt_error(1)  end' package.json)
           echo installing pnpm version $PNPM_VER
           npm i -g pnpm@$PNPM_VER
-      - name: install legacy pnpm for node14
-        if: matrix.node == 14
-        run: |
-          npm i -g pnpm@^7.33.0
-          tmppkg="$(jq '.engines.pnpm = "^7.33.0"' package.json)" && echo -E "${tmppkg}" > package.json && tmppkg=""
       - name: use svelte 3
         if: matrix.svelte == 3
         run: |
@@ -113,11 +101,7 @@ jobs:
           cache: 'pnpm'
           cache-dependency-path: '**/pnpm-lock.yaml'
       - name: install
-        if: matrix.node != 14 && matrix.svelte != 3
         run: pnpm install --frozen-lockfile --prefer-offline --ignore-scripts
-      - name: install for node14 or svelte3
-        if: matrix.node == 14 || matrix.svelte == 3
-        run: pnpm install --no-frozen-lockfile --prefer-offline --ignore-scripts
       - name: install playwright chromium
         run: pnpm playwright install chromium
       - name: run tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         # pseudo-matrix for convenience, NEVER use more than a single combination
-        node: [16]
+        node: [18]
         os: [ubuntu-latest]
     steps:
       - name: checkout

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "packageManager": "pnpm@8.7.5",
   "engines": {
     "pnpm": "^8.6.3",
-    "node": "^14.18.0 || >= 16"
+    "node": "^18.0.0 || >=20"
   },
   "pnpm": {
     "overrides": {

--- a/packages/vite-plugin-svelte-inspector/package.json
+++ b/packages/vite-plugin-svelte-inspector/package.json
@@ -19,7 +19,7 @@
     "check:types": "tsc --noEmit"
   },
   "engines": {
-    "node": "^14.18.0 || >= 16"
+    "node": "^18.0.0 || >=20"
   },
   "repository": {
     "type": "git",

--- a/packages/vite-plugin-svelte/package.json
+++ b/packages/vite-plugin-svelte/package.json
@@ -20,7 +20,7 @@
     "check:types": "tsc --noEmit"
   },
   "engines": {
-    "node": "^14.18.0 || >= 16"
+    "node": "^18.0.0 || >=20"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
node16 is end of life and vite5 also requires node18.

fixes #722 