### PR TITLE
fix: use workspace selector on internal peer deps

### DIFF
--- a/packages/vite-plugin-svelte-inspector/package.json
+++ b/packages/vite-plugin-svelte-inspector/package.json
@@ -40,7 +40,7 @@
     "debug": "^4.3.4"
   },
   "peerDependencies": {
-    "@sveltejs/vite-plugin-svelte": "^2.2.0",
+    "@sveltejs/vite-plugin-svelte": "workspace:^",
     "svelte": "^4.0.0",
     "vite": "^5.0.0-beta.1 || ^5.0.0"
   },

--- a/packages/vite-plugin-svelte/package.json
+++ b/packages/vite-plugin-svelte/package.json
@@ -38,7 +38,7 @@
   },
   "homepage": "https://github.com/sveltejs/vite-plugin-svelte#readme",
   "dependencies": {
-    "@sveltejs/vite-plugin-svelte-inspector": "^1.0.4",
+    "@sveltejs/vite-plugin-svelte-inspector": "workspace:^",
     "debug": "^4.3.4",
     "deepmerge": "^4.3.1",
     "kleur": "^4.1.5",


### PR DESCRIPTION
we had them on regular ranges to avoid changesets creating extra versions, but now we have to rely on it to set the initial change correctly