### PR TITLE
experiment: try to declare virtual css modules sideeffect free

### DIFF
--- a/packages/e2e-tests/css-nosideeffects/__tests__/css-nosideeffects.spec.ts
+++ b/packages/e2e-tests/css-nosideeffects/__tests__/css-nosideeffects.spec.ts
@@ -1,0 +1,20 @@
+import { browserLogs, findAssetFile, getColor, getText, isBuild } from '~utils';
+
+test('should not have failed requests', async () => {
+	browserLogs.forEach((msg) => {
+		expect(msg).not.toMatch('404');
+	});
+});
+
+test('should render Gold', async () => {
+	expect(await getText('h1')).toBe('Gold');
+	expect(await getColor('h1')).toBe('gold');
+});
+
+if (isBuild) {
+	test('should omit magenta', async () => {
+		const css = await findAssetFile(/index.*\.css/);
+		expect(css).toContain('gold');
+		expect(css).not.toContain('magenta');
+	});
+}

--- a/packages/e2e-tests/css-nosideeffects/index.html
+++ b/packages/e2e-tests/css-nosideeffects/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
+
+		<title>Svelte app</title>
+
+		<script type="module" src="/src/main.js"></script>
+	</head>
+
+	<body></body>
+</html>

--- a/packages/e2e-tests/css-nosideeffects/package.json
+++ b/packages/e2e-tests/css-nosideeffects/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "e2e-tests-css-none",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "@sveltejs/vite-plugin-svelte": "workspace:^",
+    "svelte": "^4.2.1",
+    "vite": "^5.0.0-beta.2"
+  },
+  "sideEffectsX": [
+    "remove X in the name and this works"
+  ]
+}

--- a/packages/e2e-tests/css-nosideeffects/src/App.svelte
+++ b/packages/e2e-tests/css-nosideeffects/src/App.svelte
@@ -1,0 +1,5 @@
+<script>
+	import { Gold } from './components/index.js';
+</script>
+
+<Gold />

--- a/packages/e2e-tests/css-nosideeffects/src/components/Gold.svelte
+++ b/packages/e2e-tests/css-nosideeffects/src/components/Gold.svelte
@@ -1,0 +1,7 @@
+<h1>Gold</h1>
+
+<style>
+	h1 {
+		color: gold;
+	}
+</style>

--- a/packages/e2e-tests/css-nosideeffects/src/components/Magenta.svelte
+++ b/packages/e2e-tests/css-nosideeffects/src/components/Magenta.svelte
@@ -1,0 +1,7 @@
+<h1>Magenta</h1>
+
+<style>
+	h1 {
+		color: magenta;
+	}
+</style>

--- a/packages/e2e-tests/css-nosideeffects/src/components/index.js
+++ b/packages/e2e-tests/css-nosideeffects/src/components/index.js
@@ -1,0 +1,8 @@
+// this is a barrel file reexporting multiple svelte components
+// App.svelte imports Gold from here and
+// we want to prevent the css of Magenta.svelte from being included in the final output
+
+// using /*@__NO_SIDE_EFFECTS__*/ or /*@__PURE__*/ here
+// leads to RollupError: Cannot read properties of null (reading 'type')
+export { default as Gold } from './Gold.svelte';
+export { default as Magenta } from './Magenta.svelte';

--- a/packages/e2e-tests/css-nosideeffects/src/components/index.js
+++ b/packages/e2e-tests/css-nosideeffects/src/components/index.js
@@ -1,8 +1,5 @@
 // this is a barrel file reexporting multiple svelte components
 // App.svelte imports Gold from here and
 // we want to prevent the css of Magenta.svelte from being included in the final output
-
-// using /*@__NO_SIDE_EFFECTS__*/ or /*@__PURE__*/ here
-// leads to RollupError: Cannot read properties of null (reading 'type')
 export { default as Gold } from './Gold.svelte';
 export { default as Magenta } from './Magenta.svelte';

--- a/packages/e2e-tests/css-nosideeffects/src/main.js
+++ b/packages/e2e-tests/css-nosideeffects/src/main.js
@@ -1,0 +1,7 @@
+import App from './App.svelte';
+
+const app = new App({
+	target: document.body
+});
+
+export default app;

--- a/packages/e2e-tests/css-nosideeffects/src/vite-env.d.ts
+++ b/packages/e2e-tests/css-nosideeffects/src/vite-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="svelte" />
+/// <reference types="vite/client" />

--- a/packages/e2e-tests/css-nosideeffects/vite.config.js
+++ b/packages/e2e-tests/css-nosideeffects/vite.config.js
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vite';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+	plugins: [svelte({ emitCss: true, experimental: { noCssModuleSideEffects: true } })],
+	build: {
+		minify: false,
+		rollupOptions: {
+			treeshake: {
+				preset: 'smallest',
+				moduleSideEffects: (id) => {
+					if (id.endsWith('svelte&type=style&lang.css')) {
+						return false; // DOES NOT WORK
+					}
+				}
+			}
+		}
+	}
+});

--- a/packages/vite-plugin-svelte/src/index.d.ts
+++ b/packages/vite-plugin-svelte/src/index.d.ts
@@ -170,6 +170,12 @@ interface ExperimentalOptions {
 	 * @default false
 	 */
 	disableSvelteResolveWarnings?: boolean;
+
+	/**
+	 *
+	 * @default false
+	 */
+	noCssModuleSideEffects?: boolean;
 }
 
 type ModuleFormat = NonNullable<'esm'>;

--- a/packages/vite-plugin-svelte/src/index.js
+++ b/packages/vite-plugin-svelte/src/index.js
@@ -105,7 +105,14 @@ export function svelte(inlineOptions) {
 						if (query.svelte && query.type === 'style') {
 							const css = cache.getCSS(svelteRequest);
 							if (css) {
-								return css;
+								if (options.experimental?.noCssModuleSideEffects && options.emitCss) {
+									return {
+										...css,
+										moduleSideEffects: false // DOES NOT WORK
+									};
+								} else {
+									return css;
+								}
 							}
 						}
 						// prevent vite asset plugin from loading files as url that should be compiled in transform

--- a/packages/vite-plugin-svelte/src/utils/compile.js
+++ b/packages/vite-plugin-svelte/src/utils/compile.js
@@ -140,7 +140,8 @@ export const _createCompileSvelte = (makeHot) => {
 			// compiler might not emit css with mode none or it may be empty
 			if (emitCss && hasCss) {
 				// TODO properly update sourcemap?
-				compiled.js.code += `\nimport ${JSON.stringify(cssId)};\n`;
+				// ADDING PURE OR NO_SIDE_EFFECTS here does not work
+				compiled.js.code += `\n/*@__NO_SIDE_EFFECTS__*/import ${JSON.stringify(cssId)};\n`;
 			}
 
 			// only apply hmr when not in ssr context and hot options are set

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -258,6 +258,18 @@ importers:
         specifier: ^5.0.0-beta.2
         version: 5.0.0-beta.2(@types/node@18.17.19)(sass@1.68.0)(stylus@0.60.0)
 
+  packages/e2e-tests/css-nosideeffects:
+    devDependencies:
+      '@sveltejs/vite-plugin-svelte':
+        specifier: workspace:^
+        version: link:../../vite-plugin-svelte
+      svelte:
+        specifier: ^4.2.1
+        version: 4.2.1
+      vite:
+        specifier: ^5.0.0-beta.2
+        version: 5.0.0-beta.2(@types/node@18.17.19)(sass@1.68.0)(stylus@0.60.0)
+
   packages/e2e-tests/custom-extensions:
     devDependencies:
       '@sveltejs/vite-plugin-svelte':


### PR DESCRIPTION
unfortunately the only thing that seems to work is using the `sideEffects` field in package.json.

using annotation comments isn't working for import/export and both returning moduleSideEffects: false from the load hook or a custom rollup.treeshake function does not lead to the magenta css being omitted in the testcase :(