### PR TITLE
feat(preprocess): check preprocess dependencies for anomalies

### DIFF
--- a/.changeset/funny-waves-poke.md
+++ b/.changeset/funny-waves-poke.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': minor
+---
+
+feat(preprocess): add warnings in case preprocess dependencies contain anomalies

--- a/packages/vite-plugin-svelte/src/utils/preprocess.js
+++ b/packages/vite-plugin-svelte/src/utils/preprocess.js
@@ -150,7 +150,7 @@ export function checkPreprocessDependencies(filename, dependencies) {
 		warnings.push({
 			code: 'vite-plugin-svelte-preprocess-depends-on-self',
 			message:
-				'svelte.preprocess returned this file as a dependency of itself. This can be caused by invalid configuration or importing generated code that depends on .svelte files (eg. tailwind base css)',
+				'svelte.preprocess returned this file as a dependency of itself. This can be caused by an invalid configuration or importing generated code that depends on .svelte files (eg. tailwind base css)',
 			filename
 		});
 	}
@@ -158,7 +158,7 @@ export function checkPreprocessDependencies(filename, dependencies) {
 	if (dependencies.length > 10) {
 		warnings.push({
 			code: 'vite-plugin-svelte-preprocess-many-dependencies',
-			message: `preprocess depends on more than 10 external files which can cause slow builds and poor DX, try to reduce them. Found: ${dependencies.join(
+			message: `svelte.preprocess depends on more than 10 external files which can cause slow builds and poor DX, try to reduce them. Found: ${dependencies.join(
 				', '
 			)}`,
 			filename


### PR DESCRIPTION
#### depending on itself 
this is usually a sign for a bad setup/import, see #763 


#### depending on many files
all these files have to be read separately and changing one of them leads to a hot reload of the component. Depending on a few files is ok, but many cause issues.


Messages get added as extra compiler warnings using the `vite-plugin-svelte-preprocess-` prefix. This way users can opt to ignore them via `onwarn` hook. 

Are these checks too rigid and do we need FAQ entries and link them in the messages?