### PR TITLE
chore: revert to regular version selectors 

### DIFF
--- a/packages/vite-plugin-svelte-inspector/package.json
+++ b/packages/vite-plugin-svelte-inspector/package.json
@@ -40,7 +40,7 @@
     "debug": "^4.3.4"
   },
   "peerDependencies": {
-    "@sveltejs/vite-plugin-svelte": "workspace:^",
+    "@sveltejs/vite-plugin-svelte": "^3.0.0-next.0 || ^3.0.0",
     "svelte": "^4.0.0",
     "vite": "^5.0.0-beta.1 || ^5.0.0"
   },

--- a/packages/vite-plugin-svelte/package.json
+++ b/packages/vite-plugin-svelte/package.json
@@ -38,7 +38,7 @@
   },
   "homepage": "https://github.com/sveltejs/vite-plugin-svelte#readme",
   "dependencies": {
-    "@sveltejs/vite-plugin-svelte-inspector": "workspace:^",
+    "@sveltejs/vite-plugin-svelte-inspector": "^2.0.0-next.0 || ^2.0.0",
     "debug": "^4.3.4",
     "deepmerge": "^4.3.1",
     "kleur": "^4.1.5",


### PR DESCRIPTION
to avoid changesets cross bumping all the time