### PR TITLE
chore: fix test run when linking vite

### DIFF
--- a/packages/vite-plugin-svelte/__tests__/preprocess.spec.js
+++ b/packages/vite-plugin-svelte/__tests__/preprocess.spec.js
@@ -8,9 +8,15 @@ const fixtureDir = normalizePath(
 	path.join(path.dirname(fileURLToPath(import.meta.url)), 'fixtures', 'preprocess')
 );
 
+/** @type {import('vite').InlineConfig} */
+const inlineConfig = {
+	configFile: false,
+	root: fixtureDir
+};
+
 describe('vitePreprocess', () => {
 	it('returns function', () => {
-		const preprocessorGroup = vitePreprocess({ script: true, style: true });
+		const preprocessorGroup = vitePreprocess({ script: true, style: inlineConfig });
 		expect(typeof preprocessorGroup).toBe('object');
 		expect(typeof preprocessorGroup.script).toBe('function');
 		expect(typeof preprocessorGroup.style).toBe('function');
@@ -18,7 +24,7 @@ describe('vitePreprocess', () => {
 
 	describe('style', async () => {
 		it('preprocess with postcss if no lang', async () => {
-			const preprocessorGroup = vitePreprocess({ style: {} });
+			const preprocessorGroup = vitePreprocess({ style: inlineConfig });
 			const style = /**@type {import('svelte/types/compiler/preprocess').Preprocessor} */ (
 				preprocessorGroup.style
 			);
@@ -37,7 +43,9 @@ describe('vitePreprocess', () => {
 		});
 
 		it('produces sourcemap with relative filename', async () => {
-			const preprocessorGroup = vitePreprocess({ style: { css: { devSourcemap: true } } });
+			const preprocessorGroup = vitePreprocess({
+				style: { ...inlineConfig, css: { devSourcemap: true } }
+			});
 			const style = /**@type {import('svelte/types/compiler/preprocess').Preprocessor} */ (
 				preprocessorGroup.style
 			);

--- a/packages/vite-plugin-svelte/package.json
+++ b/packages/vite-plugin-svelte/package.json
@@ -53,6 +53,7 @@
   "devDependencies": {
     "@types/debug": "^4.1.10",
     "esbuild": "^0.19.5",
+    "sass": "^1.69.4",
     "svelte": "^4.2.2",
     "vite": "^5.0.0-beta.11"
   }

--- a/packages/vite-plugin-svelte/src/utils/load-svelte-config.js
+++ b/packages/vite-plugin-svelte/src/utils/load-svelte-config.js
@@ -16,14 +16,13 @@ export const knownSvelteConfigNames = [
 	'svelte.config.mjs'
 ];
 
-// hide dynamic import from ts transform to prevent it turning into a require
-// see https://github.com/microsoft/TypeScript/issues/43329#issuecomment-811606238
-// also use timestamp query to avoid caching on reload
-const dynamicImportDefault = new Function(
-	'path',
-	'timestamp',
-	'return import(path + "?t=" + timestamp).then(m => m.default)'
-);
+/**
+ * @param {string} filePath
+ * @param {number} timestamp
+ */
+async function dynamicImportDefault(filePath, timestamp) {
+	return await import(filePath + '?t=' + timestamp).then((m) => m.default);
+}
 
 /** @type {import('../index.d.ts').loadSvelteConfig} */
 export async function loadSvelteConfig(viteConfig, inlineOptions) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -767,6 +767,9 @@ importers:
       esbuild:
         specifier: ^0.19.5
         version: 0.19.5
+      sass:
+        specifier: ^1.69.4
+        version: 1.69.4
       svelte:
         specifier: ^4.2.2
         version: 4.2.2


### PR DESCRIPTION
- Install `sass` in `packages/vite-plugin-svelte` so the `vitePreprocess` unit test is able to import `sass`
- Add `inlineConfig` in `vitePreprocess` unit test so it has a proper `root` to resolve `sass`
- Refactor dynamic import hack to normal import
  - I'm not really sure why, but ever since https://github.com/vitejs/vite/pull/14544 it causes Vitest to error with:

```bash
 FAIL  packages/e2e-tests/import-queries/__tests__/import-queries.spec.ts > ssrLoadModule
TypeError: A dynamic import callback was not specified.
 ❯ eval packages/vite-plugin-svelte/src/utils/load-svelte-config.js:22:30
     20| // see https://github.com/microsoft/TypeScript/issues/43329#issuecomment-811606238
     21| // also use timestamp query to avoid caching on reload
     22| const dynamicImportDefault = new Function(
       |                              ^
     23|  'path',
     24|  'timestamp',
 ❯ Module.loadSvelteConfig packages/vite-plugin-svelte/src/utils/load-svelte-config.js:39:26
 ❯ Module.preResolveOptions packages/vite-plugin-svelte/src/utils/options.js:146:9
 ❯ config packages/vite-plugin-svelte/src/index.js:57:21
 ❯ runConfigHook ../vite/packages/vite/src/node/packages.ts:17905:31
 ❯ resolveConfig ../vite/packages/vite/src/node/packages.ts:17353:20
 ❯ _createServer ../vite/packages/vite/src/node/packages.ts:16592:20
 ❯ packages/e2e-tests/import-queries/__tests__/import-queries.spec.ts:135:10

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
Serialized Error: { code: 'ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING' }
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯
```

But anyways it's good that we can remove the hack today as we don't use TS.