### PR TITLE
fix: use improved regex for script and style from svelte

### DIFF
--- a/.changeset/eighty-oranges-brush.md
+++ b/.changeset/eighty-oranges-brush.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+fix: improve checking of script and style in .svelte code to work with new generic= attribute

--- a/packages/vite-plugin-svelte/src/utils/compile.js
+++ b/packages/vite-plugin-svelte/src/utils/compile.js
@@ -12,7 +12,11 @@ import { mapToRelative } from './sourcemaps.js';
 import { enhanceCompileError } from './error.js';
 import { isSvelte5 } from './svelte-version.js';
 
-const scriptLangRE = /<script [^>]*lang=["']?([^"' >]+)["']?[^>]*>/;
+// TODO this is a patched version of https://github.com/sveltejs/vite-plugin-svelte/pull/796/files#diff-3bce0b33034aad4b35ca094893671f7e7ddf4d27254ae7b9b0f912027a001b15R10
+// which is closer to the other regexes in at least not falling into commented script
+// but ideally would be shared exactly with svelte and other tools that use it
+const scriptLangRE =
+	/<!--[^]*?-->|<script (?:[^>]*|(?:[^=>'"/]+=(?:"[^"]*"|'[^']*'|[^>\s])\s+)*)lang=["']?([^"' >]+)["']?[^>]*>/;
 
 /**
  * @param {Function} [makeHot]

--- a/packages/vite-plugin-svelte/src/utils/compile.js
+++ b/packages/vite-plugin-svelte/src/utils/compile.js
@@ -16,7 +16,7 @@ import { isSvelte5 } from './svelte-version.js';
 // which is closer to the other regexes in at least not falling into commented script
 // but ideally would be shared exactly with svelte and other tools that use it
 const scriptLangRE =
-	/<!--[^]*?-->|<script (?:[^>]*|(?:[^=>'"/]+=(?:"[^"]*"|'[^']*'|[^>\s])\s+)*)lang=["']?([^"' >]+)["']?[^>]*>/;
+	/<!--[^]*?-->|<script (?:[^>]*|(?:[^=>'"/]+=(?:"[^"]*"|'[^']*'|[^>\s]+)\s+)*)lang=["']?([^"' >]+)["']?[^>]*>/;
 
 /**
  * @param {Function} [makeHot]

--- a/packages/vite-plugin-svelte/src/utils/error.js
+++ b/packages/vite-plugin-svelte/src/utils/error.js
@@ -143,7 +143,7 @@ export function enhanceCompileError(err, originalCode, preprocessors) {
 
 	// Handle incorrect CSS preprocessor usage
 	if (err.code === 'css-syntax-error') {
-		// Reference from Svelte:https://github.com/sveltejs/svelte/blob/9926347ad9dbdd0f3324d5538e25dcb7f5e442f8/packages/svelte/src/compiler/preprocess/index.js#L257
+		// Reference from Svelte: https://github.com/sveltejs/svelte/blob/9926347ad9dbdd0f3324d5538e25dcb7f5e442f8/packages/svelte/src/compiler/preprocess/index.js#L257
 		const styleRe =
 			/<!--[^]*?-->|<style((?:\s+[^=>'"/]+=(?:"[^"]*"|'[^']*'|[^>\s]+)|\s+[^=>'"/]+)*\s*)(?:\/>|>([\S\s]*?)<\/style>)/g;
 

--- a/packages/vite-plugin-svelte/src/utils/error.js
+++ b/packages/vite-plugin-svelte/src/utils/error.js
@@ -114,9 +114,9 @@ export function enhanceCompileError(err, originalCode, preprocessors) {
 
 	// Handle incorrect TypeScript usage
 	if (err.code === 'parse-error') {
-		// Reference from Svelte: https://github.com/sveltejs/svelte/blob/e0271f0fc7b3191ba3d5fc7982ec09d7cb0d0ac9/packages/svelte/src/compiler/preprocess/index.js#L258
+		// Reference from Svelte: https://github.com/sveltejs/svelte/blob/9926347ad9dbdd0f3324d5538e25dcb7f5e442f8/packages/svelte/src/compiler/preprocess/index.js#L259
 		const scriptRe =
-			/<!--[^]*?-->|<script((?:\s+[^=>'"/]+=(?:"[^"]*"|'[^']*'|[^>\s])|\s+[^=>'"/]+)*\s*)(?:\/>|>([\S\s]*?)<\/script>)/g;
+			/<!--[^]*?-->|<script((?:\s+[^=>'"/]+=(?:"[^"]*"|'[^']*'|[^>\s]+)|\s+[^=>'"/]+)*\s*)(?:\/>|>([\S\s]*?)<\/script>)/g;
 		const errIndex = err.pos ?? -1;
 
 		let m;
@@ -143,9 +143,9 @@ export function enhanceCompileError(err, originalCode, preprocessors) {
 
 	// Handle incorrect CSS preprocessor usage
 	if (err.code === 'css-syntax-error') {
-		// Reference from Svelte: https://github.com/sveltejs/svelte/blob/e0271f0fc7b3191ba3d5fc7982ec09d7cb0d0ac9/packages/svelte/src/compiler/preprocess/index.js#L256
+		// Reference from Svelte:https://github.com/sveltejs/svelte/blob/9926347ad9dbdd0f3324d5538e25dcb7f5e442f8/packages/svelte/src/compiler/preprocess/index.js#L257
 		const styleRe =
-			/<!--[^]*?-->|<style((?:\s+[^=>'"/]+=(?:"[^"]*"|'[^']*'|[^>\s])|\s+[^=>'"/]+)*\s*)(?:\/>|>([\S\s]*?)<\/style>)/g;
+			/<!--[^]*?-->|<style((?:\s+[^=>'"/]+=(?:"[^"]*"|'[^']*'|[^>\s]+)|\s+[^=>'"/]+)*\s*)(?:\/>|>([\S\s]*?)<\/style>)/g;
 
 		let m;
 		while ((m = styleRe.exec(originalCode))) {

--- a/packages/vite-plugin-svelte/src/utils/error.js
+++ b/packages/vite-plugin-svelte/src/utils/error.js
@@ -114,8 +114,9 @@ export function enhanceCompileError(err, originalCode, preprocessors) {
 
 	// Handle incorrect TypeScript usage
 	if (err.code === 'parse-error') {
-		// Reference from Svelte: https://github.com/sveltejs/svelte/blob/800f6c076be5dd87dd4d2e9d66c59b973d54d84b/packages/svelte/src/compiler/preprocess/index.js#L262
-		const scriptRe = /<script(\s[^]*?)?(?:>([^]*?)<\/script>|\/>)/gi;
+		// Reference from Svelte: https://github.com/sveltejs/svelte/blob/e0271f0fc7b3191ba3d5fc7982ec09d7cb0d0ac9/packages/svelte/src/compiler/preprocess/index.js#L258
+		const scriptRe =
+			/<!--[^]*?-->|<script((?:\s+[^=>'"/]+=(?:"[^"]*"|'[^']*'|[^>\s])|\s+[^=>'"/]+)*\s*)(?:\/>|>([\S\s]*?)<\/script>)/g;
 		const errIndex = err.pos ?? -1;
 
 		let m;
@@ -142,7 +143,9 @@ export function enhanceCompileError(err, originalCode, preprocessors) {
 
 	// Handle incorrect CSS preprocessor usage
 	if (err.code === 'css-syntax-error') {
-		const styleRe = /<style(\s[^]*?)?(?:>([^]*?)<\/style>|\/>)/gi;
+		// Reference from Svelte: https://github.com/sveltejs/svelte/blob/e0271f0fc7b3191ba3d5fc7982ec09d7cb0d0ac9/packages/svelte/src/compiler/preprocess/index.js#L256
+		const styleRe =
+			/<!--[^]*?-->|<style((?:\s+[^=>'"/]+=(?:"[^"]*"|'[^']*'|[^>\s])|\s+[^=>'"/]+)*\s*)(?:\/>|>([\S\s]*?)<\/style>)/g;
 
 		let m;
 		while ((m = styleRe.exec(originalCode))) {


### PR DESCRIPTION
see #796 

not a fan of the complexity in these regexes or the fact that we copy them.

For the script lang regex in compile.js we could think about using a spy preprocessor to get the attribute value.
For the error messages, should this be something svelte itself emits so that other tools also benefit?

