### PR TITLE
Update faq.md : missing exports condition : svelte property must be r…

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -221,7 +221,7 @@ Example:
 ```diff
 // package.json
   "files": ["dist"],
-  "svelte": "dist/index.js",
+-  "svelte": "dist/index.js",
 + "exports": {
 +   ".": {
 +     "svelte": "./dist/index.js"


### PR DESCRIPTION
…emoved

If the svelte property remains in package.json, running "npm run dev" still displays the warning :  "[vite-plugin-svelte] WARNING: The following packages use a svelte resolve configuration in package.json that has conflicting results and is going to cause problems future."

Confirmed by the [SvelteKit Packaging Doc](https://kit.svelte.dev/docs/packaging#anatomy-of-a-package-json-svelte) that mentioned it as being only a field.