### PR TITLE
Lowers log level to debug

### DIFF
--- a/.changeset/wet-drinks-call.md
+++ b/.changeset/wet-drinks-call.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+Update log level for HMR updates where the output is functionally equivalent to the previous version to "debug"

--- a/packages/vite-plugin-svelte/src/handle-hot-update.js
+++ b/packages/vite-plugin-svelte/src/handle-hot-update.js
@@ -105,7 +105,9 @@ function jsChanged(prev, next, filename) {
 	const isLooseEqual = isCodeEqual(normalizeJsCode(prevJs), normalizeJsCode(nextJs));
 	if (!isStrictEqual && isLooseEqual) {
 		log.debug(
-			`ignoring compiler output js change for ${filename} as it is equal to previous output after normalization`
+			`ignoring compiler output js change for ${filename} as it is equal to previous output after normalization`,
+			undefined,
+			'hmr'
 		);
 	}
 	return !isLooseEqual;

--- a/packages/vite-plugin-svelte/src/handle-hot-update.js
+++ b/packages/vite-plugin-svelte/src/handle-hot-update.js
@@ -104,7 +104,7 @@ function jsChanged(prev, next, filename) {
 	}
 	const isLooseEqual = isCodeEqual(normalizeJsCode(prevJs), normalizeJsCode(nextJs));
 	if (!isStrictEqual && isLooseEqual) {
-		log.warn(
+		log.debug(
 			`ignoring compiler output js change for ${filename} as it is equal to previous output after normalization`
 		);
 	}


### PR DESCRIPTION
This message isn't immediately actionable for developers and can reasonably be considered debugging output. Therefore, the log level has been updated to reflect this.

This fixes #803.