### PR TITLE
fix: publish to npm with version-2 tag 

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint": "pnpm check:lint --fix",
     "format": "pnpm check:format --write",
     "fixup": "run-s lint format",
-    "release": "pnpm changeset publish",
+    "release": "pnpm changeset publish --tag version-2",
     "prepare": "husky install",
     "playwright": "playwright-core"
   },


### PR DESCRIPTION
to avoid overriding latest tag thats used for 3.x on main branch

see https://github.com/changesets/changesets/blob/main/docs/command-line-options.md#publish

caveat: this would also tag vite-plugin-svelte-inspector as version-2 even if that is 1.x today. But i don't think we are going to release another 1.x version and even if we could manually sync it.

A more future-proof solution could be to bump inspector to the same major as v-p-s or change to a more generic tag like `previous`.