### PR TITLE
fix: update Vite peer dependency version

### DIFF
--- a/packages/vite-plugin-svelte/package.json
+++ b/packages/vite-plugin-svelte/package.json
@@ -51,7 +51,7 @@
   },
   "peerDependencies": {
     "svelte": "^4.0.0 || ^5.0.0-next.0",
-    "vite": "^5.0.0"
+    "vite": "^5.0.3"
   },
   "devDependencies": {
     "@types/debug": "^4.1.12",


### PR DESCRIPTION
Sets 5.0.3 as the minimum because earlier versions are broken with SvelteKit