### PR TITLE
chore: allow Vite 5

### DIFF
--- a/.changeset/chilled-parents-beam.md
+++ b/.changeset/chilled-parents-beam.md
@@ -1,0 +1,6 @@
+---
+'@sveltejs/vite-plugin-svelte-inspector': patch
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+chore: allow Vite 5

--- a/.changeset/chilled-parents-beam.md
+++ b/.changeset/chilled-parents-beam.md
@@ -1,6 +1,6 @@
 ---
-'@sveltejs/vite-plugin-svelte-inspector': patch
-'@sveltejs/vite-plugin-svelte': patch
+'@sveltejs/vite-plugin-svelte-inspector': minor
+'@sveltejs/vite-plugin-svelte': minor
 ---
 
-chore: allow Vite 5
+feat: support Vite 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,13 +4,9 @@ name: CI
 on:
   push:
     branches:
-      - main
-      - v1
       - v2
   pull_request:
     branches:
-      - main
-      - v1
       - v2
 env:
   # we call `pnpm playwright install` instead
@@ -78,16 +74,32 @@ jobs:
         node: [16]
         os: [ubuntu-latest, macos-latest, windows-latest]
         svelte: [4]
+        vite: [4]
         include:
           - node: 14
             os: ubuntu-latest
             svelte: 3
+            vite: 4
           - node: 18
             os: ubuntu-latest
             svelte: 4
+            vite: 4
           - node: 20
             os: ubuntu-latest
             svelte: 4
+            vite: 4
+          - node: 14
+            os: ubuntu-latest
+            svelte: 3
+            vite: 5
+          - node: 18
+            os: ubuntu-latest
+            svelte: 4
+            vite: 5
+          - node: 20
+            os: ubuntu-latest
+            svelte: 4
+            vite: 5
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
@@ -120,6 +132,9 @@ jobs:
       - name: install for node14 or svelte3
         if: matrix.node == 14 || matrix.svelte == 3
         run: pnpm install --no-frozen-lockfile --prefer-offline --ignore-scripts
+      - name: install vite 5
+        if: matrix.vite == 5
+        run: pnpm update -r --latest vite
       - name: install playwright chromium
         run: pnpm playwright install chromium
       - name: run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,10 +88,6 @@ jobs:
             os: ubuntu-latest
             svelte: 4
             vite: 4
-          - node: 14
-            os: ubuntu-latest
-            svelte: 3
-            vite: 5
           - node: 18
             os: ubuntu-latest
             svelte: 4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
         run: pnpm install --no-frozen-lockfile --prefer-offline --ignore-scripts
       - name: install vite 5
         if: matrix.vite == 5
-        run: pnpm update -r --latest vite
+        run: pnpm i -Dw vite@^5.0.3 && pnpm install
       - name: install playwright chromium
         run: pnpm playwright install chromium
       - name: run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
         run: pnpm install --no-frozen-lockfile --prefer-offline --ignore-scripts
       - name: install vite 5
         if: matrix.vite == 5
-        run: pnpm i -Dw vite@^5.0.3 && pnpm install
+        run: pnpm i -Dw --no-frozen-lockfile vite@^5.0.3
       - name: install playwright chromium
         run: pnpm playwright install chromium
       - name: run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
         run: pnpm install --no-frozen-lockfile --prefer-offline --ignore-scripts
       - name: install vite 5
         if: matrix.vite == 5
-        run: pnpm i -Dw --no-frozen-lockfile vite@^5.0.3
+        run: pnpm i -Dw vite@^5.0.3 && pnpm install --no-frozen-lockfile
       - name: install playwright chromium
         run: pnpm playwright install chromium
       - name: run tests

--- a/packages/e2e-tests/import-queries/__tests__/import-queries.spec.ts
+++ b/packages/e2e-tests/import-queries/__tests__/import-queries.spec.ts
@@ -1,6 +1,6 @@
 import { browserLogs, fetchFromPage, getText, isBuild, testDir } from '~utils';
-import { createServer, ViteDevServer } from 'vite';
-import { VERSION } from 'svelte/compiler';
+import { createServer, version as viteVersion, ViteDevServer } from 'vite';
+import { VERSION as svelteVersion } from 'svelte/compiler';
 
 function normalizeSnapshot(result: string) {
 	// during dev, the import is rewritten but can vary on the v= hash. replace with stable short import
@@ -13,12 +13,13 @@ function normalizeSnapshot(result: string) {
 		.replace(/"total": *\d+\.\d+/g, '"total":0.123456789'); // svelte compile stats
 }
 
-const svelteMajor = VERSION.split('.', 1)[0];
+const vite5 = viteVersion.startsWith('5');
+const svelteMajor = svelteVersion.split('.', 1)[0];
 function snapshotFilename(name: string) {
 	return `./__snapshots__/svelte-${svelteMajor}/${name}.txt`;
 }
 
-describe('raw', () => {
+describe.skipIf(vite5)('raw', () => {
 	test('does not have failed requests', async () => {
 		browserLogs.forEach((msg) => {
 			expect(msg).not.toMatch('404');
@@ -90,7 +91,7 @@ describe('raw', () => {
 
 // vitest prints a warning about obsolete snapshots during build tests, ignore it, they are used in dev tests.
 // always regenerate snapshots with `pnpm test:serve import-queries -u` and check the diffs if they are correct
-describe.runIf(isBuild)('snapshots not obsolete warning', async () => {
+describe.skipIf(vite5).runIf(isBuild)('snapshots not obsolete warning', async () => {
 	afterAll(() => {
 		console.log(
 			'Ignore the obsolete snapshot warnings for ssrLoadModule snapshots from vitest during test:build, they are used in test:serve'
@@ -101,7 +102,7 @@ describe.runIf(isBuild)('snapshots not obsolete warning', async () => {
 	});
 });
 
-describe.runIf(!isBuild)('direct', () => {
+describe.skipIf(vite5).runIf(!isBuild)('direct', () => {
 	test('Dummy.svelte?direct&svelte&type=style&sourcemap&lang.css', async () => {
 		const response = await fetchFromPage(
 			'src/Dummy.svelte?direct&svelte&type=style&sourcemap&lang.css',
@@ -128,7 +129,7 @@ describe.runIf(!isBuild)('direct', () => {
 	});
 });
 
-describe.runIf(!isBuild)('ssrLoadModule', () => {
+describe.skipIf(vite5).runIf(!isBuild)('ssrLoadModule', () => {
 	let vite: ViteDevServer;
 	let ssrLoadDummy;
 	beforeAll(async () => {

--- a/packages/e2e-tests/kit-node/__tests__/kit.spec.ts
+++ b/packages/e2e-tests/kit-node/__tests__/kit.spec.ts
@@ -336,7 +336,7 @@ describe('kit-node', () => {
 				);
 				expectArrayEqual(
 					config.resolve.mainFields,
-					['svelte', 'module', 'jsnext:main', 'jsnext'],
+					['svelte', 'browser', 'module', 'jsnext:main', 'jsnext'],
 					`resolve.mainFields in ${filename}`
 				);
 				expectArrayEqual(

--- a/packages/e2e-tests/kit-node/__tests__/kit.spec.ts
+++ b/packages/e2e-tests/kit-node/__tests__/kit.spec.ts
@@ -16,7 +16,10 @@ import {
 
 import glob from 'tiny-glob';
 import path from 'node:path';
+import { version as viteVersion } from 'vite';
 import { describe, expect, it } from 'vitest';
+
+const vite5 = viteVersion.startsWith('5');
 
 describe('kit-node', () => {
 	describe('index route', () => {
@@ -336,7 +339,9 @@ describe('kit-node', () => {
 				);
 				expectArrayEqual(
 					config.resolve.mainFields,
-					['svelte', 'browser', 'module', 'jsnext:main', 'jsnext'],
+					vite5
+						? ['svelte', 'browser', 'module', 'jsnext:main', 'jsnext']
+						: ['svelte', 'module', 'jsnext:main', 'jsnext'],
 					`resolve.mainFields in ${filename}`
 				);
 				expectArrayEqual(

--- a/packages/e2e-tests/vite-ssr-esm/package.json
+++ b/packages/e2e-tests/vite-ssr-esm/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "node server",
     "build": "run-s build:client build:server",
-    "build:client": "vite build --ssrManifest --outDir dist/client",
+    "build:client": "vite build --ssrManifest .vite/ssr-manifest.json --outDir dist/client",
     "build:server": "vite build --ssr src/entry-server.js --outDir dist/server",
     "preview": "cross-env NODE_ENV=production node server",
     "debug": "node --inspect-brk server"

--- a/packages/e2e-tests/vite-ssr-esm/server.js
+++ b/packages/e2e-tests/vite-ssr-esm/server.js
@@ -21,7 +21,7 @@ async function createServer(root = process.cwd(), isProd = process.env.NODE_ENV 
 	const manifest = isProd
 		? // @ts-ignore
 
-		  JSON.parse(fs.readFileSync(resolve('dist/client/ssr-manifest.json'), 'utf-8'))
+		  JSON.parse(fs.readFileSync(resolve('dist/client/.vite/ssr-manifest.json'), 'utf-8'))
 		: {};
 
 	const app = express();

--- a/packages/playground/big-component-library-vite-ssr/package.json
+++ b/packages/playground/big-component-library-vite-ssr/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "node server",
     "build": "npm run build:client && npm run build:server",
-    "build:client": "vite build --ssrManifest --outDir dist/client",
+    "build:client": "vite build --ssrManifest .vite/ssr-manifest.json --outDir dist/client",
     "build:server": "vite build --ssr src/entry-server.js --outDir dist/server",
     "preview": "cross-env NODE_ENV=production node server"
   },

--- a/packages/playground/big-component-library-vite-ssr/server.js
+++ b/packages/playground/big-component-library-vite-ssr/server.js
@@ -9,7 +9,7 @@ const base = process.env.BASE || '/';
 // Cached production assets
 const templateHtml = isProduction ? await fs.readFile('./dist/client/index.html', 'utf-8') : '';
 const ssrManifest = isProduction
-	? await fs.readFile('./dist/client/ssr-manifest.json', 'utf-8')
+	? await fs.readFile('./dist/client/.vite/ssr-manifest.json', 'utf-8')
 	: undefined;
 
 // Create http server

--- a/packages/vite-plugin-svelte-inspector/package.json
+++ b/packages/vite-plugin-svelte-inspector/package.json
@@ -42,7 +42,7 @@
   "peerDependencies": {
     "@sveltejs/vite-plugin-svelte": "^2.2.0",
     "svelte": "^3.54.0 || ^4.0.0",
-    "vite": "^4.0.0"
+    "vite": "^4.0.0 || ^5.0.0"
   },
   "devDependencies": {
     "@types/debug": "^4.1.8",

--- a/packages/vite-plugin-svelte/package.json
+++ b/packages/vite-plugin-svelte/package.json
@@ -48,7 +48,7 @@
   },
   "peerDependencies": {
     "svelte": "^3.54.0 || ^4.0.0 || ^5.0.0-next.0",
-    "vite": "^4.0.0"
+    "vite": "^4.0.0 || ^5.0.3"
   },
   "devDependencies": {
     "@types/debug": "^4.1.8",

--- a/packages/vite-plugin-svelte/src/utils/constants.js
+++ b/packages/vite-plugin-svelte/src/utils/constants.js
@@ -1,6 +1,6 @@
 import { isSvelte3 } from './svelte-version.js';
 
-export const VITE_RESOLVE_MAIN_FIELDS = ['module', 'jsnext:main', 'jsnext'];
+export const VITE_RESOLVE_MAIN_FIELDS = ['browser', 'module', 'jsnext:main', 'jsnext'];
 
 export const SVELTE_RESOLVE_MAIN_FIELDS = ['svelte'];
 

--- a/packages/vite-plugin-svelte/src/utils/constants.js
+++ b/packages/vite-plugin-svelte/src/utils/constants.js
@@ -1,6 +1,11 @@
 import { isSvelte3 } from './svelte-version.js';
+import { version as viteVersion } from 'vite';
 
-export const VITE_RESOLVE_MAIN_FIELDS = ['browser', 'module', 'jsnext:main', 'jsnext'];
+const vite5 = viteVersion.startsWith('5');
+
+export const VITE_RESOLVE_MAIN_FIELDS = vite5
+	? ['browser', 'module', 'jsnext:main', 'jsnext']
+	: ['module', 'jsnext:main', 'jsnext'];
 
 export const SVELTE_RESOLVE_MAIN_FIELDS = ['svelte'];
 


### PR DESCRIPTION
https://github.com/sveltejs/kit/pull/10818 is very complicated and a breaking change. This would be a much simpler solution. We can bump the dependency version in a couple of months to move everyone to `vite-plugin-svelte` 3 when we release SvelteKit 2

We don't have to fix any bugs in v2. We can still fix them just in v3 and tell non-SvelteKit users to upgrade to v3 and tell SvelteKit users they'll get any fixes in a couple of months. If there are any major issues that arise that need to be backported I can send PRs for it, I'm not too worried about that as `vite-plugin-svelte` has been very stable and battle tested already.