### PR TITLE
fix(test): relax js mime type test 

### DIFF
--- a/packages/e2e-tests/import-queries/__tests__/import-queries.spec.ts
+++ b/packages/e2e-tests/import-queries/__tests__/import-queries.spec.ts
@@ -120,11 +120,12 @@ describe.runIf(!isBuild)('direct', () => {
 		const response = await fetchFromPage(
 			'src/Dummy.svelte?direct&svelte&type=script&sourcemap&lang.js',
 			{
-				headers: { Accept: 'application/javascript' }
+				headers: { Accept: 'text/javascript' }
 			}
 		);
 		expect(response.ok).toBe(true);
-		expect(response.headers.get('Content-Type')).toBe('application/javascript');
+		// vite switched from application/javascript to text/javascript in 5.1
+		expect(response.headers.get('Content-Type')).toMatch(/^(?:text|application)\/javascript$/);
 		const js = await response.text();
 		expect(normalizeSnapshot(js)).toMatchFileSnapshot(snapshotFilename('direct-js'));
 	});


### PR DESCRIPTION
to accept both application/javascript and text/javascript response from devserver

see https://github.com/vitejs/vite/pull/15427