### PR TITLE
fix: correctly detect script language during compilation

### DIFF
--- a/.changeset/rare-buttons-argue.md
+++ b/.changeset/rare-buttons-argue.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+fix(compile): correctly determine script lang in files where a comment precedes the script tag

--- a/packages/vite-plugin-svelte/__tests__/compile.spec.js
+++ b/packages/vite-plugin-svelte/__tests__/compile.spec.js
@@ -45,5 +45,33 @@ describe('createCompileSvelte', () => {
 			);
 			expect(output.compiled.js.code).not.toContain('/* @__PURE__ */\n');
 		});
+
+		it('detects script lang', async () => {
+			const code = `<!-- this file uses typescript -->
+			<script lang="ts" generics="T">
+				const x = 1;
+				console.log('something',/* @__PURE__ */ new Date());
+				console.log('something else');
+			</script>
+			<div>{x}</div>`;
+
+			const compileSvelte = createCompileSvelte(options);
+			const output = await compileSvelte(
+				{
+					cssId: 'svelte-xxxxx',
+					query: {},
+					raw: false,
+					ssr: false,
+					timestamp: Date.now(),
+					id: 'id',
+					filename: '/some/File.svelte',
+					normalizedFilename: 'some/File.svelte'
+				},
+				code,
+				{}
+			);
+
+			expect(output.lang).toBe('ts');
+		});
 	});
 });

--- a/packages/vite-plugin-svelte/__tests__/compile.spec.js
+++ b/packages/vite-plugin-svelte/__tests__/compile.spec.js
@@ -48,6 +48,9 @@ describe('createCompileSvelte', () => {
 
 		it('detects script lang', async () => {
 			const code = `<!-- this file uses typescript -->
+			<!--
+			<script lang="foo">
+			</script>-->
 			<script lang="ts" generics="T">
 				const x = 1;
 				console.log('something',/* @__PURE__ */ new Date());

--- a/packages/vite-plugin-svelte/src/utils/compile.js
+++ b/packages/vite-plugin-svelte/src/utils/compile.js
@@ -16,7 +16,7 @@ import { isSvelte5 } from './svelte-version.js';
 // which is closer to the other regexes in at least not falling into commented script
 // but ideally would be shared exactly with svelte and other tools that use it
 const scriptLangRE =
-	/<!--[^]*?-->|<script (?:[^>]*|(?:[^=>'"/]+=(?:"[^"]*"|'[^']*'|[^>\s]+)\s+)*)lang=["']?([^"' >]+)["']?[^>]*>/;
+	/<script (?:[^>]*|(?:[^=>'"/]+=(?:"[^"]*"|'[^']*'|[^>\s]+)\s+)*)lang=["']?([^"' >]+)["']?[^>]*>/;
 
 /**
  * @param {Function} [makeHot]

--- a/packages/vite-plugin-svelte/src/utils/compile.js
+++ b/packages/vite-plugin-svelte/src/utils/compile.js
@@ -16,7 +16,7 @@ import { isSvelte5 } from './svelte-version.js';
 // which is closer to the other regexes in at least not falling into commented script
 // but ideally would be shared exactly with svelte and other tools that use it
 const scriptLangRE =
-	/<script (?:[^>]*|(?:[^=>'"/]+=(?:"[^"]*"|'[^']*'|[^>\s]+)\s+)*)lang=["']?([^"' >]+)["']?[^>]*>/;
+	/<!--[^]*?-->|<script (?:[^>]*|(?:[^=>'"/]+=(?:"[^"]*"|'[^']*'|[^>\s]+)\s+)*)lang=["']?([^"' >]+)["']?[^>]*>/g;
 
 /**
  * @param {Function} [makeHot]
@@ -184,10 +184,18 @@ export const _createCompileSvelte = (makeHot) => {
 			}
 		}
 
+		let lang = 'js';
+		for (const match of code.matchAll(scriptLangRE)) {
+			if (match[1]) {
+				lang = match[1];
+				break;
+			}
+		}
+
 		return {
 			filename,
 			normalizedFilename,
-			lang: code.match(scriptLangRE)?.[1] || 'js',
+			lang,
 			// @ts-ignore
 			compiled,
 			ssr,

--- a/packages/vite-plugin-svelte/src/utils/error.js
+++ b/packages/vite-plugin-svelte/src/utils/error.js
@@ -116,7 +116,7 @@ export function enhanceCompileError(err, originalCode, preprocessors) {
 	if (err.code === 'parse-error') {
 		// Reference from Svelte: https://github.com/sveltejs/svelte/blob/9926347ad9dbdd0f3324d5538e25dcb7f5e442f8/packages/svelte/src/compiler/preprocess/index.js#L259
 		const scriptRe =
-			/<script((?:\s+[^=>'"/]+=(?:"[^"]*"|'[^']*'|[^>\s]+)|\s+[^=>'"/]+)*\s*)(?:\/>|>([\S\s]*?)<\/script>)/g;
+			/<!--[^]*?-->|<script((?:\s+[^=>'"/]+=(?:"[^"]*"|'[^']*'|[^>\s]+)|\s+[^=>'"/]+)*\s*)(?:\/>|>([\S\s]*?)<\/script>)/g;
 		const errIndex = err.pos ?? -1;
 
 		let m;

--- a/packages/vite-plugin-svelte/src/utils/error.js
+++ b/packages/vite-plugin-svelte/src/utils/error.js
@@ -116,7 +116,7 @@ export function enhanceCompileError(err, originalCode, preprocessors) {
 	if (err.code === 'parse-error') {
 		// Reference from Svelte: https://github.com/sveltejs/svelte/blob/9926347ad9dbdd0f3324d5538e25dcb7f5e442f8/packages/svelte/src/compiler/preprocess/index.js#L259
 		const scriptRe =
-			/<!--[^]*?-->|<script((?:\s+[^=>'"/]+=(?:"[^"]*"|'[^']*'|[^>\s]+)|\s+[^=>'"/]+)*\s*)(?:\/>|>([\S\s]*?)<\/script>)/g;
+			/<script((?:\s+[^=>'"/]+=(?:"[^"]*"|'[^']*'|[^>\s]+)|\s+[^=>'"/]+)*\s*)(?:\/>|>([\S\s]*?)<\/script>)/g;
 		const errIndex = err.pos ?? -1;
 
 		let m;


### PR DESCRIPTION
The script regex introduced in c2017e0 matches comment blocks by mistake. This causes files using a header comment tag to always be detected as `js`.  This will produce an error if the script tag imports a module with an explicit `.js` extensions, where physically only a `.ts` file is present.

This PR removes the comment matching part of the two regex instances and introduces a test to verify the script language gets properly detected in the presence of a header comment block.

## Bug reproduction
```svelte
<!-- this file uses typescript -->
<script lang="ts">
  // the following will cause Failed to resolve import "./foo.js" from "src/*.svelte". Does the file exist?
  // if physically the file's name is `foo.ts`
  import { foo } from './foo.js';
</script>
```