### PR TITLE
fix: ignore changelog in lint

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -191,5 +191,9 @@ module.exports = {
 			}
 		}
 	],
-	ignorePatterns: ['packages/*/types/index.d.ts', 'packages/*/types/index.d.ts.map']
+	ignorePatterns: [
+		'packages/*/types/index.d.ts',
+		'packages/*/types/index.d.ts.map',
+		'packages/*/CHANGELOG.md'
+	]
 };


### PR DESCRIPTION
for some reason changesets decided to reformat it and i don't want to have to fight it.