### PR TITLE
chore(deps): update kit and adapter-node

### DIFF
--- a/packages/e2e-tests/inspector-kit/package.json
+++ b/packages/e2e-tests/inspector-kit/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview"
   },
   "devDependencies": {
-    "@sveltejs/kit": "^2.3.2",
+    "@sveltejs/kit": "^2.5.0",
     "@sveltejs/vite-plugin-svelte": "workspace:^",
     "svelte": "^4.2.9",
     "vite": "^5.0.11"

--- a/packages/e2e-tests/kit-node/package.json
+++ b/packages/e2e-tests/kit-node/package.json
@@ -11,8 +11,8 @@
     "package": "svelte-package && echo just here for testing, don't remove svelte-package!"
   },
   "devDependencies": {
-    "@sveltejs/adapter-node": "^2.1.1",
-    "@sveltejs/kit": "^2.3.2",
+    "@sveltejs/adapter-node": "^2.1.2",
+    "@sveltejs/kit": "^2.5.0",
     "@sveltejs/package": "^2.2.6",
     "@sveltejs/vite-plugin-svelte": "workspace:^",
     "e2e-test-dep-svelte-api-only": "file:../_test_dependencies/svelte-api-only",

--- a/packages/playground/big-component-library-kit/package.json
+++ b/packages/playground/big-component-library-kit/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@sveltejs/adapter-auto": "3.1.1",
-    "@sveltejs/kit": "^2.3.2",
+    "@sveltejs/kit": "^2.5.0",
     "@sveltejs/vite-plugin-svelte": "workspace:^",
     "carbon-components-svelte": "^0.82.8",
     "carbon-icons-svelte": "^12.4.2",

--- a/packages/playground/kit-demo-app/package.json
+++ b/packages/playground/kit-demo-app/package.json
@@ -13,7 +13,7 @@
     "@fontsource/fira-mono": "^5.0.8",
     "@neoconfetti/svelte": "^2.2.1",
     "@sveltejs/adapter-auto": "^3.1.1",
-    "@sveltejs/kit": "^2.3.2",
+    "@sveltejs/kit": "^2.5.0",
     "@sveltejs/vite-plugin-svelte": "workspace:^",
     "@types/cookie": "^0.6.0",
     "svelte": "^4.2.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -358,8 +358,8 @@ importers:
   packages/e2e-tests/inspector-kit:
     devDependencies:
       '@sveltejs/kit':
-        specifier: ^2.3.2
-        version: 2.3.2(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@4.2.9)(vite@5.0.12)
+        specifier: ^2.5.0
+        version: 2.5.0(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@4.2.9)(vite@5.0.12)
       '@sveltejs/vite-plugin-svelte':
         specifier: workspace:^
         version: link:../../vite-plugin-svelte
@@ -385,11 +385,11 @@ importers:
   packages/e2e-tests/kit-node:
     devDependencies:
       '@sveltejs/adapter-node':
-        specifier: ^2.1.1
-        version: 2.1.1(@sveltejs/kit@2.3.2)
+        specifier: ^2.1.2
+        version: 2.1.2(@sveltejs/kit@2.5.0)
       '@sveltejs/kit':
-        specifier: ^2.3.2
-        version: 2.3.2(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@4.2.9)(vite@5.0.12)
+        specifier: ^2.5.0
+        version: 2.5.0(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@4.2.9)(vite@5.0.12)
       '@sveltejs/package':
         specifier: ^2.2.6
         version: 2.2.6(svelte@4.2.9)(typescript@5.3.3)
@@ -647,10 +647,10 @@ importers:
     devDependencies:
       '@sveltejs/adapter-auto':
         specifier: 3.1.1
-        version: 3.1.1(@sveltejs/kit@2.3.2)
+        version: 3.1.1(@sveltejs/kit@2.5.0)
       '@sveltejs/kit':
-        specifier: ^2.3.2
-        version: 2.3.2(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@4.2.9)(vite@5.0.12)
+        specifier: ^2.5.0
+        version: 2.5.0(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@4.2.9)(vite@5.0.12)
       '@sveltejs/vite-plugin-svelte':
         specifier: workspace:^
         version: link:../../vite-plugin-svelte
@@ -732,10 +732,10 @@ importers:
         version: 2.2.1
       '@sveltejs/adapter-auto':
         specifier: ^3.1.1
-        version: 3.1.1(@sveltejs/kit@2.3.2)
+        version: 3.1.1(@sveltejs/kit@2.5.0)
       '@sveltejs/kit':
-        specifier: ^2.3.2
-        version: 2.3.2(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@4.2.9)(vite@5.0.12)
+        specifier: ^2.5.0
+        version: 2.5.0(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@4.2.9)(vite@5.0.12)
       '@sveltejs/vite-plugin-svelte':
         specifier: workspace:^
         version: link:../../vite-plugin-svelte
@@ -1811,29 +1811,29 @@ packages:
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
     dev: true
 
-  /@sveltejs/adapter-auto@3.1.1(@sveltejs/kit@2.3.2):
+  /@sveltejs/adapter-auto@3.1.1(@sveltejs/kit@2.5.0):
     resolution: {integrity: sha512-6LeZft2Fo/4HfmLBi5CucMYmgRxgcETweQl/yQoZo/895K3S9YWYN4Sfm/IhwlIpbJp3QNvhKmwCHbsqQNYQpw==}
     peerDependencies:
       '@sveltejs/kit': ^2.0.0
     dependencies:
-      '@sveltejs/kit': 2.3.2(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@4.2.9)(vite@5.0.12)
+      '@sveltejs/kit': 2.5.0(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@4.2.9)(vite@5.0.12)
       import-meta-resolve: 4.0.0
     dev: true
 
-  /@sveltejs/adapter-node@2.1.1(@sveltejs/kit@2.3.2):
-    resolution: {integrity: sha512-ypAqdvjoyfOEgucDbY3P6DM6nLEQ7OwiWMfyITKF8svffe9FIx1ow6uELJd1BzbCrouYndkQfc5m6ihj0xxqTg==}
+  /@sveltejs/adapter-node@2.1.2(@sveltejs/kit@2.5.0):
+    resolution: {integrity: sha512-ZfVY5buBclWHoBT+RbkMUViJGEIZ3IfT/0Hvhlgp+qC3LRZwp+wS1Zsw5dgkB2sFDZXctbLNXJtwlkjSp1mw0g==}
     peerDependencies:
       '@sveltejs/kit': ^2.0.0
     dependencies:
       '@rollup/plugin-commonjs': 25.0.7(rollup@4.9.1)
       '@rollup/plugin-json': 6.1.0(rollup@4.9.1)
       '@rollup/plugin-node-resolve': 15.2.3(rollup@4.9.1)
-      '@sveltejs/kit': 2.3.2(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@4.2.9)(vite@5.0.12)
+      '@sveltejs/kit': 2.5.0(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@4.2.9)(vite@5.0.12)
       rollup: 4.9.1
     dev: true
 
-  /@sveltejs/kit@2.3.2(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@4.2.9)(vite@5.0.12):
-    resolution: {integrity: sha512-AzGWV1TyUSkBuciy06E5NegXndIEgTthDtllv80qynEJFh8bZD62ZxLajiQLOsKGqRDilEQyshDARQxjIqiaqg==}
+  /@sveltejs/kit@2.5.0(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@4.2.9)(vite@5.0.12):
+    resolution: {integrity: sha512-1uyXvzC2Lu1FZa30T4y5jUAC21R309ZMRG0TPt+PPPbNUoDpy8zSmSNVWYaBWxYDqLGQ5oPNWvjvvF2IjJ1jmA==}
     engines: {node: '>=18.13'}
     hasBin: true
     requiresBuild: true


### PR DESCRIPTION
These fix security vulnerabilities, even if they don't affect our e2e tests we want them, and dependabot :robot:  complains too