### PR TITLE
chore(deps): revert using workspace:^ selector for svelte-inspector to actual version

### DIFF
--- a/packages/vite-plugin-svelte/package.json
+++ b/packages/vite-plugin-svelte/package.json
@@ -41,7 +41,7 @@
   },
   "homepage": "https://github.com/sveltejs/vite-plugin-svelte#readme",
   "dependencies": {
-    "@sveltejs/vite-plugin-svelte-inspector": "workspace:^",
+    "@sveltejs/vite-plugin-svelte-inspector": "^2.0.0",
     "debug": "^4.3.4",
     "deepmerge": "^4.3.1",
     "kleur": "^4.1.5",


### PR DESCRIPTION
Otherwise this can cause issues with changesets generating useless extra entries and it also fails svelte-ecosystem-ci  https://github.com/sveltejs/svelte-ecosystem-ci/actions/runs/7751646929/job/21139884659