### PR TITLE
Remove unnecessary enableSourcemap usage

### DIFF
--- a/.changeset/late-pans-guess.md
+++ b/.changeset/late-pans-guess.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+Remove unnecessary `enableSourcemap` option usage and prevent passing it in Svelte 5

--- a/packages/vite-plugin-svelte/src/utils/compile.js
+++ b/packages/vite-plugin-svelte/src/utils/compile.js
@@ -71,13 +71,6 @@ export const _createCompileSvelte = (makeHot) => {
 			const hash = `s-${safeBase64Hash(normalizedFilename)}`;
 			compileOptions.cssHash = () => hash;
 		}
-		if (ssr && compileOptions.enableSourcemap !== false) {
-			if (typeof compileOptions.enableSourcemap === 'object') {
-				compileOptions.enableSourcemap.css = false;
-			} else {
-				compileOptions.enableSourcemap = { js: true, css: false };
-			}
-		}
 
 		let preprocessed;
 		let preprocessors = options.preprocess;

--- a/packages/vite-plugin-svelte/src/utils/load-raw.js
+++ b/packages/vite-plugin-svelte/src/utils/load-raw.js
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import { toRollupError } from './error.js';
 import { log } from './log.js';
-import { isSvelte4 } from './svelte-version.js';
+import { isSvelte4, isSvelte5 } from './svelte-version.js';
 /**
  * utility function to compile ?raw and ?direct requests in load hook
  *
@@ -27,12 +27,14 @@ export async function loadRaw(svelteRequest, compileSvelte, options) {
 			compilerOptions: {
 				dev: false,
 				css: 'external',
-				enableSourcemap: query.sourcemap
-					? {
-							js: type === 'script' || type === 'all',
-							css: type === 'style' || type === 'all'
-						}
-					: false,
+				enableSourcemap: isSvelte5
+					? undefined
+					: query.sourcemap
+						? {
+								js: type === 'script' || type === 'all',
+								css: type === 'style' || type === 'all'
+							}
+						: false,
 				...svelteRequest.query.compilerOptions
 			},
 			hot: false,


### PR DESCRIPTION
`enableSourcemap` for styles was disabled in SSR due to a caveat with Vite <5 static env replacement, but since Vite 5, we don't have to workaround that anymore. So the `enableSourcemap` setting for it can be removed. Tests were added in https://github.com/sveltejs/vite-plugin-svelte/pull/201. In practice, this shouldn't incur a perf hit.

We also use `enableSourcemap` in another place - the advanced queries. Since Svelte 5, the option was deprecated:

```
The enableSourcemap option has been removed. Source maps are always generated now, and tooling can choose to ignore them.
```

So I disabled it for Svelte 5. We could also completely remove in for Svelte 4, but I didn't want to change too much.