### PR TITLE
fix(test): improve stability by removing a log and vite cache

### DIFF
--- a/.changeset/popular-islands-remain.md
+++ b/.changeset/popular-islands-remain.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+remove experimental warning for Svelte 5

--- a/.changeset/popular-islands-remain.md
+++ b/.changeset/popular-islands-remain.md
@@ -2,4 +2,4 @@
 '@sveltejs/vite-plugin-svelte': patch
 ---
 
-remove experimental warning for Svelte 5
+Remove log about experimental status of Svelte 5. Note that breaking changes can still occur while vite-plugin-svelte 4 is in prerelease mode

--- a/packages/e2e-tests/configfile-custom/src/main.js
+++ b/packages/e2e-tests/configfile-custom/src/main.js
@@ -1,7 +1,3 @@
 import App from './App.svelte';
-
-if (App.toString().startsWith('class ')) {
-	new App({ target: document.body });
-} else {
-	import('svelte').then(({ mount }) => mount(App, { target: document.body }));
-}
+import { mount } from 'svelte';
+mount(App, { target: document.body });

--- a/packages/e2e-tests/configfile-esm/src/main.js
+++ b/packages/e2e-tests/configfile-esm/src/main.js
@@ -1,7 +1,3 @@
 import App from './App.svelte';
-
-if (App.toString().startsWith('class ')) {
-	new App({ target: document.body });
-} else {
-	import('svelte').then(({ mount }) => mount(App, { target: document.body }));
-}
+import { mount } from 'svelte';
+mount(App, { target: document.body });

--- a/packages/e2e-tests/css-dev-sourcemap/src/main.js
+++ b/packages/e2e-tests/css-dev-sourcemap/src/main.js
@@ -1,7 +1,3 @@
 import App from './App.svelte';
-
-if (App.toString().startsWith('class ')) {
-	new App({ target: document.body });
-} else {
-	import('svelte').then(({ mount }) => mount(App, { target: document.body }));
-}
+import { mount } from 'svelte';
+mount(App, { target: document.body });

--- a/packages/e2e-tests/custom-extensions/src/main.js
+++ b/packages/e2e-tests/custom-extensions/src/main.js
@@ -1,7 +1,3 @@
 import App from './App.svelte';
-
-if (App.toString().startsWith('class ')) {
-	new App({ target: document.body });
-} else {
-	import('svelte').then(({ mount }) => mount(App, { target: document.body }));
-}
+import { mount } from 'svelte';
+mount(App, { target: document.body });

--- a/packages/e2e-tests/dynamic-compile-options/src/main.js
+++ b/packages/e2e-tests/dynamic-compile-options/src/main.js
@@ -1,7 +1,3 @@
 import App from './App.svelte';
-
-if (App.toString().startsWith('class ')) {
-	new App({ target: document.body });
-} else {
-	import('svelte').then(({ mount }) => mount(App, { target: document.body }));
-}
+import { mount } from 'svelte';
+mount(App, { target: document.body });

--- a/packages/e2e-tests/env/src/main.js
+++ b/packages/e2e-tests/env/src/main.js
@@ -1,7 +1,3 @@
 import App from './App.svelte';
-
-if (App.toString().startsWith('class ')) {
-	new App({ target: document.body });
-} else {
-	import('svelte').then(({ mount }) => mount(App, { target: document.body }));
-}
+import { mount } from 'svelte';
+mount(App, { target: document.body });

--- a/packages/e2e-tests/hmr/src/index.js
+++ b/packages/e2e-tests/hmr/src/index.js
@@ -1,7 +1,3 @@
 import App from './App.svelte';
-
-if (App.toString().startsWith('class ')) {
-	new App({ target: document.body });
-} else {
-	import('svelte').then(({ mount }) => mount(App, { target: document.body }));
-}
+import { mount } from 'svelte';
+mount(App, { target: document.body });

--- a/packages/e2e-tests/import-queries/src/main.js
+++ b/packages/e2e-tests/import-queries/src/main.js
@@ -1,7 +1,3 @@
 import App from './App.svelte';
-
-if (App.toString().startsWith('class ')) {
-	new App({ target: document.body });
-} else {
-	import('svelte').then(({ mount }) => mount(App, { target: document.body }));
-}
+import { mount } from 'svelte';
+mount(App, { target: document.body });

--- a/packages/e2e-tests/inspector-vite/src/main.js
+++ b/packages/e2e-tests/inspector-vite/src/main.js
@@ -1,7 +1,3 @@
 import App from './App.svelte';
-
-if (App.toString().startsWith('class ')) {
-	new App({ target: document.getElementById('app') });
-} else {
-	import('svelte').then(({ mount }) => mount(App, { target: document.getElementById('app') }));
-}
+import { mount } from 'svelte';
+mount(App, { target: document.body });

--- a/packages/e2e-tests/package-json-svelte-field/src/main.js
+++ b/packages/e2e-tests/package-json-svelte-field/src/main.js
@@ -1,7 +1,3 @@
 import App from './App.svelte';
-
-if (App.toString().startsWith('class ')) {
-	new App({ target: document.body });
-} else {
-	import('svelte').then(({ mount }) => mount(App, { target: document.body }));
-}
+import { mount } from 'svelte';
+mount(App, { target: document.body });

--- a/packages/e2e-tests/prebundle-svelte-deps/src/main.js
+++ b/packages/e2e-tests/prebundle-svelte-deps/src/main.js
@@ -1,7 +1,3 @@
 import App from './App.svelte';
-
-if (App.toString().startsWith('class ')) {
-	new App({ target: document.body });
-} else {
-	import('svelte').then(({ mount }) => mount(App, { target: document.body }));
-}
+import { mount } from 'svelte';
+mount(App, { target: document.body });

--- a/packages/e2e-tests/preprocess-with-vite/src/index.ts
+++ b/packages/e2e-tests/preprocess-with-vite/src/index.ts
@@ -1,6 +1,6 @@
 import App from './App.svelte';
-
 import { Hello } from './types.js';
+import { mount } from 'svelte';
 
 const hello: Hello = 'Hello';
 
@@ -10,8 +10,5 @@ const options = {
 		hello
 	}
 };
-if (App.toString().startsWith('class ')) {
-	new App(options);
-} else {
-	import('svelte').then(({ mount }) => mount(App, options));
-}
+
+mount(App, options);

--- a/packages/e2e-tests/resolve-exports-svelte/src/main.js
+++ b/packages/e2e-tests/resolve-exports-svelte/src/main.js
@@ -1,7 +1,3 @@
 import App from './App.svelte';
-
-if (App.toString().startsWith('class ')) {
-	new App({ target: document.body });
-} else {
-	import('svelte').then(({ mount }) => mount(App, { target: document.body }));
-}
+import { mount } from 'svelte';
+mount(App, { target: document.body });

--- a/packages/e2e-tests/svelte-preprocess/src/main.ts
+++ b/packages/e2e-tests/svelte-preprocess/src/main.ts
@@ -1,7 +1,3 @@
 import App from './App.svelte';
-
-if (App.toString().startsWith('class ')) {
-	new App({ target: document.getElementById('app') });
-} else {
-	import('svelte').then(({ mount }) => mount(App, { target: document.getElementById('app') }));
-}
+import { mount } from 'svelte';
+mount(App, { target: document.body });

--- a/packages/e2e-tests/ts-type-import/src/index.ts
+++ b/packages/e2e-tests/ts-type-import/src/index.ts
@@ -1,17 +1,12 @@
 import type { Test } from './lib.js';
 import { test } from './lib.js';
 import App from './App.svelte';
+import { mount } from 'svelte';
 
 main();
 
 export function main({ arg = true }: Test = {}): void {
 	if (arg && test()) {
-		if (App.toString().startsWith('class ')) {
-			new App({ target: document.body });
-		} else {
-			import('svelte').then(({ mount }) => {
-				mount(App, { target: document.body });
-			});
-		}
+		mount(App, { target: document.body });
 	}
 }

--- a/packages/e2e-tests/vitestSetup.ts
+++ b/packages/e2e-tests/vitestSetup.ts
@@ -237,7 +237,9 @@ export async function waitForViteConnect(page: Page, timeoutMS = 5000) {
 		pageConsoleListener = (data) => {
 			const text = data.text();
 			if (text.indexOf('[vite] connected.') > -1) {
-				resolve();
+				// TODO: this is a test to see if it becomes more reliable
+				// if thats the case, we have to update the logic here to use a later signal/event than connected log
+				setTimeout(() => resolve(), 500);
 			}
 		};
 		page.on('console', pageConsoleListener);

--- a/packages/e2e-tests/vitestSetup.ts
+++ b/packages/e2e-tests/vitestSetup.ts
@@ -237,9 +237,7 @@ export async function waitForViteConnect(page: Page, timeoutMS = 10000) {
 		pageConsoleListener = (data) => {
 			const text = data.text();
 			if (text.indexOf('[vite] connected.') > -1) {
-				// TODO: this is a test to see if it becomes more reliable
-				// if thats the case, we have to update the logic here to use a later signal/event than connected log
-				setTimeout(() => resolve(), isCI ? 2000 : 500);
+				resolve();
 			}
 		};
 		page.on('console', pageConsoleListener);

--- a/packages/e2e-tests/vitestSetup.ts
+++ b/packages/e2e-tests/vitestSetup.ts
@@ -221,7 +221,7 @@ async function goToUrlAndWaitForViteWSConnect(page: Page, url: string) {
 	return Promise.all([page.goto(url), waitForViteConnect(page, 15000)]);
 }
 
-export async function waitForViteConnect(page: Page, timeoutMS = 5000) {
+export async function waitForViteConnect(page: Page, timeoutMS = 10000) {
 	if (isBuild) {
 		return Promise.resolve(); // no vite websocket on build
 	}
@@ -239,7 +239,7 @@ export async function waitForViteConnect(page: Page, timeoutMS = 5000) {
 			if (text.indexOf('[vite] connected.') > -1) {
 				// TODO: this is a test to see if it becomes more reliable
 				// if thats the case, we have to update the logic here to use a later signal/event than connected log
-				setTimeout(() => resolve(), 500);
+				setTimeout(() => resolve(), isCI ? 2000 : 500);
 			}
 		};
 		page.on('console', pageConsoleListener);

--- a/packages/e2e-tests/vitestSetup.ts
+++ b/packages/e2e-tests/vitestSetup.ts
@@ -137,6 +137,12 @@ beforeAll(
 				if (!stat.isSymbolicLink()) {
 					console.error(`failed to symlink ${e2e_tests_node_modules} to ${temp_node_modules}`);
 				}
+				// ensure there is no leftover vite cache
+				const tempViteCache = path.join(temp_node_modules, '.vite');
+				if (fs.existsSync(tempViteCache)) {
+					await fs.rm(tempViteCache, { force: true, recursive: true });
+				}
+
 				await fs.mkdir(path.join(tempDir, 'logs'));
 				const customServerScript = path.resolve(path.dirname(testPath), 'serve.js');
 				const defaultServerScript = path.resolve(e2eTestsRoot, 'e2e-server.js');

--- a/packages/vite-plugin-svelte/src/index.js
+++ b/packages/vite-plugin-svelte/src/index.js
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import { svelteInspector } from '@sveltejs/vite-plugin-svelte-inspector';
 import { handleHotUpdate } from './handle-hot-update.js';
-import { log, logCompilerWarnings, logSvelte5Warning } from './utils/log.js';
+import { log, logCompilerWarnings } from './utils/log.js';
 import { createCompileSvelte } from './utils/compile.js';
 import { buildIdParser, buildModuleIdParser } from './utils/id.js';
 import {
@@ -23,9 +23,6 @@ import * as svelteCompiler from 'svelte/compiler';
  * @returns {import('vite').Plugin[]}
  */
 export function svelte(inlineOptions) {
-	// TODO remove for v-p-s 4.0.0
-	logSvelte5Warning();
-
 	if (process.env.DEBUG != null) {
 		log.setLevel('debug');
 	}

--- a/packages/vite-plugin-svelte/src/utils/log.js
+++ b/packages/vite-plugin-svelte/src/utils/log.js
@@ -1,7 +1,6 @@
 /* eslint-disable no-console */
 import { cyan, red, yellow } from 'kleur/colors';
 import debug from 'debug';
-import { VERSION } from 'svelte/compiler';
 
 /** @type {import('../types/log.d.ts').LogLevel[]} */
 const levels = ['debug', 'info', 'warn', 'error', 'silent'];
@@ -259,12 +258,4 @@ export function buildExtendedLogMessage(w) {
  */
 export function isDebugNamespaceEnabled(namespace) {
 	return debug.enabled(`${prefix}:${namespace}`);
-}
-
-export function logSvelte5Warning() {
-	const notice = `You are using Svelte ${VERSION}. Svelte 5 support is experimental, breaking changes can occur in any release until this notice is removed.`;
-	const wip = ['svelte-inspector: loaded but requires additional metadata to work'];
-	if (wip.length > 0) {
-		log.warn(`${notice}\nwork in progress:\n - ${wip.join('\n - ')}\n`);
-	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,7 +60,7 @@ importers:
         version: 5.1.3(eslint-config-prettier@9.1.0)(eslint@8.57.0)(prettier@3.2.5)
       eslint-plugin-svelte:
         specifier: ^2.37.0
-        version: 2.37.0(eslint@8.57.0)(svelte@5.0.0-next.121)
+        version: 2.37.0(eslint@8.57.0)(svelte@5.0.0-next.123)
       eslint-plugin-unicorn:
         specifier: ^52.0.0
         version: 52.0.0(eslint@8.57.0)
@@ -90,13 +90,13 @@ importers:
         version: 3.2.5
       prettier-plugin-svelte:
         specifier: ^3.2.3
-        version: 3.2.3(prettier@3.2.5)(svelte@5.0.0-next.121)
+        version: 3.2.3(prettier@3.2.5)(svelte@5.0.0-next.123)
       publint:
         specifier: ^0.2.7
         version: 0.2.7
       svelte:
         specifier: ^5.0.0-next.121
-        version: 5.0.0-next.121
+        version: 5.0.0-next.123
       typescript:
         specifier: ^5.4.5
         version: 5.4.5
@@ -133,7 +133,7 @@ importers:
     dependencies:
       svelte:
         specifier: ^5.0.0-next.121
-        version: 5.0.0-next.121
+        version: 5.0.0-next.123
 
   packages/e2e-tests/_test_dependencies/svelte-exports-simple:
     dependencies:
@@ -194,10 +194,10 @@ importers:
         version: 5.0.3(postcss@8.4.38)
       svelte:
         specifier: ^5.0.0-next.121
-        version: 5.0.0-next.121
+        version: 5.0.0-next.123
       svelte-preprocess:
         specifier: ^5.1.4
-        version: 5.1.4(postcss-load-config@5.0.3)(postcss@8.4.38)(svelte@5.0.0-next.121)(typescript@5.4.5)
+        version: 5.1.4(postcss-load-config@5.0.3)(postcss@8.4.38)(svelte@5.0.0-next.123)(typescript@5.4.5)
       vite:
         specifier: ^5.2.11
         version: 5.2.11(@types/node@20.12.7)(sass@1.75.0)(stylus@0.63.0)
@@ -213,7 +213,7 @@ importers:
         version: link:../../vite-plugin-svelte
       svelte:
         specifier: ^5.0.0-next.121
-        version: 5.0.0-next.121
+        version: 5.0.0-next.123
       vite:
         specifier: ^5.2.11
         version: 5.2.11(@types/node@20.12.7)(sass@1.75.0)(stylus@0.63.0)
@@ -229,10 +229,10 @@ importers:
         version: link:../../vite-plugin-svelte
       svelte:
         specifier: ^5.0.0-next.121
-        version: 5.0.0-next.121
+        version: 5.0.0-next.123
       svelte-preprocess:
         specifier: ^5.1.4
-        version: 5.1.4(postcss@8.4.38)(sass@1.75.0)(svelte@5.0.0-next.121)(typescript@5.4.5)
+        version: 5.1.4(postcss@8.4.38)(sass@1.75.0)(svelte@5.0.0-next.123)(typescript@5.4.5)
       vite:
         specifier: ^5.2.11
         version: 5.2.11(@types/node@20.12.7)(sass@1.75.0)(stylus@0.63.0)
@@ -247,7 +247,7 @@ importers:
         version: 1.75.0
       svelte:
         specifier: ^5.0.0-next.121
-        version: 5.0.0-next.121
+        version: 5.0.0-next.123
       vite:
         specifier: ^5.2.11
         version: 5.2.11(@types/node@20.12.7)(sass@1.75.0)(stylus@0.63.0)
@@ -259,7 +259,7 @@ importers:
         version: link:../../vite-plugin-svelte
       svelte:
         specifier: ^5.0.0-next.121
-        version: 5.0.0-next.121
+        version: 5.0.0-next.123
       vite:
         specifier: ^5.2.11
         version: 5.2.11(@types/node@20.12.7)(sass@1.75.0)(stylus@0.63.0)
@@ -289,7 +289,7 @@ importers:
         version: link:../../vite-plugin-svelte
       svelte:
         specifier: ^5.0.0-next.121
-        version: 5.0.0-next.121
+        version: 5.0.0-next.123
       vite:
         specifier: ^5.2.11
         version: 5.2.11(@types/node@20.12.7)(sass@1.75.0)(stylus@0.63.0)
@@ -301,7 +301,7 @@ importers:
         version: link:../../vite-plugin-svelte
       svelte:
         specifier: ^5.0.0-next.121
-        version: 5.0.0-next.121
+        version: 5.0.0-next.123
       vite:
         specifier: ^5.2.11
         version: 5.2.11(@types/node@20.12.7)(sass@1.75.0)(stylus@0.63.0)
@@ -323,7 +323,7 @@ importers:
         version: 3.3.2
       svelte:
         specifier: ^5.0.0-next.121
-        version: 5.0.0-next.121
+        version: 5.0.0-next.123
       vite:
         specifier: ^5.2.11
         version: 5.2.11(@types/node@20.12.7)(sass@1.75.0)(stylus@0.63.0)
@@ -338,7 +338,7 @@ importers:
         version: 1.75.0
       svelte:
         specifier: ^5.0.0-next.121
-        version: 5.0.0-next.121
+        version: 5.0.0-next.123
       vite:
         specifier: ^5.2.11
         version: 5.2.11(@types/node@20.12.7)(sass@1.75.0)(stylus@0.63.0)
@@ -347,13 +347,13 @@ importers:
     devDependencies:
       '@sveltejs/kit':
         specifier: ^2.5.6
-        version: 2.5.6(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.0.0-next.121)(vite@5.2.11)
+        version: 2.5.6(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.0.0-next.123)(vite@5.2.11)
       '@sveltejs/vite-plugin-svelte':
         specifier: workspace:^
         version: link:../../vite-plugin-svelte
       svelte:
         specifier: ^5.0.0-next.121
-        version: 5.0.0-next.121
+        version: 5.0.0-next.123
       vite:
         specifier: ^5.2.11
         version: 5.2.11(@types/node@20.12.7)(sass@1.75.0)(stylus@0.63.0)
@@ -365,7 +365,7 @@ importers:
         version: link:../../vite-plugin-svelte
       svelte:
         specifier: ^5.0.0-next.121
-        version: 5.0.0-next.121
+        version: 5.0.0-next.123
       vite:
         specifier: ^5.2.11
         version: 5.2.11(@types/node@20.12.7)(sass@1.75.0)(stylus@0.63.0)
@@ -377,10 +377,10 @@ importers:
         version: 5.0.1(@sveltejs/kit@2.5.6)
       '@sveltejs/kit':
         specifier: ^2.5.6
-        version: 2.5.6(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.0.0-next.121)(vite@5.2.11)
+        version: 2.5.6(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.0.0-next.123)(vite@5.2.11)
       '@sveltejs/package':
         specifier: ^2.3.1
-        version: 2.3.1(svelte@5.0.0-next.121)(typescript@5.4.5)
+        version: 2.3.1(svelte@5.0.0-next.123)(typescript@5.4.5)
       '@sveltejs/vite-plugin-svelte':
         specifier: workspace:^
         version: link:../../vite-plugin-svelte
@@ -392,13 +392,13 @@ importers:
         version: file:packages/e2e-tests/_test_dependencies/vite-plugins
       svelte:
         specifier: ^5.0.0-next.121
-        version: 5.0.0-next.121
+        version: 5.0.0-next.123
       svelte-check:
         specifier: ^3.6.9
-        version: 3.6.9(postcss@8.4.38)(svelte@5.0.0-next.121)
+        version: 3.6.9(postcss@8.4.38)(svelte@5.0.0-next.123)
       svelte-i18n:
         specifier: ^4.0.0
-        version: 4.0.0(svelte@5.0.0-next.121)
+        version: 4.0.0(svelte@5.0.0-next.123)
       tiny-glob:
         specifier: ^0.2.9
         version: 0.2.9
@@ -426,7 +426,7 @@ importers:
         version: 1.75.0
       svelte:
         specifier: ^5.0.0-next.121
-        version: 5.0.0-next.121
+        version: 5.0.0-next.123
       vite:
         specifier: ^5.2.11
         version: 5.2.11(@types/node@20.12.7)(sass@1.75.0)(stylus@0.63.0)
@@ -457,10 +457,10 @@ importers:
         version: 1.75.0
       svelte:
         specifier: ^5.0.0-next.121
-        version: 5.0.0-next.121
+        version: 5.0.0-next.123
       svelte-preprocess:
         specifier: ^5.1.4
-        version: 5.1.4(postcss@8.4.38)(sass@1.75.0)(svelte@5.0.0-next.121)(typescript@5.4.5)
+        version: 5.1.4(postcss@8.4.38)(sass@1.75.0)(svelte@5.0.0-next.123)(typescript@5.4.5)
       vite:
         specifier: ^5.2.11
         version: 5.2.11(@types/node@20.12.7)(sass@1.75.0)(stylus@0.63.0)
@@ -478,7 +478,7 @@ importers:
         version: 0.63.0
       svelte:
         specifier: ^5.0.0-next.121
-        version: 5.0.0-next.121
+        version: 5.0.0-next.123
       vite:
         specifier: ^5.2.11
         version: 5.2.11(@types/node@20.12.7)(sass@1.75.0)(stylus@0.63.0)
@@ -494,7 +494,7 @@ importers:
         version: link:../../vite-plugin-svelte
       svelte:
         specifier: ^5.0.0-next.121
-        version: 5.0.0-next.121
+        version: 5.0.0-next.123
       vite:
         specifier: ^5.2.11
         version: 5.2.11(@types/node@20.12.7)(sass@1.75.0)(stylus@0.63.0)
@@ -509,10 +509,10 @@ importers:
         version: 1.75.0
       svelte:
         specifier: ^5.0.0-next.121
-        version: 5.0.0-next.121
+        version: 5.0.0-next.123
       svelte-preprocess:
         specifier: ^5.1.4
-        version: 5.1.4(postcss@8.4.38)(sass@1.75.0)(svelte@5.0.0-next.121)(typescript@5.4.5)
+        version: 5.1.4(postcss@8.4.38)(sass@1.75.0)(svelte@5.0.0-next.123)(typescript@5.4.5)
       typescript:
         specifier: ^5.4.5
         version: 5.4.5
@@ -533,10 +533,10 @@ importers:
         version: 20.12.7
       svelte:
         specifier: ^5.0.0-next.121
-        version: 5.0.0-next.121
+        version: 5.0.0-next.123
       svelte-preprocess:
         specifier: ^5.1.4
-        version: 5.1.4(postcss@8.4.38)(sass@1.75.0)(svelte@5.0.0-next.121)(typescript@5.4.5)
+        version: 5.1.4(postcss@8.4.38)(sass@1.75.0)(svelte@5.0.0-next.123)(typescript@5.4.5)
       vite:
         specifier: ^5.2.11
         version: 5.2.11(@types/node@20.12.7)(sass@1.75.0)(stylus@0.63.0)
@@ -569,7 +569,7 @@ importers:
         version: 1.15.0
       svelte:
         specifier: ^5.0.0-next.121
-        version: 5.0.0-next.121
+        version: 5.0.0-next.123
       vite:
         specifier: ^5.2.11
         version: 5.2.11(@types/node@20.12.7)(sass@1.75.0)(stylus@0.63.0)
@@ -586,7 +586,7 @@ importers:
         version: link:../../e2e-tests/_test_dependencies/svelte-module
       svelte:
         specifier: ^5.0.0-next.121
-        version: 5.0.0-next.121
+        version: 5.0.0-next.123
       vite:
         specifier: ^5.2.11
         version: 5.2.11(@types/node@20.12.7)(sass@1.75.0)(stylus@0.63.0)
@@ -598,7 +598,7 @@ importers:
         version: link:../../vite-plugin-svelte
       svelte:
         specifier: ^5.0.0-next.121
-        version: 5.0.0-next.121
+        version: 5.0.0-next.123
       vite:
         specifier: ^5.2.11
         version: 5.2.11(@types/node@20.12.7)(sass@1.75.0)(stylus@0.63.0)
@@ -623,10 +623,10 @@ importers:
         version: 0.11.2
       svelte:
         specifier: ^5.0.0-next.121
-        version: 5.0.0-next.121
+        version: 5.0.0-next.123
       svelte-preprocess:
         specifier: ^5.1.4
-        version: 5.1.4(postcss@8.4.38)(sass@1.75.0)(svelte@5.0.0-next.121)(typescript@5.4.5)
+        version: 5.1.4(postcss@8.4.38)(sass@1.75.0)(svelte@5.0.0-next.123)(typescript@5.4.5)
       vite:
         specifier: ^5.2.11
         version: 5.2.11(@types/node@20.12.7)(sass@1.75.0)(stylus@0.63.0)
@@ -638,7 +638,7 @@ importers:
         version: 3.2.0(@sveltejs/kit@2.5.6)
       '@sveltejs/kit':
         specifier: ^2.5.6
-        version: 2.5.6(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.0.0-next.121)(vite@5.2.11)
+        version: 2.5.6(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.0.0-next.123)(vite@5.2.11)
       '@sveltejs/vite-plugin-svelte':
         specifier: workspace:^
         version: link:../../vite-plugin-svelte
@@ -656,13 +656,13 @@ importers:
         version: 4.17.21
       svelte:
         specifier: ^5.0.0-next.121
-        version: 5.0.0-next.121
+        version: 5.0.0-next.123
       svelte-check:
         specifier: ^3.6.9
-        version: 3.6.9(postcss@8.4.38)(svelte@5.0.0-next.121)
+        version: 3.6.9(postcss@8.4.38)(svelte@5.0.0-next.123)
       svelte-preprocess:
         specifier: ^5.1.4
-        version: 5.1.4(postcss@8.4.38)(sass@1.75.0)(svelte@5.0.0-next.121)(typescript@5.4.5)
+        version: 5.1.4(postcss@8.4.38)(sass@1.75.0)(svelte@5.0.0-next.123)(typescript@5.4.5)
       typescript:
         specifier: ^5.4.5
         version: 5.4.5
@@ -702,10 +702,10 @@ importers:
         version: 4.17.21
       svelte:
         specifier: ^5.0.0-next.121
-        version: 5.0.0-next.121
+        version: 5.0.0-next.123
       svelte-preprocess:
         specifier: ^5.1.4
-        version: 5.1.4(postcss@8.4.38)(sass@1.75.0)(svelte@5.0.0-next.121)(typescript@5.4.5)
+        version: 5.1.4(postcss@8.4.38)(sass@1.75.0)(svelte@5.0.0-next.123)(typescript@5.4.5)
       vite:
         specifier: ^5.2.11
         version: 5.2.11(@types/node@20.12.7)(sass@1.75.0)(stylus@0.63.0)
@@ -723,16 +723,16 @@ importers:
         version: 3.2.0(@sveltejs/kit@2.5.7)
       '@sveltejs/kit':
         specifier: ^2.5.7
-        version: 2.5.7(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.0.0-next.121)(vite@5.2.11)
+        version: 2.5.7(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.0.0-next.123)(vite@5.2.11)
       '@sveltejs/vite-plugin-svelte':
         specifier: workspace:^
         version: link:../../vite-plugin-svelte
       svelte:
         specifier: ^5.0.0-next.121
-        version: 5.0.0-next.121
+        version: 5.0.0-next.123
       svelte-check:
         specifier: ^3.7.0
-        version: 3.7.0(postcss@8.4.38)(svelte@5.0.0-next.121)
+        version: 3.7.0(postcss@8.4.38)(svelte@5.0.0-next.123)
       typescript:
         specifier: ^5.0.0
         version: 5.4.5
@@ -747,7 +747,7 @@ importers:
         version: link:../../vite-plugin-svelte
       svelte:
         specifier: ^5.0.0-next.121
-        version: 5.0.0-next.121
+        version: 5.0.0-next.123
       tinro:
         specifier: ^0.6.12
         version: 0.6.12
@@ -787,7 +787,7 @@ importers:
         version: 1.75.0
       svelte:
         specifier: ^5.0.0-next.121
-        version: 5.0.0-next.121
+        version: 5.0.0-next.123
       vite:
         specifier: ^5.2.11
         version: 5.2.11(@types/node@20.12.7)(sass@1.75.0)(stylus@0.63.0)
@@ -806,7 +806,7 @@ importers:
         version: 4.1.12
       svelte:
         specifier: ^5.0.0-next.121
-        version: 5.0.0-next.121
+        version: 5.0.0-next.123
       vite:
         specifier: ^5.2.11
         version: 5.2.11(@types/node@20.12.7)(sass@1.75.0)(stylus@0.63.0)
@@ -1915,7 +1915,7 @@ packages:
     peerDependencies:
       '@sveltejs/kit': ^2.0.0
     dependencies:
-      '@sveltejs/kit': 2.5.6(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.0.0-next.121)(vite@5.2.11)
+      '@sveltejs/kit': 2.5.6(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.0.0-next.123)(vite@5.2.11)
       import-meta-resolve: 4.0.0
     dev: true
 
@@ -1924,7 +1924,7 @@ packages:
     peerDependencies:
       '@sveltejs/kit': ^2.0.0
     dependencies:
-      '@sveltejs/kit': 2.5.7(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.0.0-next.121)(vite@5.2.11)
+      '@sveltejs/kit': 2.5.7(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.0.0-next.123)(vite@5.2.11)
       import-meta-resolve: 4.0.0
     dev: true
 
@@ -1936,11 +1936,11 @@ packages:
       '@rollup/plugin-commonjs': 25.0.7(rollup@4.9.6)
       '@rollup/plugin-json': 6.1.0(rollup@4.9.6)
       '@rollup/plugin-node-resolve': 15.2.3(rollup@4.9.6)
-      '@sveltejs/kit': 2.5.6(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.0.0-next.121)(vite@5.2.11)
+      '@sveltejs/kit': 2.5.6(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.0.0-next.123)(vite@5.2.11)
       rollup: 4.9.6
     dev: true
 
-  /@sveltejs/kit@2.5.6(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.0.0-next.121)(vite@5.2.11):
+  /@sveltejs/kit@2.5.6(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.0.0-next.123)(vite@5.2.11):
     resolution: {integrity: sha512-AYb02Jm5MfNqJHc8zrj7ScQAFAKmTUCkpkfoi8EVaZZDdnjkvI7L2GtnTDhpiXSAZRVitZX4qm59sMS1FgL+lQ==}
     engines: {node: '>=18.13'}
     hasBin: true
@@ -1962,12 +1962,12 @@ packages:
       sade: 1.8.1
       set-cookie-parser: 2.6.0
       sirv: 2.0.4
-      svelte: 5.0.0-next.121
+      svelte: 5.0.0-next.123
       tiny-glob: 0.2.9
       vite: 5.2.11(@types/node@20.12.7)(sass@1.75.0)(stylus@0.63.0)
     dev: true
 
-  /@sveltejs/kit@2.5.7(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.0.0-next.121)(vite@5.2.11):
+  /@sveltejs/kit@2.5.7(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.0.0-next.123)(vite@5.2.11):
     resolution: {integrity: sha512-6uedTzrb7nQrw6HALxnPrPaXdIN2jJJTzTIl96Z3P5NiG+OAfpdPbrWrvkJ3GN4CfWqrmU4dJqwMMRMTD/C7ow==}
     engines: {node: '>=18.13'}
     hasBin: true
@@ -1989,12 +1989,12 @@ packages:
       sade: 1.8.1
       set-cookie-parser: 2.6.0
       sirv: 2.0.4
-      svelte: 5.0.0-next.121
+      svelte: 5.0.0-next.123
       tiny-glob: 0.2.9
       vite: 5.2.11(@types/node@20.12.7)(sass@1.75.0)(stylus@0.63.0)
     dev: true
 
-  /@sveltejs/package@2.3.1(svelte@5.0.0-next.121)(typescript@5.4.5):
+  /@sveltejs/package@2.3.1(svelte@5.0.0-next.123)(typescript@5.4.5):
     resolution: {integrity: sha512-JvR2J4ost1oCn1CSdqenYRwGX/1RX+7LN+VZ71aPnz3JAlIFaEKQd1pBxlb+OSQTfeugJO0W39gB9voAbBO5ow==}
     engines: {node: ^16.14 || >=18}
     hasBin: true
@@ -2005,8 +2005,8 @@ packages:
       kleur: 4.1.5
       sade: 1.8.1
       semver: 7.5.4
-      svelte: 5.0.0-next.121
-      svelte2tsx: 0.7.0(svelte@5.0.0-next.121)(typescript@5.4.5)
+      svelte: 5.0.0-next.123
+      svelte2tsx: 0.7.0(svelte@5.0.0-next.123)(typescript@5.4.5)
     transitivePeerDependencies:
       - typescript
     dev: true
@@ -3481,7 +3481,7 @@ packages:
       synckit: 0.8.6
     dev: true
 
-  /eslint-plugin-svelte@2.37.0(eslint@8.57.0)(svelte@5.0.0-next.121):
+  /eslint-plugin-svelte@2.37.0(eslint@8.57.0)(svelte@5.0.0-next.123):
     resolution: {integrity: sha512-H/2Gz7agYHEMEEzRuLYuCmAIdjuBnbhFG9hOK0yCdSBvvJGJMkjo+lR6j67OIvLOavgp4L7zA5LnDKi8WqdPhQ==}
     engines: {node: ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -3503,8 +3503,8 @@ packages:
       postcss-safe-parser: 6.0.0(postcss@8.4.38)
       postcss-selector-parser: 6.0.16
       semver: 7.6.0
-      svelte: 5.0.0-next.121
-      svelte-eslint-parser: 0.34.0(svelte@5.0.0-next.121)
+      svelte: 5.0.0-next.123
+      svelte-eslint-parser: 0.34.0(svelte@5.0.0-next.123)
     transitivePeerDependencies:
       - supports-color
       - ts-node
@@ -5441,14 +5441,14 @@ packages:
       fast-diff: 1.3.0
     dev: true
 
-  /prettier-plugin-svelte@3.2.3(prettier@3.2.5)(svelte@5.0.0-next.121):
+  /prettier-plugin-svelte@3.2.3(prettier@3.2.5)(svelte@5.0.0-next.123):
     resolution: {integrity: sha512-wJq8RunyFlWco6U0WJV5wNCM7zpBFakS76UBSbmzMGpncpK98NZABaE+s7n8/APDCEVNHXC5Mpq+MLebQtsRlg==}
     peerDependencies:
       prettier: ^3.0.0
       svelte: ^5.0.0-next.121
     dependencies:
       prettier: 3.2.5
-      svelte: 5.0.0-next.121
+      svelte: 5.0.0-next.123
     dev: true
 
   /prettier@2.8.8:
@@ -6149,7 +6149,7 @@ packages:
     engines: {node: '>= 0.4'}
     dev: true
 
-  /svelte-check@3.6.9(postcss@8.4.38)(svelte@5.0.0-next.121):
+  /svelte-check@3.6.9(postcss@8.4.38)(svelte@5.0.0-next.123):
     resolution: {integrity: sha512-hDQrk3L0osX07djQyMiXocKysTLfusqi8AriNcCiQxhQR49/LonYolcUGMtZ0fbUR8HTR198Prrgf52WWU9wEg==}
     hasBin: true
     peerDependencies:
@@ -6161,8 +6161,8 @@ packages:
       import-fresh: 3.3.0
       picocolors: 1.0.0
       sade: 1.8.1
-      svelte: 5.0.0-next.121
-      svelte-preprocess: 5.1.4(postcss@8.4.38)(sass@1.75.0)(svelte@5.0.0-next.121)(typescript@5.4.5)
+      svelte: 5.0.0-next.123
+      svelte-preprocess: 5.1.4(postcss@8.4.38)(sass@1.75.0)(svelte@5.0.0-next.123)(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -6176,7 +6176,7 @@ packages:
       - sugarss
     dev: true
 
-  /svelte-check@3.7.0(postcss@8.4.38)(svelte@5.0.0-next.121):
+  /svelte-check@3.7.0(postcss@8.4.38)(svelte@5.0.0-next.123):
     resolution: {integrity: sha512-Va6sGL4Vy4znn0K+vaatk98zoBvG2aDee4y3r5X4S80z8DXfbACHvdLlyXa4C4c5tQzK9H0Uq2pbd20wH3ucjQ==}
     hasBin: true
     peerDependencies:
@@ -6188,8 +6188,8 @@ packages:
       import-fresh: 3.3.0
       picocolors: 1.0.0
       sade: 1.8.1
-      svelte: 5.0.0-next.121
-      svelte-preprocess: 5.1.4(postcss@8.4.38)(sass@1.75.0)(svelte@5.0.0-next.121)(typescript@5.4.5)
+      svelte: 5.0.0-next.123
+      svelte-preprocess: 5.1.4(postcss@8.4.38)(sass@1.75.0)(svelte@5.0.0-next.123)(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -6203,7 +6203,7 @@ packages:
       - sugarss
     dev: true
 
-  /svelte-eslint-parser@0.34.0(svelte@5.0.0-next.121):
+  /svelte-eslint-parser@0.34.0(svelte@5.0.0-next.123):
     resolution: {integrity: sha512-jOozxWbHVtIFt6fvettJK9T9aK1AyrcWBJzqcjqJxkr7QfgMYWjHNVlG/qFFOr72cw8mUVS/D/8BO6HlPEtNug==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -6217,10 +6217,10 @@ packages:
       espree: 9.6.1
       postcss: 8.4.38
       postcss-scss: 4.0.9(postcss@8.4.38)
-      svelte: 5.0.0-next.121
+      svelte: 5.0.0-next.123
     dev: true
 
-  /svelte-i18n@4.0.0(svelte@5.0.0-next.121):
+  /svelte-i18n@4.0.0(svelte@5.0.0-next.123):
     resolution: {integrity: sha512-4vivjKZADUMRIhTs38JuBNy3unbnh9AFRxWFLxq62P4NHic+/BaIZZlAsvqsCdnp7IdJf5EoSiH6TNdItcjA6g==}
     engines: {node: '>= 16'}
     hasBin: true
@@ -6233,11 +6233,11 @@ packages:
       estree-walker: 2.0.2
       intl-messageformat: 10.5.8
       sade: 1.8.1
-      svelte: 5.0.0-next.121
+      svelte: 5.0.0-next.123
       tiny-glob: 0.2.9
     dev: true
 
-  /svelte-preprocess@5.1.4(postcss-load-config@5.0.3)(postcss@8.4.38)(svelte@5.0.0-next.121)(typescript@5.4.5):
+  /svelte-preprocess@5.1.4(postcss-load-config@5.0.3)(postcss@8.4.38)(svelte@5.0.0-next.123)(typescript@5.4.5):
     resolution: {integrity: sha512-IvnbQ6D6Ao3Gg6ftiM5tdbR6aAETwjhHV+UKGf5bHGYR69RQvF1ho0JKPcbUON4vy4R7zom13jPjgdOWCQ5hDA==}
     engines: {node: '>= 16.0.0'}
     requiresBuild: true
@@ -6282,11 +6282,11 @@ packages:
       postcss-load-config: 5.0.3(postcss@8.4.38)
       sorcery: 0.11.0
       strip-indent: 3.0.0
-      svelte: 5.0.0-next.121
+      svelte: 5.0.0-next.123
       typescript: 5.4.5
     dev: true
 
-  /svelte-preprocess@5.1.4(postcss@8.4.38)(sass@1.75.0)(svelte@5.0.0-next.121)(typescript@5.4.5):
+  /svelte-preprocess@5.1.4(postcss@8.4.38)(sass@1.75.0)(svelte@5.0.0-next.123)(typescript@5.4.5):
     resolution: {integrity: sha512-IvnbQ6D6Ao3Gg6ftiM5tdbR6aAETwjhHV+UKGf5bHGYR69RQvF1ho0JKPcbUON4vy4R7zom13jPjgdOWCQ5hDA==}
     engines: {node: '>= 16.0.0'}
     requiresBuild: true
@@ -6331,11 +6331,11 @@ packages:
       sass: 1.75.0
       sorcery: 0.11.0
       strip-indent: 3.0.0
-      svelte: 5.0.0-next.121
+      svelte: 5.0.0-next.123
       typescript: 5.4.5
     dev: true
 
-  /svelte2tsx@0.7.0(svelte@5.0.0-next.121)(typescript@5.4.5):
+  /svelte2tsx@0.7.0(svelte@5.0.0-next.123)(typescript@5.4.5):
     resolution: {integrity: sha512-qAelcydnmuiDvD1HsrWi23RWx24RZTKRv6n4JaGC/pkoJfbLkJPQT2wa1qN0ZyfKTNLSyoj2FW9z62l/AUzUNA==}
     peerDependencies:
       svelte: ^5.0.0-next.121
@@ -6343,12 +6343,12 @@ packages:
     dependencies:
       dedent-js: 1.0.1
       pascal-case: 3.1.2
-      svelte: 5.0.0-next.121
+      svelte: 5.0.0-next.123
       typescript: 5.4.5
     dev: true
 
-  /svelte@5.0.0-next.121:
-    resolution: {integrity: sha512-dWxr42t8wv6iUmgKrYDG9RwQd2lf3vF2+ACYT7ziDnLeYItPM4sABmM8ptMaYL8czwtqpNzfCsxQR7ShN5PS9A==}
+  /svelte@5.0.0-next.123:
+    resolution: {integrity: sha512-EKdXcqT795J34V8TyyUO5ExI0amjeKBECA2t7Py8QeDTMgS9//pQElD0jKsCT/sfmKV4HEoOwf7sqPYINKEfUQ==}
     engines: {node: '>=18'}
     dependencies:
       '@ampproject/remapping': 2.2.1
@@ -7091,7 +7091,7 @@ packages:
     resolution: {directory: packages/e2e-tests/_test_dependencies/svelte-api-only, type: directory}
     name: e2e-test-dep-svelte-api-only
     dependencies:
-      svelte: 5.0.0-next.121
+      svelte: 5.0.0-next.123
 
   file:packages/e2e-tests/_test_dependencies/svelte-exports-simple:
     resolution: {directory: packages/e2e-tests/_test_dependencies/svelte-exports-simple, type: directory}


### PR DESCRIPTION
the warning was needed in vite-plugin-svelte 3.x because thats not a prerelease.

4.0.0-next will be in prerelease so breaking changes are expected. Inspector is going to work around the same time we release the first one.

cleaning .vite cache in test projects helped locally to avoid test fails on reruns.