### PR TITLE
Update FAQ to include section about inline asset URLs

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -246,4 +246,4 @@ Currently, Svelte does not support inline asset URLs, you can only specify it vi
 <img src="./assets/inline/url/to/asset.png" />
 ```
 
-2 recommended solutions are to use either [sveltejs/enhanced-img](https://kit.svelte.dev/docs/images#sveltejs-enhanced-img)(only for image elements) or [svelte-preprocess-import-assets](https://www.npmjs.com/package/svelte-preprocess-import-assets)(for all asset URLs).
+2 recommended solutions are to use either [sveltejs/enhanced-img](https://kit.svelte.dev/docs/images#sveltejs-enhanced-img) (only for image elements) or [svelte-preprocess-import-assets](https://www.npmjs.com/package/svelte-preprocess-import-assets) (for all asset URLs).

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -237,3 +237,9 @@ See the faq about [vite and prebundling](#what-is-going-on-with-vite-and-pre-bun
 > [svelte-package](https://kit.svelte.dev/docs/packaging) which already supports it.
 >
 > For backwards compatibility, you can keep the `svelte` field in addition to the `exports` condition. But make sure that both always resolve to the same files.
+
+### How do I manually specify an <img/> 'src', or any other asset, with an inline URL?
+
+Currently, Svelte does not support inline asset URLs, you can only specify it via an imported asset.
+
+2 recommended solutions are to use either [sveltejs/enhanced-img](https://kit.svelte.dev/docs/images#sveltejs-enhanced-img)(only for image elements) or [svelte-preprocess-import-assets](https://www.npmjs.com/package/svelte-preprocess-import-assets)(for all asset URLs).

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -238,12 +238,16 @@ See the faq about [vite and prebundling](#what-is-going-on-with-vite-and-pre-bun
 >
 > For backwards compatibility, you can keep the `svelte` field in addition to the `exports` condition. But make sure that both always resolve to the same files.
 
-### How do I manually specify an `<img/>` `src`, or any other asset, with an inline URL?
+### How can I use relative paths for asset references in svelte components like `<img src="./asset.png">`
 
-Currently, Svelte does not support inline asset URLs, you can only specify it via an imported asset, meaning that the following won't work:
+This is not supported out of the box. To resolve assets, you have to either import them like this:
 
+```html
+<script>
+  import assetUrl from './asset.png';
+</script>
+<img src="{assetUrl}" />
 ```
-<img src="./assets/inline/url/to/asset.png" />
-```
 
-2 recommended solutions are to use either [sveltejs/enhanced-img](https://kit.svelte.dev/docs/images#sveltejs-enhanced-img) (only for image elements) or [svelte-preprocess-import-assets](https://www.npmjs.com/package/svelte-preprocess-import-assets) (for all asset URLs).
+or use a separate tool to add this functionality.
+The 2 recommended solutions are [sveltejs/enhanced-img](https://kit.svelte.dev/docs/images#sveltejs-enhanced-img) (only for image elements) and [svelte-preprocess-import-assets](https://www.npmjs.com/package/svelte-preprocess-import-assets) (for all asset URLs).

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -240,6 +240,10 @@ See the faq about [vite and prebundling](#what-is-going-on-with-vite-and-pre-bun
 
 ### How do I manually specify an `<img/>` `src`, or any other asset, with an inline URL?
 
-Currently, Svelte does not support inline asset URLs, you can only specify it via an imported asset.
+Currently, Svelte does not support inline asset URLs, you can only specify it via an imported asset, meaning that the following won't work:
+
+```
+<img src="./assets/inline/url/to/asset.png" />
+```
 
 2 recommended solutions are to use either [sveltejs/enhanced-img](https://kit.svelte.dev/docs/images#sveltejs-enhanced-img)(only for image elements) or [svelte-preprocess-import-assets](https://www.npmjs.com/package/svelte-preprocess-import-assets)(for all asset URLs).

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -238,7 +238,7 @@ See the faq about [vite and prebundling](#what-is-going-on-with-vite-and-pre-bun
 >
 > For backwards compatibility, you can keep the `svelte` field in addition to the `exports` condition. But make sure that both always resolve to the same files.
 
-### How do I manually specify an <img/> 'src', or any other asset, with an inline URL?
+### How do I manually specify an `<img/>` `src`, or any other asset, with an inline URL?
 
 Currently, Svelte does not support inline asset URLs, you can only specify it via an imported asset.
 


### PR DESCRIPTION
As per this issue: https://github.com/sveltejs/vite-plugin-svelte/issues/863 , this PR updates the FAQ section to include information on how to go about using inline URLs.