### PR TITLE
fix: ensure svelte modules correctly run in DEV mode

### DIFF
--- a/.changeset/long-suns-happen.md
+++ b/.changeset/long-suns-happen.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/vite-plugin-svelte": major
+---
+
+fix: ensure svelte modules correctly run in DEV mode

--- a/.changeset/long-suns-happen.md
+++ b/.changeset/long-suns-happen.md
@@ -1,5 +1,5 @@
 ---
-"@sveltejs/vite-plugin-svelte": major
+'@sveltejs/vite-plugin-svelte': major
 ---
 
 fix: ensure svelte modules correctly run in DEV mode

--- a/.changeset/long-suns-happen.md
+++ b/.changeset/long-suns-happen.md
@@ -1,5 +1,5 @@
 ---
-'@sveltejs/vite-plugin-svelte': major
+'@sveltejs/vite-plugin-svelte': patch
 ---
 
 fix: ensure svelte modules correctly run in DEV mode

--- a/packages/vite-plugin-svelte/src/index.js
+++ b/packages/vite-plugin-svelte/src/index.js
@@ -200,6 +200,7 @@ export function svelte(inlineOptions) {
 				}
 				try {
 					const compileResult = svelteCompiler.compileModule(code, {
+						dev: !viteConfig.isProduction,
 						generate: ssr ? 'server' : 'client',
 						filename: moduleRequest.filename
 					});


### PR DESCRIPTION
We were missing this option, meaning Svelte modules that were `.ts` or `.js` were always compiled in prod mode.