### PR TITLE
fix(vitePreprocess): default to build config 

### DIFF
--- a/.changeset/shiny-rocks-grow.md
+++ b/.changeset/shiny-rocks-grow.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+fix(vitePreprocess): default to build config so that svelte-check does not trigger dev-only plugins

--- a/packages/vite-plugin-svelte/src/preprocess.js
+++ b/packages/vite-plugin-svelte/src/preprocess.js
@@ -103,10 +103,11 @@ async function createCssTransform(style, config) {
 	} else if (isResolvedConfig(config)) {
 		resolvedConfig = config;
 	} else {
-		resolvedConfig = await resolveConfig(
-			config,
-			process.env.NODE_ENV === 'production' ? 'build' : 'serve'
-		);
+		// default to "build" if no NODE_ENV is set to avoid running in dev mode for svelte-check etc.
+		const useBuild = !process.env.NODE_ENV || process.env.NODE_ENV === 'production';
+		const command = useBuild ? 'build' : 'serve';
+		const defaultMode = useBuild ? 'production' : 'development';
+		resolvedConfig = await resolveConfig(config, command, defaultMode, defaultMode, false);
 	}
 	return async (code, filename) => {
 		return preprocessCSS(code, filename, resolvedConfig);


### PR DESCRIPTION
so that svelte-check does not trigger dev-only plugins