### PR TITLE
fix(hmr): compile files in /node_modules/ with hmr: false

### DIFF
--- a/.changeset/breezy-shrimps-flash.md
+++ b/.changeset/breezy-shrimps-flash.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+fix(hmr): compile with hmr:false for files in node_modules

--- a/packages/vite-plugin-svelte/src/utils/compile.js
+++ b/packages/vite-plugin-svelte/src/utils/compile.js
@@ -59,6 +59,7 @@ export function createCompileSvelte() {
 		/** @type {import('svelte/compiler').CompileOptions} */
 		const compileOptions = {
 			...options.compilerOptions,
+			hmr: options.compilerOptions.hmr && !normalizedFilename.includes('/node_modules/'),
 			filename,
 			generate: ssr ? 'server' : 'client'
 		};

--- a/packages/vite-plugin-svelte/src/utils/compile.js
+++ b/packages/vite-plugin-svelte/src/utils/compile.js
@@ -59,7 +59,7 @@ export function createCompileSvelte() {
 		/** @type {import('svelte/compiler').CompileOptions} */
 		const compileOptions = {
 			...options.compilerOptions,
-			hmr: options.compilerOptions.hmr && !normalizedFilename.includes('/node_modules/'),
+			hmr: !!options.compilerOptions?.hmr && !normalizedFilename.includes('/node_modules/'),
 			filename,
 			generate: ssr ? 'server' : 'client'
 		};

--- a/packages/vite-plugin-svelte/src/utils/esbuild.js
+++ b/packages/vite-plugin-svelte/src/utils/esbuild.js
@@ -65,7 +65,8 @@ async function compileSvelte(options, { filename, code }, statsCollection) {
 		...options.compilerOptions,
 		css,
 		filename,
-		generate: 'client'
+		generate: 'client',
+		hmr: false
 	};
 
 	let preprocessed;


### PR DESCRIPTION
this saves some time and space, but also ensures consistency in cssHash which avoids bugs like https://github.com/sveltejs/svelte/issues/12601