### PR TITLE
fix: align css hash in prebundling and disable hmr

### DIFF
--- a/.changeset/healthy-years-battle.md
+++ b/.changeset/healthy-years-battle.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+fix(dev): compile with hmr: false for prebundled deps as hmr does not work with that

--- a/.changeset/twenty-walls-watch.md
+++ b/.changeset/twenty-walls-watch.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+fix(dev): make sure custom cssHash is applied consistently even for prebundled components to avoid hash mismatches during hydration

--- a/packages/vite-plugin-svelte/src/utils/esbuild.js
+++ b/packages/vite-plugin-svelte/src/utils/esbuild.js
@@ -77,9 +77,12 @@ async function compileSvelte(options, { filename, code }, normalizeFilename, sta
 		generate: 'client'
 	};
 
-	if (compileOptions.hmr && options.emitCss) {
-		const hash = `s-${safeBase64Hash(normalizeFilename(filename))}`;
-		compileOptions.cssHash = () => hash;
+	if (compileOptions.hmr) {
+		if (options.emitCss) {
+			const hash = `s-${safeBase64Hash(normalizeFilename(filename))}`;
+			compileOptions.cssHash = () => hash;
+		}
+		compileOptions.hmr = false;
 	}
 
 	let preprocessed;

--- a/packages/vite-plugin-svelte/src/utils/id.js
+++ b/packages/vite-plugin-svelte/src/utils/id.js
@@ -133,19 +133,8 @@ function parseRequestQuery(rawQuery) {
  * @param {string} normalizedRoot
  * @returns {string}
  */
-function normalize(filename, normalizedRoot) {
+export function normalize(filename, normalizedRoot) {
 	return stripRoot(normalizePath(filename), normalizedRoot);
-}
-
-/**
- * create a normalizer function for root
- *
- * @param {string} root
- * @returns {(filename: string) => string}
- */
-export function buildFilenameNormalizer(root) {
-	const normalizedRoot = normalizePath(root);
-	return (filename) => normalize(filename, normalizedRoot);
 }
 
 /**

--- a/packages/vite-plugin-svelte/src/utils/id.js
+++ b/packages/vite-plugin-svelte/src/utils/id.js
@@ -141,7 +141,7 @@ function normalize(filename, normalizedRoot) {
  * create a normalizer function for root
  *
  * @param {string} root
- * @returns {function(filename: string): string}
+ * @returns {(filename: string) => string}
  */
 export function buildFilenameNormalizer(root) {
 	const normalizedRoot = normalizePath(root);

--- a/packages/vite-plugin-svelte/src/utils/id.js
+++ b/packages/vite-plugin-svelte/src/utils/id.js
@@ -138,6 +138,17 @@ function normalize(filename, normalizedRoot) {
 }
 
 /**
+ * create a normalizer function for root
+ *
+ * @param {string} root
+ * @returns {function(filename: string): string}
+ */
+export function buildFilenameNormalizer(root) {
+	const normalizedRoot = normalizePath(root);
+	return (filename) => normalize(filename, normalizedRoot);
+}
+
+/**
  * @param {string} filename
  * @param {string} root
  * @returns {boolean}


### PR DESCRIPTION
alternative to #949  

this preserves hmr for dependencies that are in node_modules but excluded from optimizeDeps and also ensures that cssHash function is applied consistently so that it does not break during hydration