### PR TITLE
fix(hmr): ensure consistent use of compilerOptions.hmr during prebundling

### DIFF
--- a/.changeset/odd-pens-protect.md
+++ b/.changeset/odd-pens-protect.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+ensure consistent use of compileOptions.hmr also for prebundling

--- a/packages/vite-plugin-svelte/src/utils/esbuild.js
+++ b/packages/vite-plugin-svelte/src/utils/esbuild.js
@@ -70,12 +70,9 @@ async function compileSvelte(options, { filename, code }, statsCollection) {
 		generate: 'client'
 	};
 
-	if (compileOptions.hmr) {
-		if (options.emitCss) {
-			const hash = `s-${safeBase64Hash(normalize(filename, options.root))}`;
-			compileOptions.cssHash = () => hash;
-		}
-		compileOptions.hmr = false;
+	if (compileOptions.hmr && options.emitCss) {
+		const hash = `s-${safeBase64Hash(normalize(filename, options.root))}`;
+		compileOptions.cssHash = () => hash;
 	}
 
 	let preprocessed;


### PR DESCRIPTION
This avoid a compatibility issue if prebundled client code compiled with hmr false hydrates server code compiled with hmr true. Even if it should be identical now that might not be true in the future.