### PR TITLE
fix(types): export PluginOptions

### DIFF
--- a/.changeset/plenty-weeks-battle.md
+++ b/.changeset/plenty-weeks-battle.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+export PluginOptions interface

--- a/packages/vite-plugin-svelte/src/public.d.ts
+++ b/packages/vite-plugin-svelte/src/public.d.ts
@@ -15,7 +15,7 @@ interface PluginOptionsInline extends PluginOptions {
 	configFile?: string | false;
 }
 
-interface PluginOptions {
+export interface PluginOptions {
 	/**
 	 * A `picomatch` pattern, or array of patterns, which specifies the files the plugin should
 	 * operate on. By default, all svelte files are included.

--- a/packages/vite-plugin-svelte/types/index.d.ts
+++ b/packages/vite-plugin-svelte/types/index.d.ts
@@ -15,7 +15,7 @@ declare module '@sveltejs/vite-plugin-svelte' {
 		configFile?: string | false;
 	}
 
-	interface PluginOptions {
+	export interface PluginOptions {
 		/**
 		 * A `picomatch` pattern, or array of patterns, which specifies the files the plugin should
 		 * operate on. By default, all svelte files are included.

--- a/packages/vite-plugin-svelte/types/index.d.ts.map
+++ b/packages/vite-plugin-svelte/types/index.d.ts.map
@@ -3,6 +3,7 @@
 	"file": "index.d.ts",
 	"names": [
 		"Options",
+		"PluginOptions",
 		"SvelteConfig",
 		"VitePreprocessOptions",
 		"svelte",
@@ -21,5 +22,5 @@
 		null,
 		null
 	],
-	"mappings": ";;;;aAIYA,OAAOA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;kBA6GFC,YAAYA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;kBA8EZC,qBAAqBA;;;;;;;;;;;;;iBCvKtBC,MAAMA;iBCTNC,cAAcA;iBCgBRC,gBAAgBA"
+	"mappings": ";;;;aAIYA,OAAOA;;;;;;;;;;;;;kBAaFC,aAAaA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;kBAgGbC,YAAYA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;kBA8EZC,qBAAqBA;;;;;;;;;;;;;iBCvKtBC,MAAMA;iBCTNC,cAAcA;iBCgBRC,gBAAgBA"
 }


### PR DESCRIPTION
primarily exported so that SvelteKit can forward it in its config type. Endusers should prefer the SvelteConfig or Options.