### PR TITLE
Added missing spacing around an || (OR operator) in package.json.

### DIFF
--- a/packages/vite-plugin-svelte/package.json
+++ b/packages/vite-plugin-svelte/package.json
@@ -41,7 +41,7 @@
   },
   "homepage": "https://github.com/sveltejs/vite-plugin-svelte#readme",
   "dependencies": {
-    "@sveltejs/vite-plugin-svelte-inspector": "^3.0.0-next.0||^3.0.0",
+    "@sveltejs/vite-plugin-svelte-inspector": "^3.0.0-next.0 || ^3.0.0",
     "debug": "^4.3.7",
     "deepmerge": "^4.3.1",
     "kleur": "^4.1.5",


### PR DESCRIPTION
Fixed: @sveltejs/vite-plugin-svelte-inspector version was missing spacing around "||".