### PR TITLE
fix: remove references to compiler options no longer available in svelte5

### DIFF
--- a/.changeset/hungry-pans-check.md
+++ b/.changeset/hungry-pans-check.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+removed references to compiler options no longer available in svelte5

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -100,10 +100,8 @@ add `&sourcemap` to `?(raw|direct)&svelte&type=(script|style|all)` queries to in
 ```js
 const compilerOptions = {
   dev: false,
-  generate: 'dom',
-  css: false,
-  hydratable: false,
-  enableSourcemap: false // or {js: true} or {css:true} if sourcemap query is set
+  generate: 'client',
+  css: 'external'
 };
 ```
 
@@ -111,7 +109,7 @@ to get output with different compilerOptions, append them as json like this:
 
 ```js
 //get ssr output of svelte.compile js as {code, map, dependencies}
-import script from 'File.svelte?raw&svelte&type=script&compilerOptions={"generate":"ssr"}';
+import script from 'File.svelte?raw&svelte&type=script&compilerOptions={"generate":"server"}';
 ```
 
 only a subset of compilerOptions is supported
@@ -119,7 +117,5 @@ only a subset of compilerOptions is supported
 - generate
 - dev
 - css
-- hydratable
 - customElement
 - immutable
-- enableSourcemap

--- a/docs/config.md
+++ b/docs/config.md
@@ -240,9 +240,9 @@ A [picomatch pattern](https://github.com/micromatch/picomatch), or array of patt
     plugins: [
       svelte({
         dynamicCompileOptions({ filename, compileOptions }) {
-          // Dynamically set immutable flag per Svelte file
-          if (compileWithImmutable(filename) && !compileOptions.immutable) {
-            return { immutable: true };
+          // Dynamically set runes mode per Svelte file
+          if (forceRunesMode(filename) && !compileOptions.runes) {
+            return { runes: true };
           }
         }
       })

--- a/docs/config.md
+++ b/docs/config.md
@@ -240,9 +240,9 @@ A [picomatch pattern](https://github.com/micromatch/picomatch), or array of patt
     plugins: [
       svelte({
         dynamicCompileOptions({ filename, compileOptions }) {
-          // Dynamically set hydration per Svelte file
-          if (compileWithHydratable(filename) && !compileOptions.hydratable) {
-            return { hydratable: true };
+          // Dynamically set immutable flag per Svelte file
+          if (compileWithImmutable(filename) && !compileOptions.immutable) {
+            return { immutable: true };
           }
         }
       })

--- a/packages/playground/big-component-library-vite-ssr/vite.config.js
+++ b/packages/playground/big-component-library-vite-ssr/vite.config.js
@@ -2,7 +2,7 @@ import { svelte } from '@sveltejs/vite-plugin-svelte';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-	plugins: [svelte({ prebundleSvelteLibraries: true, compilerOptions: { hydratable: true } })],
+	plugins: [svelte({ prebundleSvelteLibraries: true })],
 	optimizeDeps: {
 		include: ['carbon-components-svelte', 'carbon-icons-svelte']
 	},

--- a/packages/vite-plugin-svelte/src/public.d.ts
+++ b/packages/vite-plugin-svelte/src/public.d.ts
@@ -92,9 +92,9 @@ export interface PluginOptions {
 	 * @example
 	 * ```
 	 * ({ filename, compileOptions }) => {
-	 *   // Dynamically set hydration per Svelte file
-	 *   if (compileWithHydratable(filename) && !compileOptions.hydratable) {
-	 *     return { hydratable: true };
+	 *   // Dynamically set immutable flag per Svelte file
+	 *   if (compileWithImmutable(filename) && !compileOptions.immutable) {
+	 *     return { immutable: true };
 	 *   }
 	 * }
 	 * ```

--- a/packages/vite-plugin-svelte/src/public.d.ts
+++ b/packages/vite-plugin-svelte/src/public.d.ts
@@ -92,9 +92,9 @@ export interface PluginOptions {
 	 * @example
 	 * ```
 	 * ({ filename, compileOptions }) => {
-	 *   // Dynamically set immutable flag per Svelte file
-	 *   if (compileWithImmutable(filename) && !compileOptions.immutable) {
-	 *     return { immutable: true };
+	 *   // Dynamically set runes mode per Svelte file
+	 *   if (forceRunesMode(filename) && !compileOptions.runes) {
+	 *     return { runes: true };
 	 *   }
 	 * }
 	 * ```

--- a/packages/vite-plugin-svelte/src/utils/id.js
+++ b/packages/vite-plugin-svelte/src/utils/id.js
@@ -8,15 +8,7 @@ import { DEFAULT_SVELTE_MODULE_EXT, DEFAULT_SVELTE_MODULE_INFIX } from './consta
 const VITE_FS_PREFIX = '/@fs/';
 const IS_WINDOWS = process.platform === 'win32';
 
-const SUPPORTED_COMPILER_OPTIONS = [
-	'generate',
-	'dev',
-	'css',
-	'hydratable',
-	'customElement',
-	'immutable',
-	'enableSourcemap'
-];
+const SUPPORTED_COMPILER_OPTIONS = ['generate', 'dev', 'css', 'customElement', 'immutable'];
 const TYPES_WITH_COMPILER_OPTIONS = ['style', 'script', 'all'];
 
 /**
@@ -102,7 +94,7 @@ function parseRequestQuery(rawQuery) {
 			throw new Error(
 				`Invalid compilerOptions in query ${rawQuery}. CompilerOptions are only supported for raw or direct queries with type in "${TYPES_WITH_COMPILER_OPTIONS.join(
 					', '
-				)}" e.g. '?svelte&raw&type=script&compilerOptions={"generate":"ssr","dev":false}`
+				)}" e.g. '?svelte&raw&type=script&compilerOptions={"generate":"server","dev":false}`
 			);
 		}
 		try {

--- a/packages/vite-plugin-svelte/types/index.d.ts
+++ b/packages/vite-plugin-svelte/types/index.d.ts
@@ -92,9 +92,9 @@ declare module '@sveltejs/vite-plugin-svelte' {
 		 * @example
 		 * ```
 		 * ({ filename, compileOptions }) => {
-		 *   // Dynamically set hydration per Svelte file
-		 *   if (compileWithHydratable(filename) && !compileOptions.hydratable) {
-		 *     return { hydratable: true };
+		 *   // Dynamically set immutable flag per Svelte file
+		 *   if (compileWithImmutable(filename) && !compileOptions.immutable) {
+		 *     return { immutable: true };
 		 *   }
 		 * }
 		 * ```

--- a/packages/vite-plugin-svelte/types/index.d.ts
+++ b/packages/vite-plugin-svelte/types/index.d.ts
@@ -92,9 +92,9 @@ declare module '@sveltejs/vite-plugin-svelte' {
 		 * @example
 		 * ```
 		 * ({ filename, compileOptions }) => {
-		 *   // Dynamically set immutable flag per Svelte file
-		 *   if (compileWithImmutable(filename) && !compileOptions.immutable) {
-		 *     return { immutable: true };
+		 *   // Dynamically set runes mode per Svelte file
+		 *   if (forceRunesMode(filename) && !compileOptions.runes) {
+		 *     return { runes: true };
 		 *   }
 		 * }
 		 * ```


### PR DESCRIPTION
hydratable and enableSourcemaps were removed, also values for generate and css have changed.

fixes #1002 