### PR TITLE
feat: support `?inline` query on svelte style virtual modules

### DIFF
--- a/.changeset/sixty-chefs-relate.md
+++ b/.changeset/sixty-chefs-relate.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': minor
+---
+
+Support `?inline` query on Svelte style virtual modules

--- a/packages/e2e-tests/import-queries/__tests__/__snapshots__/svelte-5/ssr-inline-style.txt
+++ b/packages/e2e-tests/import-queries/__tests__/__snapshots__/svelte-5/ssr-inline-style.txt
@@ -1,0 +1,3 @@
+button.svelte-d8vj6a {
+  color: #000099;
+}

--- a/packages/e2e-tests/import-queries/__tests__/import-queries.spec.ts
+++ b/packages/e2e-tests/import-queries/__tests__/import-queries.spec.ts
@@ -162,4 +162,11 @@ describe.runIf(!isBuild)('ssrLoadModule', () => {
 		const result = await ssrLoadDummy('?raw&svelte&type=style');
 		await expect(result).toMatchFileSnapshot(snapshotFilename('ssr-style'));
 	});
+	test('?inline&svelte&type=style&lang.css', async () => {
+		// Preload Dummy.svelte first so its CSS is processed in the module graph, otherwise loading
+		// its css inlined url directly will return the raw svelte file rather than the style
+		await ssrLoadDummy('');
+		const result = await ssrLoadDummy('?inline&svelte&type=style&lang.css');
+		await expect(result).toMatchFileSnapshot(snapshotFilename('ssr-inline-style'));
+	});
 });

--- a/packages/vite-plugin-svelte/src/index.js
+++ b/packages/vite-plugin-svelte/src/index.js
@@ -124,7 +124,7 @@ export function svelte(inlineOptions) {
 				const ssr = !!opts?.ssr;
 				const svelteRequest = requestParser(importee, ssr);
 				if (svelteRequest?.query.svelte) {
-					if (svelteRequest.query.type === 'style' && !svelteRequest.raw) {
+					if (svelteRequest.query.type === 'style' && !svelteRequest.raw && !svelteRequest.inline) {
 						// return cssId with root prefix so postcss pipeline of vite finds the directory correctly
 						// see https://github.com/sveltejs/vite-plugin-svelte/issues/14
 						log.debug(

--- a/packages/vite-plugin-svelte/src/types/id.d.ts
+++ b/packages/vite-plugin-svelte/src/types/id.d.ts
@@ -15,6 +15,7 @@ export interface RequestQuery {
 	url?: boolean;
 	raw?: boolean;
 	direct?: boolean;
+	inline?: boolean;
 }
 
 export interface SvelteRequest {
@@ -26,6 +27,7 @@ export interface SvelteRequest {
 	timestamp: number;
 	ssr: boolean;
 	raw: boolean;
+	inline: boolean;
 }
 
 export interface SvelteModuleRequest {

--- a/packages/vite-plugin-svelte/src/utils/id.js
+++ b/packages/vite-plugin-svelte/src/utils/id.js
@@ -50,7 +50,8 @@ function parseToSvelteRequest(id, filename, rawQuery, root, timestamp, ssr) {
 		query,
 		timestamp,
 		ssr,
-		raw
+		raw,
+		inline: !!query.inline
 	};
 }
 


### PR DESCRIPTION
In Vite 6, importing CSS in SSR now no longer return a default export of the transformed CSS file, you'd need to use `?inline` instead. This was already pushed for in Vite 5 but we forgot to remove support in SSR.

That means frameworks who do CSS crawling to prevent FOUC will now have to use `?inline` to get the transformed CSS, which most already did. However, there's a quirk where v-p-s always strips out the `?inline` here: https://github.com/sveltejs/vite-plugin-svelte/blob/da54670065f949c7352597dcafbd51dfa202e638/packages/vite-plugin-svelte/src/index.js#L127-L136

This was fine for Vite 5 as mentioned above, Vite still supported default exports of CSS files in SSR, but with Vite 6 it is now empty. For v-p-s to properly support `?inline`, it needs to leave the query as is, similar to `?raw` handling.

---

In practice, this isn't a breaking change, however due to some unintended reliance of the old behaviour, **the SvelteKit tests here will fail due to HMR**. I sent a PR upstream to fix this https://github.com/sveltejs/kit/pull/13007 and if we want to play it safe for now, we can merge this only in the next major.

With this merged, it should unblock Vite 6 support for CSS FOUC for both SvelteKit and Astro.