### PR TITLE
fix: update warning codes for svelte5 (#1044)

### DIFF
--- a/.changeset/eleven-pears-compare.md
+++ b/.changeset/eleven-pears-compare.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+adapt internal handling of warning and error `code` property to changes in svelte5

--- a/packages/e2e-tests/import-queries/svelte.config.js
+++ b/packages/e2e-tests/import-queries/svelte.config.js
@@ -4,7 +4,7 @@ export default {
 	preprocess: [vitePreprocess()],
 	onwarn(warning, defaultHandler) {
 		// import query test generates one of these
-		if (warning.code === 'custom-element-no-tag') return;
+		if (warning.code === 'options_missing_custom_element') return;
 		defaultHandler(warning);
 	}
 };

--- a/packages/vite-plugin-svelte/src/utils/error.js
+++ b/packages/vite-plugin-svelte/src/utils/error.js
@@ -102,6 +102,16 @@ function formatFrameForVite(frame) {
 }
 
 /**
+ *
+ * @param {string} code the svelte error code
+ * @see https://github.com/sveltejs/svelte/blob/main/packages/svelte/src/compiler/errors.js
+ * @returns {boolean}
+ */
+function couldBeFixedByCssPreprocessor(code) {
+	return code === 'expected_token' || code === 'unexpected_eof' || code.startsWith('css_');
+}
+
+/**
  * @param {import('svelte/compiler').Warning & Error} err a svelte compiler error, which is a mix of Warning and an error
  * @param {string} originalCode
  * @param {import('../public.d.ts').Options['preprocess']} [preprocessors]
@@ -113,7 +123,7 @@ export function enhanceCompileError(err, originalCode, preprocessors) {
 	const additionalMessages = [];
 
 	// Handle incorrect CSS preprocessor usage
-	if (err.code === 'css-syntax-error') {
+	if (couldBeFixedByCssPreprocessor(err.code)) {
 		// Reference from Svelte: https://github.com/sveltejs/svelte/blob/9926347ad9dbdd0f3324d5538e25dcb7f5e442f8/packages/svelte/src/compiler/preprocess/index.js#L257
 		const styleRe =
 			/<!--[^]*?-->|<style((?:\s+[^=>'"/]+=(?:"[^"]*"|'[^']*'|[^>\s]+)|\s+[^=>'"/]+)*\s*)(?:\/>|>([\S\s]*?)<\/style>)/g;

--- a/packages/vite-plugin-svelte/src/utils/log.js
+++ b/packages/vite-plugin-svelte/src/utils/log.js
@@ -182,7 +182,7 @@ export function logCompilerWarnings(svelteRequest, warnings, options) {
  */
 function ignoreCompilerWarning(warning, isBuild, emitCss) {
 	return (
-		(!emitCss && warning.code === 'css-unused-selector') || // same as rollup-plugin-svelte
+		(!emitCss && warning.code === 'css_unused_selector') || // same as rollup-plugin-svelte
 		(!isBuild && isNoScopableElementWarning(warning))
 	);
 }
@@ -194,7 +194,7 @@ function ignoreCompilerWarning(warning, isBuild, emitCss) {
  */
 function isNoScopableElementWarning(warning) {
 	// see https://github.com/sveltejs/vite-plugin-svelte/issues/153
-	return warning.code === 'css-unused-selector' && warning.message.includes('"*"');
+	return warning.code === 'css_unused_selector' && warning.message.includes('"*"');
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2931,8 +2931,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.7:
-    resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
+  nanoid@3.3.8:
+    resolution: {integrity: sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -5902,7 +5902,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.7: {}
+  nanoid@3.3.8: {}
 
   natural-compare@1.4.0: {}
 
@@ -6115,7 +6115,7 @@ snapshots:
 
   postcss@8.4.49:
     dependencies:
-      nanoid: 3.3.7
+      nanoid: 3.3.8
       picocolors: 1.1.1
       source-map-js: 1.2.1
 


### PR DESCRIPTION
* fix: update warning codes for svelte5

* fix(audit): bump nanoid

* fix: replace css error code detection so that it works for svelte5

* chore: update changeset

(cherry picked from commit e41edff61afe645c2f6b07fa1b3bfd98ec8d806e)