### PR TITLE
Use optional chaining to catch null error codes in error.js

### DIFF
--- a/.changeset/giant-plants-learn.md
+++ b/.changeset/giant-plants-learn.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+fix errorhandling to work with errors that don't have a code property

--- a/packages/vite-plugin-svelte/src/utils/error.js
+++ b/packages/vite-plugin-svelte/src/utils/error.js
@@ -108,7 +108,7 @@ function formatFrameForVite(frame) {
  * @returns {boolean}
  */
 function couldBeFixedByCssPreprocessor(code) {
-	return code === 'expected_token' || code === 'unexpected_eof' || code.startsWith('css_');
+	return code === 'expected_token' || code === 'unexpected_eof' || code?.startsWith('css_');
 }
 
 /**


### PR DESCRIPTION
Starting a new vite project and selecting svelte-ts template results in an error, because `code` var in error.js is null. Optional chaining resolves this issue.