### PR TITLE
fix(types): correct default key combo in typing docs

### DIFF
--- a/packages/vite-plugin-svelte-inspector/src/public.d.ts
+++ b/packages/vite-plugin-svelte-inspector/src/public.d.ts
@@ -1,7 +1,7 @@
 export interface Options {
 	/**
 	 * define a key combo to toggle inspector,
-	 * @default 'meta-shift' on mac, 'control-shift' on other os
+	 * @default 'alt-x'
 	 *
 	 * any number of modifiers `control` `shift` `alt` `meta` followed by zero or one regular key, separated by -
 	 * examples: control-shift, control-o, control-alt-s  meta-x control-meta
@@ -56,7 +56,7 @@ export interface Options {
 
 	/**
 	 * where to display the toggle button
-	 * @default top-right
+	 * @default 'top-right'
 	 */
 	toggleButtonPos?: 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left';
 

--- a/packages/vite-plugin-svelte-inspector/types/index.d.ts
+++ b/packages/vite-plugin-svelte-inspector/types/index.d.ts
@@ -2,7 +2,7 @@ declare module '@sveltejs/vite-plugin-svelte-inspector' {
 	export interface Options {
 		/**
 		 * define a key combo to toggle inspector,
-		 * @default 'meta-shift' on mac, 'control-shift' on other os
+		 * @default 'alt-x'
 		 *
 		 * any number of modifiers `control` `shift` `alt` `meta` followed by zero or one regular key, separated by -
 		 * examples: control-shift, control-o, control-alt-s  meta-x control-meta
@@ -57,7 +57,7 @@ declare module '@sveltejs/vite-plugin-svelte-inspector' {
 
 		/**
 		 * where to display the toggle button
-		 * @default top-right
+		 * @default 'top-right'
 		 */
 		toggleButtonPos?: 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left';
 


### PR DESCRIPTION
The default key combo was changed in #995 but not reflect in TypeScript definitions.