### PR TITLE
fix: pre-optimize clsx

### DIFF
--- a/packages/vite-plugin-svelte/src/utils/options.js
+++ b/packages/vite-plugin-svelte/src/utils/options.js
@@ -563,6 +563,10 @@ function buildExtraConfigForSvelte(config) {
 			'config'
 		);
 	}
+	// clsx may be imported by svelte runtime, make vite optimize it ahead of time
+	if (!isDepExcluded('clsx', config.optimizeDeps?.exclude ?? [])) {
+		include.push('clsx');
+	}
 	/** @type {(string | RegExp)[]} */
 	const noExternal = [];
 	/** @type {string[]} */


### PR DESCRIPTION
Small fix to address these small log lines:

```
  VITE v6.0.7  ready in 1533 ms

  ➜  Local:   http://localhost:5173/
  ➜  Network: use --host to expose
  ➜  press h + enter to show help
11:33:51 PM [vite] (client) ✨ new dependencies optimized: clsx
11:33:51 PM [vite] (client) ✨ optimized dependencies changed. reloading
```