### PR TITLE
chore: Update caniuse-lite

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4502,14 +4502,6 @@ snapshots:
       chai: 5.1.2
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.0.2(vite@6.0.9(@types/node@20.11.5)(sass@1.83.4)(stylus@0.64.0)(yaml@2.6.1))':
-    dependencies:
-      '@vitest/spy': 3.0.2
-      estree-walker: 3.0.3
-      magic-string: 0.30.17
-    optionalDependencies:
-      vite: 6.0.9(@types/node@20.11.5)(sass@1.83.4)(stylus@0.64.0)(yaml@2.6.1)
-
   '@vitest/mocker@3.0.2(vite@6.0.9(@types/node@22.10.7)(sass@1.83.4)(stylus@0.64.0)(yaml@2.6.1))':
     dependencies:
       '@vitest/spy': 3.0.2
@@ -6475,7 +6467,7 @@ snapshots:
   vitest@3.0.2(@types/node@20.11.5)(sass@1.83.4)(stylus@0.64.0)(yaml@2.6.1):
     dependencies:
       '@vitest/expect': 3.0.2
-      '@vitest/mocker': 3.0.2(vite@6.0.9(@types/node@20.11.5)(sass@1.83.4)(stylus@0.64.0)(yaml@2.6.1))
+      '@vitest/mocker': 3.0.2(vite@6.0.9(@types/node@22.10.7)(sass@1.83.4)(stylus@0.64.0)(yaml@2.6.1))
       '@vitest/pretty-format': 3.0.2
       '@vitest/runner': 3.0.2
       '@vitest/snapshot': 3.0.2


### PR DESCRIPTION
This (or its counterpart in `svelte-preprocess`, not sure which) is causing yellow logs in SvelteKit dev.