### PR TITLE
feat: scope css to js module to allow treeshaking it (requires vite 6.2)

### DIFF
--- a/.changeset/plenty-eyes-talk.md
+++ b/.changeset/plenty-eyes-talk.md
@@ -2,4 +2,4 @@
 '@sveltejs/vite-plugin-svelte': minor
 ---
 
-scope css to js module to enable treeshaking scoped css from unused components. Requires vite 6.2
+scope css to js module to enable treeshaking scoped css from unused components. Requires vite 6.2 and svelte 5.26

--- a/.changeset/plenty-eyes-talk.md
+++ b/.changeset/plenty-eyes-talk.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': minor
+---
+
+scope css to js module to enable treeshaking scoped css from unused components. Requires vite 6.2

--- a/packages/e2e-tests/css-treeshake/__tests__/css-treeshake.spec.ts
+++ b/packages/e2e-tests/css-treeshake/__tests__/css-treeshake.spec.ts
@@ -1,0 +1,37 @@
+import { browserLogs, findAssetFile, getColor, getEl, getText, isBuild } from '~utils';
+import { expect } from 'vitest';
+
+test('should not have failed requests', async () => {
+	browserLogs.forEach((msg) => {
+		expect(msg).not.toMatch('404');
+	});
+});
+
+test('should apply css from used components', async () => {
+	expect(await getText('#app')).toBe('App');
+	expect(await getColor('#app')).toBe('blue');
+	expect(await getText('#a')).toBe('A');
+	expect(await getColor('#a')).toBe('red');
+});
+
+test('should apply css from unused components that contain global styles', async () => {
+	expect(await getEl('head style[src]'));
+	expect(await getColor('#test')).toBe('green'); // from B.svelte
+});
+
+test('should not render unused components', async () => {
+	expect(await getEl('#b')).toBeNull();
+	expect(await getEl('#c')).toBeNull();
+});
+
+if (isBuild) {
+	test('should include unscoped global styles from unused components', async () => {
+		const cssOutput = findAssetFile(/index-.*\.css/);
+		expect(cssOutput).toContain('#test{color:green}'); // from B.svelte
+	});
+	test('should not include scoped styles from unused components', async () => {
+		const cssOutput = findAssetFile(/index-.*\.css/);
+		// from C.svelte
+		expect(cssOutput).not.toContain('.unused');
+	});
+}

--- a/packages/e2e-tests/css-treeshake/index.html
+++ b/packages/e2e-tests/css-treeshake/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
+
+		<title>Svelte app</title>
+
+		<script type="module" src="/src/main.js"></script>
+	</head>
+
+	<body></body>
+</html>

--- a/packages/e2e-tests/css-treeshake/package.json
+++ b/packages/e2e-tests/css-treeshake/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "e2e-tests-css-treeshake",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "@sveltejs/vite-plugin-svelte": "workspace:^",
+    "sass": "^1.85.1",
+    "svelte": "^5.20.5",
+    "vite": "^6.2.0"
+  }
+}

--- a/packages/e2e-tests/css-treeshake/src/A.svelte
+++ b/packages/e2e-tests/css-treeshake/src/A.svelte
@@ -1,0 +1,7 @@
+<h1 id="a">A</h1>
+
+<style>
+	h1 {
+		color: red;
+	}
+</style>

--- a/packages/e2e-tests/css-treeshake/src/App.svelte
+++ b/packages/e2e-tests/css-treeshake/src/App.svelte
@@ -1,0 +1,13 @@
+<script>
+	import { A } from './barrel.js';
+</script>
+
+<div id="test">test</div>
+<h1 id="app">App</h1>
+<A />
+
+<style>
+	#app {
+		color: blue;
+	}
+</style>

--- a/packages/e2e-tests/css-treeshake/src/B.svelte
+++ b/packages/e2e-tests/css-treeshake/src/B.svelte
@@ -1,0 +1,10 @@
+<h1 id="b">B</h1>
+
+<style>
+	h1 {
+		color: green;
+	}
+	:global(#test) {
+		color: green;
+	}
+</style>

--- a/packages/e2e-tests/css-treeshake/src/C.svelte
+++ b/packages/e2e-tests/css-treeshake/src/C.svelte
@@ -1,0 +1,14 @@
+<h1 id="c" class="unused"><strong>C</strong></h1>
+
+<style>
+	.unused {
+		color: magenta;
+	}
+	h1 :global {
+		background: blue;
+	}
+
+	h1 :global(strong) {
+		color: magenta;
+	}
+</style>

--- a/packages/e2e-tests/css-treeshake/src/barrel.js
+++ b/packages/e2e-tests/css-treeshake/src/barrel.js
@@ -1,0 +1,4 @@
+export { default as A } from './A.svelte';
+// B and C are unused, their css should not be included
+export { default as B } from './B.svelte';
+export { default as C } from './C.svelte';

--- a/packages/e2e-tests/css-treeshake/src/main.js
+++ b/packages/e2e-tests/css-treeshake/src/main.js
@@ -1,0 +1,3 @@
+import App from './App.svelte';
+import { mount } from 'svelte';
+mount(App, { target: document.body });

--- a/packages/e2e-tests/css-treeshake/src/vite-env.d.ts
+++ b/packages/e2e-tests/css-treeshake/src/vite-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="svelte" />
+/// <reference types="vite/client" />

--- a/packages/e2e-tests/css-treeshake/svelte.config.js
+++ b/packages/e2e-tests/css-treeshake/svelte.config.js
@@ -1,0 +1,5 @@
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+
+export default {
+	preprocess: [vitePreprocess()]
+};

--- a/packages/e2e-tests/css-treeshake/vite.config.js
+++ b/packages/e2e-tests/css-treeshake/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+import { env } from 'node:process';
+// https://vitejs.dev/config/
+export default defineConfig({
+	plugins: [svelte()]
+});

--- a/packages/vite-plugin-svelte/package.json
+++ b/packages/vite-plugin-svelte/package.json
@@ -46,8 +46,7 @@
     "deepmerge": "^4.3.1",
     "kleur": "^4.1.5",
     "magic-string": "^0.30.17",
-    "vitefu": "^1.0.6",
-    "zimmerframe": "^1.1.2"
+    "vitefu": "^1.0.6"
   },
   "peerDependencies": {
     "svelte": "^5.0.0",

--- a/packages/vite-plugin-svelte/package.json
+++ b/packages/vite-plugin-svelte/package.json
@@ -46,7 +46,8 @@
     "deepmerge": "^4.3.1",
     "kleur": "^4.1.5",
     "magic-string": "^0.30.17",
-    "vitefu": "^1.0.6"
+    "vitefu": "^1.0.6",
+    "zimmerframe": "^1.1.2"
   },
   "peerDependencies": {
     "svelte": "^5.0.0",

--- a/packages/vite-plugin-svelte/src/index.js
+++ b/packages/vite-plugin-svelte/src/index.js
@@ -118,9 +118,20 @@ export function svelte(inlineOptions) {
 						};
 					} else {
 						if (query.svelte && query.type === 'style') {
-							const css = cache.getCSS(svelteRequest);
+							// @ts-expect-error __meta does not exist
+							const { __meta, ...css } = cache.getCSS(svelteRequest);
 							if (css) {
-								return css;
+								if (__meta?.hasUnscopedGlobalCss) {
+									return css; // css contains unscoped global, do not scope to component
+								}
+								return {
+									...css,
+									meta: {
+										vite: {
+											cssScopeTo: [svelteRequest.filename, 'default']
+										}
+									}
+								};
 							}
 						}
 						// prevent vite asset plugin from loading files as url that should be compiled in transform

--- a/packages/vite-plugin-svelte/src/index.js
+++ b/packages/vite-plugin-svelte/src/index.js
@@ -118,20 +118,16 @@ export function svelte(inlineOptions) {
 						};
 					} else {
 						if (query.svelte && query.type === 'style') {
-							// @ts-expect-error __meta does not exist
-							const { __meta, ...css } = cache.getCSS(svelteRequest);
-							if (css) {
-								if (__meta?.hasUnscopedGlobalCss) {
-									return css; // css contains unscoped global, do not scope to component
+							const cachedCss = cache.getCSS(svelteRequest);
+							if (cachedCss) {
+								const { hasGlobal, ...css } = cachedCss;
+								if (hasGlobal === false) {
+									// hasGlobal was added in svelte 5.26.0, so make sure it is boolean false
+									css.meta ??= {};
+									css.meta.vite ??= {};
+									css.meta.vite.cssScopeTo = [svelteRequest.filename, 'default'];
 								}
-								return {
-									...css,
-									meta: {
-										vite: {
-											cssScopeTo: [svelteRequest.filename, 'default']
-										}
-									}
-								};
+								return css;
 							}
 						}
 						// prevent vite asset plugin from loading files as url that should be compiled in transform

--- a/packages/vite-plugin-svelte/src/types/compile.d.ts
+++ b/packages/vite-plugin-svelte/src/types/compile.d.ts
@@ -12,6 +12,9 @@ export interface Code {
 	code: string;
 	map?: any;
 	dependencies?: any[];
+	__meta?: {
+		hasUnscopedGlobalCss?: boolean;
+	};
 }
 
 export interface CompileData {

--- a/packages/vite-plugin-svelte/src/types/compile.d.ts
+++ b/packages/vite-plugin-svelte/src/types/compile.d.ts
@@ -1,6 +1,7 @@
 import type { Processed, CompileResult } from 'svelte/compiler';
 import type { SvelteRequest } from './id.d.ts';
 import type { ResolvedOptions } from './options.d.ts';
+import type { CustomPluginOptionsVite } from 'vite';
 
 export type CompileSvelte = (
 	svelteRequest: SvelteRequest,
@@ -12,8 +13,9 @@ export interface Code {
 	code: string;
 	map?: any;
 	dependencies?: any[];
-	__meta?: {
-		hasUnscopedGlobalCss?: boolean;
+	hasGlobal?: boolean;
+	meta?: {
+		vite?: CustomPluginOptionsVite;
 	};
 }
 

--- a/packages/vite-plugin-svelte/src/utils/compile.js
+++ b/packages/vite-plugin-svelte/src/utils/compile.js
@@ -68,19 +68,18 @@ export function createCompileSvelte() {
 		}
 
 		let preprocessed;
-
-		const preprocessors = options.preprocess
-			? Array.isArray(options.preprocess)
-				? [...options.preprocess]
-				: [options.preprocess]
-			: [];
-
+		let preprocessors = options.preprocess;
 		if (!options.isBuild && options.emitCss && compileOptions.hmr) {
 			// inject preprocessor that ensures css hmr works better
-			preprocessors.push(devStylePreprocessor);
+			if (!Array.isArray(preprocessors)) {
+				preprocessors = preprocessors
+					? [preprocessors, devStylePreprocessor]
+					: [devStylePreprocessor];
+			} else {
+				preprocessors = preprocessors.concat(devStylePreprocessor);
+			}
 		}
-
-		if (preprocessors.length > 0) {
+		if (preprocessors) {
 			try {
 				preprocessed = await svelte.preprocess(code, preprocessors, { filename }); // full filename here so postcss works
 			} catch (e) {

--- a/packages/vite-plugin-svelte/src/utils/compile.js
+++ b/packages/vite-plugin-svelte/src/utils/compile.js
@@ -86,8 +86,7 @@ export function createCompileSvelte() {
 			preprocessors.push({
 				name: 'test-has-global-style',
 				style({ content }) {
-					hasUnscopedGlobalCss =
-						content?.length > 0 && /(?:^|,)\s*(?::global[\s{(]|@keyframes -global-)/m.test(content);
+					hasUnscopedGlobalCss = /(?:^|,)\s*(?::global[\s{(]|@keyframes -global-)/m.test(content);
 				}
 			});
 		}

--- a/packages/vite-plugin-svelte/src/utils/compile.js
+++ b/packages/vite-plugin-svelte/src/utils/compile.js
@@ -68,7 +68,7 @@ export function createCompileSvelte() {
 		}
 
 		let preprocessed;
-		let hasUnscopedGlobalCss = false;
+
 		const preprocessors = options.preprocess
 			? Array.isArray(options.preprocess)
 				? [...options.preprocess]
@@ -78,17 +78,6 @@ export function createCompileSvelte() {
 		if (!options.isBuild && options.emitCss && compileOptions.hmr) {
 			// inject preprocessor that ensures css hmr works better
 			preprocessors.push(devStylePreprocessor);
-		}
-
-		if (options.emitCss) {
-			// check if css has unscoped global rules
-			// This is later used to decide if css output can be scoped to the js module for treeshaking
-			preprocessors.push({
-				name: 'test-has-global-style',
-				style({ content }) {
-					hasUnscopedGlobalCss = /(?:^|,)\s*(?::global[\s{(]|@keyframes -global-)/m.test(content);
-				}
-			});
 		}
 
 		if (preprocessors.length > 0) {
@@ -144,15 +133,6 @@ export function createCompileSvelte() {
 		let compiled;
 		try {
 			compiled = svelte.compile(finalCode, { ...finalCompileOptions, filename });
-
-			if (compiled.css && hasUnscopedGlobalCss) {
-				Object.defineProperty(compiled.css, '__meta', {
-					value: { hasUnscopedGlobalCss },
-					writable: false,
-					enumerable: false,
-					configurable: false
-				});
-			}
 
 			// patch output with partial accept until svelte does it
 			// TODO remove later

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -269,13 +269,13 @@ importers:
         version: link:../../vite-plugin-svelte
       sass:
         specifier: ^1.85.1
-        version: 1.85.1
+        version: 1.86.3
       svelte:
-        specifier: ^5.22.2
-        version: 5.22.2
+        specifier: ^5.28.1
+        version: 5.28.1
       vite:
-        specifier: ^6.2.0
-        version: 6.2.0(@types/node@20.17.23)(sass@1.85.1)(stylus@0.64.0)(yaml@2.7.0)
+        specifier: ^6.3.2
+        version: 6.3.2(@types/node@20.17.30)(sass@1.86.3)(stylus@0.64.0)(yaml@2.7.0)
 
   packages/e2e-tests/custom-extensions:
     devDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -262,6 +262,21 @@ importers:
         specifier: ^6.3.2
         version: 6.3.2(@types/node@20.17.30)(sass@1.86.3)(stylus@0.64.0)(yaml@2.7.0)
 
+  packages/e2e-tests/css-treeshake:
+    devDependencies:
+      '@sveltejs/vite-plugin-svelte':
+        specifier: workspace:^
+        version: link:../../vite-plugin-svelte
+      sass:
+        specifier: ^1.85.1
+        version: 1.85.1
+      svelte:
+        specifier: ^5.22.2
+        version: 5.22.2
+      vite:
+        specifier: ^6.2.0
+        version: 6.2.0(@types/node@20.17.23)(sass@1.85.1)(stylus@0.64.0)(yaml@2.7.0)
+
   packages/e2e-tests/custom-extensions:
     devDependencies:
       '@sveltejs/vite-plugin-svelte':


### PR DESCRIPTION
see https://github.com/vitejs/vite/pull/19418

This allows vite to treeshake unused svelte component css if the component was referenced in a barrel file.