### PR TITLE
Add node exports for CJS

### DIFF
--- a/packages/vite-plugin-svelte/package.json
+++ b/packages/vite-plugin-svelte/package.json
@@ -14,6 +14,10 @@
       "import": {
         "types": "./types/index.d.ts",
         "default": "./src/index.js"
+      },
+      "node": {
+        "types": "./types/index.d.ts",
+        "default": "./src/index.js"
       }
     }
   },


### PR DESCRIPTION
Since the newest versions of node supports require(esm), adding this exports make that work, (without it, requiring fails with a ERR_PACKAGE_PATH_NOT_EXPORTED). I need for one of my projects that still can't be moved from CJS and AFAIK adding this extra definition should do no harm.