### PR TITLE
fix: tell vite not to optimize clsx

### DIFF
--- a/packages/vite-plugin-svelte/src/utils/options.js
+++ b/packages/vite-plugin-svelte/src/utils/options.js
@@ -577,6 +577,10 @@ function buildExtraConfigForSvelte(config) {
 	if (!isDepExternaled('esm-env', config.ssr?.external ?? [])) {
 		noExternal.push('esm-env');
 	}
+	// prevent server restart when clsx is lazily discovered by vite - it does not need optimization
+	if (!isDepIncluded('clsx', config.optimizeDeps?.include ?? [])) {
+		exclude.push('clsx');
+	}
 	return { optimizeDeps: { include, exclude }, ssr: { noExternal, external } };
 }
 


### PR DESCRIPTION
alternative to #1067 

clsx has a single file esm export so does not benefit from being optimized. In theory vite can do better itself here but to help svelte users experiencing this behavior we can add it to optimizeDeps.exclude. This works well even for svelte versions that do not use clsx and requires minimal code change.

Users who want clsx "optimized" can put it in optimizeDeps.include to force it - which will also prevent the dev server restart.