### PR TITLE
fix(optimizeDeps): add svelte > clsx to avoid devserver restart

### DIFF
--- a/.changeset/fine-nights-mix.md
+++ b/.changeset/fine-nights-mix.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+add `svelte > clsx` to optimizeDeps.include to avoid page reload when using vite6 and npm

--- a/packages/e2e-tests/kit-node/__tests__/kit.spec.ts
+++ b/packages/e2e-tests/kit-node/__tests__/kit.spec.ts
@@ -318,6 +318,7 @@ describe('kit-node', () => {
 					'svelte/store',
 					'svelte/transition',
 					'svelte',
+					'svelte > clsx',
 					'svelte/internal/disclose-version',
 					'svelte/internal/flags/legacy',
 					'svelte/internal/flags/tracing',

--- a/packages/e2e-tests/prebundle-svelte-deps/__tests__/prebundle-svelte-deps.spec.ts
+++ b/packages/e2e-tests/prebundle-svelte-deps/__tests__/prebundle-svelte-deps.spec.ts
@@ -33,6 +33,8 @@ if (!isBuild) {
 		expect(optimizedPaths).toContain('e2e-test-dep-svelte-api-only');
 		expect(optimizedPaths).toContain('e2e-test-dep-svelte-nested');
 		expect(optimizedPaths).toContain('e2e-test-dep-svelte-module');
+		expect(optimizedPaths).toContain('svelte');
+		expect(optimizedPaths).toContain('svelte > clsx');
 	});
 
 	test('should not optimize excluded svelte dependencies', () => {

--- a/packages/vite-plugin-svelte/src/utils/constants.js
+++ b/packages/vite-plugin-svelte/src/utils/constants.js
@@ -1,8 +1,10 @@
 import { createRequire } from 'node:module';
 
-export const SVELTE_IMPORTS = Object.entries(
-	createRequire(import.meta.url)('svelte/package.json').exports
-)
+const sveltePkg = createRequire(import.meta.url)('svelte/package.json');
+// ensure we only include deps used for the client runtime of current svelte version
+export const SVELTE_RUNTIME_DEPENDENCIES = ['clsx'].filter((dep) => !!sveltePkg.dependencies[dep]);
+
+export const SVELTE_IMPORTS = Object.entries(sveltePkg.exports)
 	.map(([name, config]) => {
 		// ignore type only
 		if (typeof config === 'object' && Object.keys(config).length === 1 && config.types) {

--- a/packages/vite-plugin-svelte/src/utils/options.js
+++ b/packages/vite-plugin-svelte/src/utils/options.js
@@ -12,7 +12,8 @@ import {
 	DEFAULT_SVELTE_EXT,
 	FAQ_LINK_MISSING_EXPORTS_CONDITION,
 	SVELTE_EXPORT_CONDITIONS,
-	SVELTE_IMPORTS
+	SVELTE_IMPORTS,
+	SVELTE_RUNTIME_DEPENDENCIES
 } from './constants.js';
 
 import path from 'node:path';
@@ -550,8 +551,9 @@ function buildExtraConfigForSvelte(config) {
 		const svelteImportsToInclude = SVELTE_IMPORTS.filter(
 			(si) => !(si.endsWith('/server') || si.includes('/server/'))
 		);
+		svelteImportsToInclude.push(...SVELTE_RUNTIME_DEPENDENCIES.map((dep) => `svelte > ${dep}`));
 		log.debug(
-			`adding bare svelte packages to optimizeDeps.include: ${svelteImportsToInclude.join(', ')} `,
+			`adding bare svelte packages and runtime dependencies to optimizeDeps.include: ${svelteImportsToInclude.join(', ')} `,
 			undefined,
 			'config'
 		);


### PR DESCRIPTION
alternative to #1067 only adding it when clsx is a dep of svelte and as a subpath optimization.