### PR TITLE
chore: setup branch to release v5

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,7 +7,7 @@
 	"commit": false,
 	"linked": [],
 	"access": "public",
-	"baseBranch": "main",
+	"baseBranch": "v5",
 	"bumpVersionsWithWorkspaceProtocolOnly": true,
 	"updateInternalDependencies": "minor",
 	"ignore": ["!(@sveltejs/*)"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,10 @@ name: CI
 on:
   push:
     branches:
-      - main
+      - v5
   pull_request:
     branches:
-      - main
+      - v5
 env:
   # we call `pnpm playwright install` instead
   PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - main
+      - v5
 permissions: {}
 
 jobs:

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "pnpm check:lint --fix",
     "format": "pnpm check:format --write",
     "fixup": "run-s lint format",
-    "release": "pnpm changeset publish",
+    "release": "pnpm changeset publish --tag version-5",
     "prepare": "husky",
     "playwright": "playwright-core",
     "generate:types": "pnpm --filter \"./packages/*\" --parallel generate:types",


### PR DESCRIPTION
this enables running changesets from the v5 branch if we have to backport fixes