### PR TITLE
drop node 18 and update exports syntax

### DIFF
--- a/.changeset/better-moles-brake.md
+++ b/.changeset/better-moles-brake.md
@@ -1,0 +1,6 @@
+---
+'@sveltejs/vite-plugin-svelte-inspector': major
+'@sveltejs/vite-plugin-svelte': major
+---
+
+drop support for node18 and update exports map to use default export. cjs is supported via require esm in node 20.19+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,8 +77,6 @@ jobs:
         node: [22]
         os: [ubuntu-latest, macos-latest, windows-latest]
         include:
-          - node: 18
-            os: ubuntu-latest
           - node: 20
             os: ubuntu-latest
           - node: 24

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -181,31 +181,16 @@ You should not use prebundleSvelteLibraries during build or for ssr, disable one
 
 You really shouldn't. Svelte and Vite are esm first and the ecosystem is moving away from commonjs and so should you. Consider migrating to esm.
 
-In case you have to, use dynamic import to load vite-plugin-svelte's esm code from cjs like this:
+In case you have to, you can rely on node's "require esm" feature available in v20.19+
 
-```diff
+```js
 // vite.config.cjs
 const { defineConfig } = require('vite');
-- const { svelte } = require('@sveltejs/vite-plugin-svelte');
-module.exports = defineConfig(async ({ command, mode }) => {
-+ const { svelte } = await import('@sveltejs/vite-plugin-svelte');
-  return {plugins:[svelte()]}
-}
-```
+const { svelte, vitePreprocess } = require('@sveltejs/vite-plugin-svelte');
 
-And for `vitePreprocess` you have to set up a lazy promise as top-level-await doesn't work for esm imports in cjs:
-
-```diff
-- const {vitePreprocess} = require('@sveltejs/vite-plugin-svelte')
-+ const vitePreprocess = import('@sveltejs/vite-plugin-svelte').then(m => m.vitePreprocess())
-
-module.exports = {
--    preprocess: vitePreprocess()
-+    preprocess: {
-+        script:async (options) => (await vitePreprocess).script(options),
-+        style:async (options) => (await vitePreprocess).style(options),
-+    }
-}
+module.exports = defineConfig({
+  plugins: [svelte({ preprocess: vitePreprocess() })]
+});
 ```
 
 <!-- the following header generates an anchor that is used in logging, do not modify!-->

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -139,6 +139,13 @@ export default [
 		}
 	},
 	{
+		name: 'local/markdown-codefences/allow-require',
+		files: ['**/docs/faq.md/*.js'],
+		rules: {
+			'@typescript-eslint/no-require-imports': 'off'
+		}
+	},
+	{
 		name: 'local/spec-files',
 		files: ['**/__tests__/**/*.spec.ts'],
 

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   "packageManager": "pnpm@10.11.0",
   "engines": {
     "pnpm": "^10.2.0",
-    "node": "^20.18 || ^22 || >=24"
+    "node": "^20.19 || ^22.12 || >=24"
   },
   "pnpm": {
     "overrides": {

--- a/packages/vite-plugin-svelte-inspector/package.json
+++ b/packages/vite-plugin-svelte-inspector/package.json
@@ -11,10 +11,8 @@
   "types": "types/index.d.ts",
   "exports": {
     ".": {
-      "import": {
-        "types": "./types/index.d.ts",
-        "default": "./src/index.js"
-      }
+      "types": "./types/index.d.ts",
+      "default": "./src/index.js"
     }
   },
   "scripts": {
@@ -23,7 +21,7 @@
     "generate:types": "dts-buddy -m \"@sveltejs/vite-plugin-svelte-inspector:src/public.d.ts\""
   },
   "engines": {
-    "node": "^18.0.0 || ^20.0.0 || >=22"
+    "node": "^20.19 || ^22.12 || >=24"
   },
   "repository": {
     "type": "git",
@@ -44,7 +42,7 @@
     "debug": "^4.4.1"
   },
   "peerDependencies": {
-    "@sveltejs/vite-plugin-svelte": "^5.0.0",
+    "@sveltejs/vite-plugin-svelte": "workspace:^",
     "svelte": "^5.0.0",
     "vite": "^6.0.0"
   },

--- a/packages/vite-plugin-svelte/package.json
+++ b/packages/vite-plugin-svelte/package.json
@@ -11,10 +11,8 @@
   "types": "types/index.d.ts",
   "exports": {
     ".": {
-      "import": {
-        "types": "./types/index.d.ts",
-        "default": "./src/index.js"
-      }
+      "types": "./types/index.d.ts",
+      "default": "./src/index.js"
     }
   },
   "scripts": {
@@ -23,7 +21,7 @@
     "generate:types": "dts-buddy -m \"@sveltejs/vite-plugin-svelte:src/public.d.ts\""
   },
   "engines": {
-    "node": "^18.0.0 || ^20.0.0 || >=22"
+    "node": "^20.19 || ^22.12 || >=24"
   },
   "repository": {
     "type": "git",
@@ -41,7 +39,7 @@
   },
   "homepage": "https://github.com/sveltejs/vite-plugin-svelte#readme",
   "dependencies": {
-    "@sveltejs/vite-plugin-svelte-inspector": "^4.0.1",
+    "@sveltejs/vite-plugin-svelte-inspector": "workspace:^",
     "debug": "^4.4.1",
     "deepmerge": "^4.3.1",
     "kleur": "^4.1.5",


### PR DESCRIPTION
using `default` instead of `import` is possible now since you can use require thanks to "require-esm" support in the node versions we bumped to