### PR TITLE
feat: experimental rolldown-vite support

### DIFF
--- a/.changeset/heavy-dots-repeat.md
+++ b/.changeset/heavy-dots-repeat.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': major
+---
+
+add support for rolldown-vite in vitePreprocess. Using the typescript preprocessor requires a tsconfig.json with verbatimModuleSyntax enabled, eg @tsconfig/svelte

--- a/.changeset/heavy-dots-repeat.md
+++ b/.changeset/heavy-dots-repeat.md
@@ -2,4 +2,4 @@
 '@sveltejs/vite-plugin-svelte': major
 ---
 
-add support for rolldown-vite in vitePreprocess. Using the typescript preprocessor requires a tsconfig.json with verbatimModuleSyntax enabled, eg @tsconfig/svelte
+Using the typescript preprocessor now requires a tsconfig.json with verbatimModuleSyntax enabled, eg @tsconfig/svelte

--- a/.changeset/huge-lamps-greet.md
+++ b/.changeset/huge-lamps-greet.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': minor
+---
+
+Add experimental support for rolldown-vite

--- a/.changeset/hungry-phones-prove.md
+++ b/.changeset/hungry-phones-prove.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': minor
+---
+
+replace esbuild optimizer with rolldown optimizer if rolldown-vite is used

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,10 @@ jobs:
           - node: 20.19
             os: ubuntu-latest
             vite: '6.3.0'
+          # future test with rolldown-vite
+          - node: 24
+            os: ubuntu-latest
+            vite: 'npm:rolldown-vite@latest'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,11 +87,11 @@ jobs:
           # baseline test lowest vite and node version
           - node: 20.19
             os: ubuntu-latest
-            vite: '6.3.0'
+            vite: 'baseline'
           # future test with rolldown-vite
           - node: 24
             os: ubuntu-latest
-            vite: 'npm:rolldown-vite@latest'
+            vite: 'rolldown-vite'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -110,9 +110,16 @@ jobs:
           cache-dependency-path: '**/pnpm-lock.yaml'
       - name: install
         run: pnpm install --frozen-lockfile --ignore-scripts
-      - name: update vite version
-        if: matrix.vite != 'current'
-        run: pnpm update -r --no-save vite@${{matrix.vite}}
+      - name: downgrade vite to baseline
+        if: matrix.vite == 'baseline'
+        run: |
+          pnpm update -r --no-save vite@6.3.0
+          pnpm ls vite
+      - name: update vite to rolldown-vite
+        if: matrix.vite == 'rolldown-vite'
+        run: |
+          pnpm update -r --no-save vite@npm:rolldown-vite@latest
+          pnpm ls rolldown-vite
       - name: install playwright chromium
         run: pnpm playwright install chromium
       - name: run tests

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,7 +14,8 @@ export default [
 			'packages/playground/big/src/pages/**', // lots of generated files
 			'packages/*/types/index.d.ts',
 			'packages/*/types/index.d.ts.map',
-			'packages/*/CHANGELOG.md'
+			'packages/*/CHANGELOG.md',
+			'packages/e2e-tests/**/logs/**'
 		]
 	},
 	...svelteOrgEslintConfig, // contains setup for svelte and typescript

--- a/packages/e2e-tests/_test_dependencies/vite-plugins/index.js
+++ b/packages/e2e-tests/_test_dependencies/vite-plugins/index.js
@@ -63,7 +63,7 @@ export function writeResolvedConfig() {
 			};
 			const dir = path.join(config.root, 'logs', 'resolved-configs');
 			if (!fs.existsSync(dir)) {
-				fs.mkdirSync(dir);
+				fs.mkdirSync(dir, { recursive: true });
 			}
 			const filename = path.join(dir, `vite.config.${cmd}${config.build.ssr ? '.ssr' : ''}.json`);
 			fs.writeFileSync(filename, JSON.stringify(serializableConfig, replacer, '\t'), 'utf-8');

--- a/packages/e2e-tests/kit-node/.gitignore
+++ b/packages/e2e-tests/kit-node/.gitignore
@@ -6,3 +6,4 @@ node_modules
 #.env
 .env.*
 !.env.example
+logs

--- a/packages/e2e-tests/prebundle-svelte-deps/svelte.config.js
+++ b/packages/e2e-tests/prebundle-svelte-deps/svelte.config.js
@@ -1,6 +1,6 @@
-import preprocess from 'svelte-preprocess';
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 export default {
-	preprocess: [preprocess()],
+	preprocess: [vitePreprocess()],
 	vitePlugin: {
 		prebundleSvelteLibraries: true
 	}

--- a/packages/e2e-tests/preprocess-with-vite/__tests__/preprocess-with-vite.spec.ts
+++ b/packages/e2e-tests/preprocess-with-vite/__tests__/preprocess-with-vite.spec.ts
@@ -7,6 +7,7 @@ test('should render App', async () => {
 	expect(await getText('#foo-title')).toBe('Styles with stylus blub');
 	expect(await getColor('#foo-title')).toBe('magenta');
 	expect(await getColor('p.note')).toBe('rgb(255, 62, 0)');
+	expect(await getText('#enum')).toBe('qoox');
 });
 
 test('should not mangle code from esbuild pure annotations', async () => {

--- a/packages/e2e-tests/preprocess-with-vite/package.json
+++ b/packages/e2e-tests/preprocess-with-vite/package.json
@@ -9,6 +9,7 @@
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "workspace:^",
+    "@tsconfig/svelte": "^5.0.4",
     "sass": "^1.89.1",
     "stylus": "^0.64.0",
     "svelte": "^5.33.18",

--- a/packages/e2e-tests/preprocess-with-vite/src/App.svelte
+++ b/packages/e2e-tests/preprocess-with-vite/src/App.svelte
@@ -3,12 +3,17 @@
 	import Bar from './Bar.svelte';
 	export let hello: string;
 	const world: string = 'world'; // edit world and save to see hmr update
+	enum Baz {
+		Qoox = 'qoox'
+	}
+	let qoox = Baz.Qoox;
 </script>
 
 <h1 class="foo">{hello} {world}</h1>
 <p id="app-scss">This is styled with scss using darken fn</p>
 <Foo />
 <Bar />
+<p id="enum">{qoox}</p>
 
 <style lang="scss">
 	@use 'sass:color';

--- a/packages/e2e-tests/preprocess-with-vite/src/index.ts
+++ b/packages/e2e-tests/preprocess-with-vite/src/index.ts
@@ -1,5 +1,5 @@
 import App from './App.svelte';
-import { Hello } from './types.js';
+import { type Hello } from './types.ts';
 import { mount } from 'svelte';
 
 const hello: Hello = 'Hello';

--- a/packages/e2e-tests/preprocess-with-vite/src/tsconfig.json
+++ b/packages/e2e-tests/preprocess-with-vite/src/tsconfig.json
@@ -1,0 +1,3 @@
+{
+	"extends": "@tsconfig/svelte"
+}

--- a/packages/e2e-tests/preprocess-with-vite/svelte.config.js
+++ b/packages/e2e-tests/preprocess-with-vite/svelte.config.js
@@ -1,5 +1,5 @@
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
 export default {
-	preprocess: [vitePreprocess()]
+	preprocess: [vitePreprocess({ script: true })]
 };

--- a/packages/e2e-tests/scan-deps/__tests__/scan-deps.spec.ts
+++ b/packages/e2e-tests/scan-deps/__tests__/scan-deps.spec.ts
@@ -3,10 +3,7 @@ import { describe, expect, it } from 'vitest';
 describe('vite import scan', () => {
 	it('should not fail to discover dependencies exported from script module', async () => {
 		// vite logs an error if scan fails but continues, so validate no errors logged
-		// rolldown-vite logs an error for optimizeDeps.esbuildOptions that is unrelated
-		const errorLogs = e2eServer.logs.server.err.filter(
-			(m) => !m.includes('optimizeDeps.esbuildOptions')
-		);
+		const errorLogs = e2eServer.logs.server.err;
 		expect(errorLogs.length, `unexpected errors:\n${errorLogs.join('\n')}`).toBe(0);
 	});
 	it('should work with exports from module context', async () => {

--- a/packages/e2e-tests/scan-deps/__tests__/scan-deps.spec.ts
+++ b/packages/e2e-tests/scan-deps/__tests__/scan-deps.spec.ts
@@ -3,7 +3,9 @@ import { describe, expect, it } from 'vitest';
 describe('vite import scan', () => {
 	it('should not fail to discover dependencies exported from script module', async () => {
 		// vite logs an error if scan fails but continues, so validate no errors logged
-		const errorLogs = e2eServer.logs.server.err;
+		const errorLogs = e2eServer.logs.server.err.filter(
+			(line) => !line.includes('Support for rolldown-vite in vite-plugin-svelte is experimental')
+		);
 		expect(errorLogs.length, `unexpected errors:\n${errorLogs.join('\n')}`).toBe(0);
 	});
 	it('should work with exports from module context', async () => {

--- a/packages/e2e-tests/scan-deps/__tests__/scan-deps.spec.ts
+++ b/packages/e2e-tests/scan-deps/__tests__/scan-deps.spec.ts
@@ -3,10 +3,11 @@ import { describe, expect, it } from 'vitest';
 describe('vite import scan', () => {
 	it('should not fail to discover dependencies exported from script module', async () => {
 		// vite logs an error if scan fails but continues, so validate no errors logged
-		expect(
-			e2eServer.logs.server.err.length,
-			`unexpected errors:\n${e2eServer.logs.server.err.join('\n')}`
-		).toBe(0);
+		// rolldown-vite logs an error for optimizeDeps.esbuildOptions that is unrelated
+		const errorLogs = e2eServer.logs.server.err.filter(
+			(m) => !m.startsWith('You or a plugin you are using have set `optimizeDeps.esbuildOptions`')
+		);
+		expect(errorLogs.length, `unexpected errors:\n${errorLogs.join('\n')}`).toBe(0);
 	});
 	it('should work with exports from module context', async () => {
 		expect(await getText('#svelte5')).toBe('svelte5');

--- a/packages/e2e-tests/scan-deps/__tests__/scan-deps.spec.ts
+++ b/packages/e2e-tests/scan-deps/__tests__/scan-deps.spec.ts
@@ -5,7 +5,7 @@ describe('vite import scan', () => {
 		// vite logs an error if scan fails but continues, so validate no errors logged
 		// rolldown-vite logs an error for optimizeDeps.esbuildOptions that is unrelated
 		const errorLogs = e2eServer.logs.server.err.filter(
-			(m) => !m.startsWith('You or a plugin you are using have set `optimizeDeps.esbuildOptions`')
+			(m) => !m.includes('optimizeDeps.esbuildOptions')
 		);
 		expect(errorLogs.length, `unexpected errors:\n${errorLogs.join('\n')}`).toBe(0);
 	});

--- a/packages/e2e-tests/vitestSetup.ts
+++ b/packages/e2e-tests/vitestSetup.ts
@@ -141,8 +141,11 @@ beforeAll(
 				if (fs.existsSync(tempViteCache)) {
 					await fs.rm(tempViteCache, { force: true, recursive: true });
 				}
-
-				await fs.mkdir(path.join(tempDir, 'logs'));
+				const logsDir = path.join(tempDir, 'logs');
+				if (fs.existsSync(logsDir)) {
+					fs.rmSync(logsDir, { recursive: true, force: true });
+				}
+				await fs.mkdir(logsDir);
 				const customServerScript = path.resolve(path.dirname(testPath), 'serve.js');
 				const defaultServerScript = path.resolve(e2eTestsRoot, 'e2e-server.js');
 				const hasCustomServer = fs.existsSync(customServerScript);

--- a/packages/vite-plugin-svelte/src/index.js
+++ b/packages/vite-plugin-svelte/src/index.js
@@ -39,10 +39,9 @@ export function svelte(inlineOptions) {
 		log.setLevel('debug');
 	}
 	if (rolldownVersion) {
-		log.warn.once('!!! Support for rolldown-vite in vite-plugin-svelte is experimental !!!', {
-			rolldownVersion,
-			viteVersion
-		});
+		log.warn.once(
+			`!!! Support for rolldown-vite in vite-plugin-svelte is experimental (rolldown: ${rolldownVersion}, vite: ${viteVersion}) !!!`
+		);
 	}
 
 	validateInlineOptions(inlineOptions);

--- a/packages/vite-plugin-svelte/src/index.js
+++ b/packages/vite-plugin-svelte/src/index.js
@@ -26,6 +26,9 @@ import { VitePluginSvelteCache } from './utils/vite-plugin-svelte-cache.js';
 import { loadRaw } from './utils/load-raw.js';
 import * as svelteCompiler from 'svelte/compiler';
 import { SVELTE_VIRTUAL_STYLE_ID_REGEX } from './utils/constants.js';
+import * as vite from 'vite';
+// @ts-expect-error rolldownVersion
+const { version: viteVersion, rolldownVersion } = vite;
 
 /**
  * @param {Partial<import('./public.d.ts').Options>} [inlineOptions]
@@ -35,6 +38,13 @@ export function svelte(inlineOptions) {
 	if (process.env.DEBUG != null) {
 		log.setLevel('debug');
 	}
+	if (rolldownVersion) {
+		log.warn.once('!!! Support for rolldown-vite in vite-plugin-svelte is experimental !!!', {
+			rolldownVersion,
+			viteVersion
+		});
+	}
+
 	validateInlineOptions(inlineOptions);
 	const cache = new VitePluginSvelteCache();
 	// updated in configResolved hook

--- a/packages/vite-plugin-svelte/src/index.js
+++ b/packages/vite-plugin-svelte/src/index.js
@@ -140,6 +140,8 @@ export function svelte(inlineOptions) {
 									css.meta.vite ??= {};
 									css.meta.vite.cssScopeTo = [svelteRequest.filename, 'default'];
 								}
+								css.moduleType = 'css';
+
 								return css;
 							}
 						}
@@ -194,6 +196,7 @@ export function svelte(inlineOptions) {
 				}
 				return {
 					...compileData.compiled.js,
+					moduleType: 'js',
 					meta: {
 						vite: {
 							lang: compileData.lang

--- a/packages/vite-plugin-svelte/src/preprocess.js
+++ b/packages/vite-plugin-svelte/src/preprocess.js
@@ -1,13 +1,14 @@
 import process from 'node:process';
 import * as vite from 'vite';
 import { mapToRelative, removeLangSuffix } from './utils/sourcemaps.js';
-//@ts-expect-error rolldown types don't exist
 const {
 	isCSSRequest,
 	preprocessCSS,
 	resolveConfig,
 	transformWithEsbuild,
+	//@ts-expect-error rolldown types don't exist
 	rolldownVersion,
+	//@ts-expect-error rolldown types don't exist
 	transformWithOxc
 } = vite;
 /**

--- a/packages/vite-plugin-svelte/src/types/compile.d.ts
+++ b/packages/vite-plugin-svelte/src/types/compile.d.ts
@@ -14,6 +14,7 @@ export interface Code {
 	map?: any;
 	dependencies?: any[];
 	hasGlobal?: boolean;
+	moduleType?: string; //rolldown-vite
 	meta?: {
 		vite?: CustomPluginOptionsVite;
 	};

--- a/packages/vite-plugin-svelte/src/utils/optimizer-plugins.js
+++ b/packages/vite-plugin-svelte/src/utils/optimizer-plugins.js
@@ -89,23 +89,13 @@ export function patchRolldownOptimizerPlugin(plugin, options) {
 					}
 				}
 			};
-			plugin.buildStart = {
-				handler: () => {
-					if (isScanner) {
-						return;
-					}
-					statsCollection = options.stats?.startCollection(statsName, {
-						logResult: (c) => c.stats.length > 1
-					});
-				}
+			plugin.buildStart = () => {
+				statsCollection = options.stats?.startCollection(statsName, {
+					logResult: (c) => c.stats.length > 1
+				});
 			};
-			plugin.buildEnd = {
-				handler: () => {
-					if (isScanner) {
-						return;
-					}
-					statsCollection?.finish();
-				}
+			plugin.buildEnd = () => {
+				statsCollection?.finish();
 			};
 		}
 	};

--- a/packages/vite-plugin-svelte/types/index.d.ts.map
+++ b/packages/vite-plugin-svelte/types/index.d.ts.map
@@ -26,6 +26,6 @@
 		null,
 		null
 	],
-	"mappings": ";;;;aAIYA,OAAOA;;WAETC,mBAAmBA;;;;;;;;;;;kBAWZC,aAAaA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;kBAgGbC,YAAYA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;WAiDnBC,mBAAmBA;;;;;;;;;;;;;;;;WAgBnBC,oBAAoBA;;;;;;;;;;;;;;;MAezBC,SAASA;;kBAEGC,qBAAqBA;;;;;;;;;;;;;iBClKtBC,MAAMA;iBCTNC,cAAcA;iBCQRC,gBAAgBA",
+	"mappings": ";;;;aAIYA,OAAOA;;WAETC,mBAAmBA;;;;;;;;;;;kBAWZC,aAAaA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;kBAgGbC,YAAYA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;WAiDnBC,mBAAmBA;;;;;;;;;;;;;;;;WAgBnBC,oBAAoBA;;;;;;;;;;;;;;;MAezBC,SAASA;;kBAEGC,qBAAqBA;;;;;;;;;;;;;iBClKtBC,MAAMA;iBCRNC,cAAcA;iBCORC,gBAAgBA",
 	"ignoreList": []
 }

--- a/packages/vite-plugin-svelte/types/index.d.ts.map
+++ b/packages/vite-plugin-svelte/types/index.d.ts.map
@@ -26,6 +26,6 @@
 		null,
 		null
 	],
-	"mappings": ";;;;aAIYA,OAAOA;;WAETC,mBAAmBA;;;;;;;;;;;kBAWZC,aAAaA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;kBAgGbC,YAAYA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;WAiDnBC,mBAAmBA;;;;;;;;;;;;;;;;WAgBnBC,oBAAoBA;;;;;;;;;;;;;;;MAezBC,SAASA;;kBAEGC,qBAAqBA;;;;;;;;;;;;;iBClKtBC,MAAMA;iBCjBNC,cAAcA;iBCgBRC,gBAAgBA",
+	"mappings": ";;;;aAIYA,OAAOA;;WAETC,mBAAmBA;;;;;;;;;;;kBAWZC,aAAaA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;kBAgGbC,YAAYA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;WAiDnBC,mBAAmBA;;;;;;;;;;;;;;;;WAgBnBC,oBAAoBA;;;;;;;;;;;;;;;MAezBC,SAASA;;kBAEGC,qBAAqBA;;;;;;;;;;;;;iBClKtBC,MAAMA;iBCTNC,cAAcA;iBCQRC,gBAAgBA",
 	"ignoreList": []
 }

--- a/packages/vite-plugin-svelte/types/index.d.ts.map
+++ b/packages/vite-plugin-svelte/types/index.d.ts.map
@@ -26,6 +26,6 @@
 		null,
 		null
 	],
-	"mappings": ";;;;aAIYA,OAAOA;;WAETC,mBAAmBA;;;;;;;;;;;kBAWZC,aAAaA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;kBAgGbC,YAAYA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;WAiDnBC,mBAAmBA;;;;;;;;;;;;;;;;WAgBnBC,oBAAoBA;;;;;;;;;;;;;;;MAezBC,SAASA;;kBAEGC,qBAAqBA;;;;;;;;;;;;;iBClKtBC,MAAMA;iBCRNC,cAAcA;iBCORC,gBAAgBA",
+	"mappings": ";;;;aAIYA,OAAOA;;WAETC,mBAAmBA;;;;;;;;;;;kBAWZC,aAAaA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;kBAgGbC,YAAYA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;WAiDnBC,mBAAmBA;;;;;;;;;;;;;;;;WAgBnBC,oBAAoBA;;;;;;;;;;;;;;;MAezBC,SAASA;;kBAEGC,qBAAqBA;;;;;;;;;;;;;iBC/JtBC,MAAMA;iBCXNC,cAAcA;iBCORC,gBAAgBA",
 	"ignoreList": []
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -503,6 +503,9 @@ importers:
       '@sveltejs/vite-plugin-svelte':
         specifier: workspace:^
         version: link:../../vite-plugin-svelte
+      '@tsconfig/svelte':
+        specifier: ^5.0.4
+        version: 5.0.4
       sass:
         specifier: ^1.89.1
         version: 1.89.1


### PR DESCRIPTION
fixes #1117 

the goal is that users can swap in npm:rolldown-vite for vite, vite-plugin-svelte detects it and it *just works*

- [x] add to test matrix
- [x] add detection
- [x] update config
- [x] transformWithEsbuild to transformWithOxc
- [x] esbuild optimizer plugin to rolldown optimizer

optional:
- [ ] run build with both and diff output, make sure that there are no hidden changes
