### PR TITLE
chore: remove workspace ref from plugins circular dep 

### DIFF
--- a/packages/vite-plugin-svelte-inspector/package.json
+++ b/packages/vite-plugin-svelte-inspector/package.json
@@ -42,7 +42,7 @@
     "debug": "^4.4.1"
   },
   "peerDependencies": {
-    "@sveltejs/vite-plugin-svelte": "workspace:^",
+    "@sveltejs/vite-plugin-svelte": "^6.0.0-next.0",
     "svelte": "^5.0.0",
     "vite": "^6.3.0 || ^7.0.0-beta.0"
   },

--- a/packages/vite-plugin-svelte/package.json
+++ b/packages/vite-plugin-svelte/package.json
@@ -39,7 +39,7 @@
   },
   "homepage": "https://github.com/sveltejs/vite-plugin-svelte#readme",
   "dependencies": {
-    "@sveltejs/vite-plugin-svelte-inspector": "workspace:^",
+    "@sveltejs/vite-plugin-svelte-inspector": "^5.0.0-next.0",
     "debug": "^4.4.1",
     "deepmerge": "^4.3.1",
     "kleur": "^4.1.5",


### PR DESCRIPTION
avoids odd changesets behavior

maybe we should move the inspector inside vite-plugin-svelte again. it was made  a separate plugin to be able to update it without updating vite-plugin-svelte but that hardly happened and this circular dependency is an annoyance on every major release.