### PR TITLE
refactor(load-config): remove support for cjs and add support for ts

### DIFF
--- a/.changeset/nasty-ghosts-warn.md
+++ b/.changeset/nasty-ghosts-warn.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': major
+---
+
+remove support for loading commonjs svelte config files

--- a/.changeset/tall-rivers-sleep.md
+++ b/.changeset/tall-rivers-sleep.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': minor
+---
+
+add support for loading typescript svelte config files in runtimes that support it

--- a/packages/e2e-tests/configfile-custom/__tests__/configfile-custom.spec.ts
+++ b/packages/e2e-tests/configfile-custom/__tests__/configfile-custom.spec.ts
@@ -1,5 +1,8 @@
 import { it, expect } from 'vitest';
 import { editViteConfig, isBuild, page, e2eServer } from '~utils';
+import { versions } from 'node:process';
+
+const isNodeWithoutTypeStripping = Number(versions.node?.split('.', 1)[0]) < 22;
 
 it('should load default config and work', async () => {
 	expect(e2eServer.logs.server.out).toContain('default svelte config loaded');
@@ -11,11 +14,11 @@ it('should load default config and work', async () => {
 if (!isBuild) {
 	// editing vite config does not work in build tests, build only runs once
 	// TODO split into different tests
-	it('should load custom cjs config and work', async () => {
+	it.skipIf(isNodeWithoutTypeStripping)('should load custom ts config and work', async () => {
 		await editViteConfig((c) =>
-			c.replace(/svelte\([^)]*\)/, "svelte({configFile:'svelte.config.custom.cjs'})")
+			c.replace(/svelte\([^)]*\)/, "svelte({configFile:'svelte.config.custom.ts'})")
 		);
-		expect(e2eServer.logs.server.out).toContain('custom svelte config loaded cjs');
+		expect(e2eServer.logs.server.out).toContain('custom svelte config loaded ts');
 		expect(await page.textContent('h1')).toMatch('Hello world!');
 		expect(await page.textContent('#test-child')).toBe('test-child');
 		expect(await page.textContent('#dependency-import')).toBe('dependency-import');

--- a/packages/e2e-tests/configfile-custom/package.json
+++ b/packages/e2e-tests/configfile-custom/package.json
@@ -3,8 +3,8 @@
   "private": true,
   "version": "1.0.0",
   "scripts": {
-    "dev": "vite",
-    "build": "vite build",
+    "dev": "cross-env NODE_OPTIONS=\"--experimental-strip-types\" vite",
+    "build": "cross-env NODE_OPTIONS=\"--experimental-strip-types\" vite build",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/packages/e2e-tests/configfile-custom/svelte.config.custom.cjs
+++ b/packages/e2e-tests/configfile-custom/svelte.config.custom.cjs
@@ -1,6 +1,0 @@
-console.log('custom svelte config loaded cjs');
-module.exports = {
-	vitePlugin: {
-		emitCss: false
-	}
-};

--- a/packages/e2e-tests/configfile-custom/svelte.config.custom.ts
+++ b/packages/e2e-tests/configfile-custom/svelte.config.custom.ts
@@ -1,0 +1,8 @@
+console.log('custom svelte config loaded ts');
+import type { SvelteConfig } from '@sveltejs/vite-plugin-svelte';
+const config: SvelteConfig = {
+	vitePlugin: {
+		emitCss: false
+	}
+};
+export default config;

--- a/packages/e2e-tests/configfile-custom/svelte.config.js
+++ b/packages/e2e-tests/configfile-custom/svelte.config.js
@@ -1,2 +1,2 @@
 console.log('default svelte config loaded');
-module.exports = {};
+export default {};

--- a/packages/vite-plugin-svelte/types/index.d.ts.map
+++ b/packages/vite-plugin-svelte/types/index.d.ts.map
@@ -26,6 +26,6 @@
 		null,
 		null
 	],
-	"mappings": ";;;;aAIYA,OAAOA;;WAETC,mBAAmBA;;;;;;;;;;;kBAWZC,aAAaA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;kBAgGbC,YAAYA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;WAiDnBC,mBAAmBA;;;;;;;;;;;;;;;;WAgBnBC,oBAAoBA;;;;;;;;;;;;;;;MAezBC,SAASA;;kBAEGC,qBAAqBA;;;;;;;;;;;;;iBC/JtBC,MAAMA;iBCXNC,cAAcA;iBCORC,gBAAgBA",
+	"mappings": ";;;;aAIYA,OAAOA;;WAETC,mBAAmBA;;;;;;;;;;;kBAWZC,aAAaA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;kBAgGbC,YAAYA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;WAiDnBC,mBAAmBA;;;;;;;;;;;;;;;;WAgBnBC,oBAAoBA;;;;;;;;;;;;;;;MAezBC,SAASA;;kBAEGC,qBAAqBA;;;;;;;;;;;;;iBC/JtBC,MAAMA;iBCXNC,cAAcA;iBCFRC,gBAAgBA",
 	"ignoreList": []
 }


### PR DESCRIPTION
# Add typescript 

Recently, nodejs enabled type stripping by default, and even in node 22 it can be used with the `--experimental-strip-types` flag. Other runtimes like deno or bun support importing local typescript files as well.

Simply rename your `svelte.config.js` to `svelte.config.ts` .


# Remove commonjs

If you still have a `svelte.config.cjs` in active use, you can create a svelte.config.js like this

``js
import config from './svelte.config.cjs'
export default config
```

or simply refactor it to esm. It's time.