### PR TITLE
fix: log missing config at info level

### DIFF
--- a/.changeset/whole-bees-sink.md
+++ b/.changeset/whole-bees-sink.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+increase logLevel to info for "no Svelte config found" message

--- a/packages/vite-plugin-svelte/src/utils/load-svelte-config.js
+++ b/packages/vite-plugin-svelte/src/utils/load-svelte-config.js
@@ -67,7 +67,7 @@ function findConfigToLoad(viteConfig, inlineOptions) {
 			.map((candidate) => path.resolve(root, candidate))
 			.filter((file) => fs.existsSync(file));
 		if (existingKnownConfigFiles.length === 0) {
-			log.debug(`no svelte config found at ${root}`, undefined, 'config');
+			log.info(`no Svelte config found at ${root} - using default configuration.`);
 			return;
 		} else if (existingKnownConfigFiles.length > 1) {
 			log.warn(


### PR DESCRIPTION
fixes #1165  and generally helps users to understand that default configuration is used. 

In most cases this is not on purpose but due to accidentally moved files or directories.