### PR TITLE
feat(rolldown-vite): enable optimization.inlineConst by default

### DIFF
--- a/.changeset/all-colts-dig.md
+++ b/.changeset/all-colts-dig.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': minor
+---
+
+feat(rolldown-vite): enable `optimization.inlineConst` by default to ensure treeshaking works with esm-env in svelte


### PR DESCRIPTION
This is going to help with treeshaking and esm-env. 

We have to wait for a new release of rolldown (1.0.0-beta.35) and rolldown-vite using that before merging.