### PR TITLE
chore: change renovate-bot range strategy

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -7,7 +7,7 @@
 		":semanticCommits" // nicer commit messages
 	],
 	"labels": ["dependencies"],
-	"rangeStrategy": "bump",
+	"rangeStrategy": "update-lockfile",
 	"packageRules": [
 		{
 			"matchDepTypes": ["peerDependencies","engines"],


### PR DESCRIPTION
 to reduce churn in package.json files