### PR TITLE
fix: remove automatic setting of rolldown inlineConst

### DIFF
--- a/.changeset/tall-days-draw.md
+++ b/.changeset/tall-days-draw.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+Remove automatic configuration for rolldownOptions.optimization.inlineConst because latest version of rolldown-vite has it enabled by default.

--- a/packages/vite-plugin-svelte/src/plugins/configure.js
+++ b/packages/vite-plugin-svelte/src/plugins/configure.js
@@ -12,7 +12,6 @@ import {
 } from '../utils/options.js';
 import { buildIdFilter, buildIdParser } from '../utils/id.js';
 import { createCompileSvelte } from '../utils/compile.js';
-import { gte } from '../utils/svelte-version.js';
 
 // @ts-ignore rolldownVersion
 const { version: viteVersion, rolldownVersion } = vite;
@@ -59,39 +58,7 @@ export function configure(api, inlineOptions) {
 				preOptions = await preResolveOptions(inlineOptions, config, configEnv);
 				// extra vite config
 				const extraViteConfig = await buildExtraViteConfig(preOptions, config);
-
-				if (
-					rolldownVersion &&
-					configEnv.command === 'build' &&
-					gte(rolldownVersion, '1.0.0-beta.35') // inlineConst received a critical bugfix in 1.0.0-beta.35
-				) {
-					extraViteConfig.build ??= {};
-					// rename rollupOptions to rolldownOptions
-					//@ts-ignore rolldownOptions only exists in rolldown-vite
-					extraViteConfig.build.rolldownOptions = extraViteConfig.build.rollupOptions || {};
-					delete extraViteConfig.build.rollupOptions;
-					// read user config inlineConst value
-					const inlineConst =
-						//@ts-ignore optimization only exists in rolldown-vite
-						config.build?.rolldownOptions?.optimization?.inlineConst ??
-						//@ts-ignore optimization only exists in rolldown-vite
-						config.build?.rollupOptions?.optimization?.inlineConst;
-
-					if (inlineConst == null) {
-						// set inlineConst build optimization for esm-env
-						//@ts-ignore rolldownOptions only exists in rolldown-vite
-						extraViteConfig.build.rolldownOptions.optimization ??= {};
-						//@ts-ignore rolldownOptions only exists in rolldown-vite
-						extraViteConfig.build.rolldownOptions.optimization.inlineConst = true;
-					} else if (inlineConst === false) {
-						log.warn(
-							'Your rolldown config contains `optimization.inlineConst: false`. This can lead to increased bundle size and leaked server code in client build.'
-						);
-					}
-				}
-
 				log.debug('additional vite config', extraViteConfig, 'config');
-
 				return extraViteConfig;
 			}
 		},

--- a/packages/vite-plugin-svelte/src/utils/options.js
+++ b/packages/vite-plugin-svelte/src/utils/options.js
@@ -6,7 +6,9 @@ const {
 	defaultClientConditions,
 	defaultServerConditions,
 	normalizePath,
-	searchForWorkspaceRoot
+	searchForWorkspaceRoot,
+	// @ts-ignore
+	rolldownVersion
 } = vite;
 import { log } from './log.js';
 import { loadSvelteConfig } from './load-svelte-config.js';
@@ -415,6 +417,20 @@ function validateViteConfig(extraViteConfig, config, options) {
 				'optimizeDeps.disabled',
 				viteOptimizeDepsDisabled,
 				'Disable optimizeDeps or prebundleSvelteLibraries for build if you experience errors.'
+			);
+		}
+	}
+	if (rolldownVersion && isBuild) {
+		// read user config inlineConst value
+		const inlineConst =
+			//@ts-ignore optimization only exists in rolldown-vite
+			config.build?.rolldownOptions?.optimization?.inlineConst ??
+			//@ts-ignore optimization only exists in rolldown-vite
+			config.build?.rollupOptions?.optimization?.inlineConst;
+
+		if (inlineConst === false) {
+			log.warn(
+				'Your rolldown config contains `optimization.inlineConst: false`. This can lead to increased bundle size and leaked server code in client build.'
 			);
 		}
 	}


### PR DESCRIPTION
previously `inlineConst: true` was needed to ensure esm-env works correctly but now rolldown-vite uses smart inlineConst by default which is less agressive but still works.

Keeps the warning when user explicitly sets false but moves it other validations