### PR TITLE
chore: add first party svelte dependencies to minimumReleaseAgeExclude

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,6 +16,12 @@ minimumReleaseAgeExclude:
   - 'rolldown'
   - '@rolldown/*'
   - '@oxc-project/*'
+  - 'devalue'
+  - 'esm-env'
+  - 'esrap'
+  - 'is-reference'
+  - 'locate-character'
+  - 'zimmerframe'
 
 onlyBuiltDependencies:
   - esbuild


### PR DESCRIPTION
to prevent breaking install in svelte-ecosystem-ci.