### PR TITLE
chore: downgrade playwright to 1.56.1 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
           pnpm update -r --no-save vite@beta
           pnpm ls vite
       - name: install playwright chromium
-        run: pnpm playwright install chromium
+        run: pnpm playwright install chromium --only-shell
       - name: run tests
         run: pnpm test
       - name: check-types with vite-8-beta

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "lint-staged": "^16.2.7",
     "node-fetch": "^3.3.2",
     "npm-run-all2": "^8.0.4",
-    "playwright-core": "~1.57.0",
+    "playwright-core": "~1.56.1",
     "prettier": "^3.7.3",
     "prettier-plugin-svelte": "^3.4.0",
     "publint": "^0.3.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,8 +92,8 @@ importers:
         specifier: ^8.0.4
         version: 8.0.4
       playwright-core:
-        specifier: ~1.57.0
-        version: 1.57.0
+        specifier: ~1.56.1
+        version: 1.56.1
       prettier:
         specifier: ^3.7.3
         version: 3.7.4
@@ -2853,8 +2853,8 @@ packages:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
 
-  playwright-core@1.57.0:
-    resolution: {integrity: sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==}
+  playwright-core@1.56.1:
+    resolution: {integrity: sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -5622,7 +5622,7 @@ snapshots:
 
   pify@4.0.1: {}
 
-  playwright-core@1.57.0: {}
+  playwright-core@1.56.1: {}
 
   polka@1.0.0-next.28:
     dependencies:


### PR DESCRIPTION
to avoid instability in macos with 1.57.0