### PR TITLE
fix(filter): ignore zero-tagged ids per rollup convention

### DIFF
--- a/.changeset/brave-places-ask.md
+++ b/.changeset/brave-places-ask.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+fix(filter): ignore zero-tagged ids per rollup convention

--- a/packages/vite-plugin-svelte/src/utils/id.js
+++ b/packages/vite-plugin-svelte/src/utils/id.js
@@ -184,6 +184,7 @@ export function buildIdFilter(options) {
 		id: {
 			include: [extensionsRE, .../**@type {Array<string|RegExp>}*/ arraify(include)],
 			exclude: /**@type {Array<string|RegExp>}*/ [
+				'\0',
 				SVELTE_VIRTUAL_STYLE_ID_REGEX, // exclude from regular pipeline, we load it in a separate plugin
 				...arraify(exclude)
 			]
@@ -225,7 +226,7 @@ export function buildModuleIdFilter(options) {
 	return {
 		id: {
 			include: [infixWithExtRE, .../**@type {Array<string|RegExp>}*/ arraify(include)],
-			exclude: /**@type {Array<string|RegExp>}*/ arraify(exclude)
+			exclude: ['\0', .../**@type {Array<string|RegExp>}*/ arraify(exclude)]
 		}
 	};
 }


### PR DESCRIPTION
This fixes a regression that was introduced when switching from rollup-pluginutils createFilter that automatically excludes`\0`.  Reported here https://github.com/withastro/astro/pull/14821#issue-3645454410
