### PR TITLE
Support for Vite 8

### DIFF
--- a/packages/vite-plugin-svelte/package.json
+++ b/packages/vite-plugin-svelte/package.json
@@ -47,7 +47,7 @@
   },
   "peerDependencies": {
     "svelte": "^5.0.0",
-    "vite": "^6.3.0 || ^7.0.0"
+    "vite": "^6.3.0 || ^7.0.0 || ^8.0.0"
   },
   "devDependencies": {
     "@types/debug": "^4.1.12",


### PR DESCRIPTION
Without it I'm unable to use Vite `8.0.0-beta.7`

```
npm error code ERESOLVE
npm error ERESOLVE unable to resolve dependency tree
npm error
npm error While resolving: my-project
npm error Found: vite@8.0.0-beta.7
npm error node_modules/vite
npm error   dev vite@"8.0.0-beta.7" from the root project
npm error
npm error Could not resolve dependency:
npm error peer vite@"^6.3.0 || ^7.0.0" from @sveltejs/vite-plugin-svelte@6.2.4
npm error node_modules/@sveltejs/vite-plugin-svelte
npm error   dev @sveltejs/vite-plugin-svelte@"6.2.4" from the root project
npm error   peer @sveltejs/vite-plugin-svelte@"^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0" from @sveltejs/kit@2.49.4
npm error   node_modules/@sveltejs/kit
npm error     dev @sveltejs/kit@"2.49.4" from the root project
npm error     1 more (@sveltejs/adapter-static)
npm error
npm error Fix the upstream dependency conflict, or retry
npm error this command with --force or --legacy-peer-deps
npm error to accept an incorrect (and potentially broken) dependency resolution.
```