### PR TITLE
chore: fix codefence lint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -43,13 +43,6 @@ export default defineConfig([
 		extends: ['markdown/recommended', 'markdown/processor']
 	},
 	{
-		name: 'local/markdown-rules',
-		files: ['**/*.md'],
-		rules: {
-			'no-undef': 'off'
-		}
-	},
-	{
 		name: 'local/language-options',
 		languageOptions: {
 			ecmaVersion: 2022,
@@ -154,7 +147,8 @@ export default defineConfig([
 		files: ['**/*.md/*.js', '**/*.md/*.ts', '**/*.md/*.svelte'],
 		rules: {
 			'n/no-missing-import': 'off',
-			'@typescript-eslint/no-unused-vars': 'off'
+			'@typescript-eslint/no-unused-vars': 'off',
+			'no-undef': 'off'
 		}
 	},
 	{


### PR DESCRIPTION
The markdown files are only linted for their codefences. This PR fixes the config so that they're not influenced by our svelte org's linting rules which are meant for actual js and svelte files.