### PR TITLE
chore: restore pnpm CLI options

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -57,3 +57,10 @@ overrides:
 
 # needed for _test_dependencies
 dedupeInjectedDeps: false
+
+# cli output
+# These are only documented as inline options and they also show an error in VS Code
+# based on the schema from https://json.schemastore.org/pnpm-workspace.json
+# However, they do work and are valid options
+aggregateOutput: true
+reporter: append-only


### PR DESCRIPTION
This PR restores the pnpm aggregate output option which _does_ work when configured in the `pnpm-workspace.yaml` file. When running `pnpm check`, it makes the output easier to read. This is also used in `vite-ecosystem-ci`

With --aggregate-output:
```
Checking formatting...
Scope: 2 of 43 workspace projects
Scope: 2 of 43 workspace projects
1 vulnerabilities found
Severity: 1 high (1 ignored)
packages/vite-plugin-svelte check:publint$ publint --strict
packages/vite-plugin-svelte check:publint: Running publint v0.3.18 for @sveltejs/vite-plugin-svelte...
packages/vite-plugin-svelte check:publint: Packing files with `pnpm pack`...
packages/vite-plugin-svelte check:publint: Linting...
packages/e2e-tests/configfile-esm/src/App.sveltepackages/vite-plugin-svelte check:publint: All good!
packages/vite-plugin-svelte check:publint: Done
All matched files use Prettier code style!
[@stylistic/eslint-plugin-js] This package is deprecated in favor of the unified @stylistic/eslint-plugin, please consider migrating to the main package
packages/vite-plugin-svelte check:types$ tsc --noEmit
packages/vite-plugin-svelte check:types: Done
```

Without --aggregate-output:

```
Checking formatting...
Scope: 2 of 43 workspace projects
.husky/_/post-applypatchpackages/vite-plugin-svelte check:types$ tsc --noEmit
Scope: 2 of 43 workspace projects
.husky/_/post-commitpackages/vite-plugin-svelte check:publint$ publint --strict
packages/vite-plugin-svelte check:publint: Running publint v0.3.18 for @sveltejs/vite-plugin-svelte...
packages/vite-plugin-svelte check:publint: Packing files with `pnpm pack`...
1 vulnerabilities found
Severity: 1 high (1 ignored)
packages/e2e-tests/configfile-custom/src/main.jspackages/vite-plugin-svelte check:publint: Linting...
packages/vite-plugin-svelte check:publint: All good!
packages/e2e-tests/configfile-custom/svelte.config.tspackages/vite-plugin-svelte check:publint: Done
[@stylistic/eslint-plugin-js] This package is deprecated in favor of the unified @stylistic/eslint-plugin, please consider migrating to the main package
All matched files use Prettier code style!
packages/vite-plugin-svelte check:types: Done
```