### PR TITLE
chore: use modern JSDoc imports

### DIFF
--- a/packages/vite-plugin-svelte/src/index.js
+++ b/packages/vite-plugin-svelte/src/index.js
@@ -1,3 +1,7 @@
+/** @import { Options } from './public.js' */
+/** @import { PluginAPI } from './types/plugin-api.js' */
+/** @import { Plugin } from 'vite' */
+
 import process from 'node:process';
 import { log } from './utils/log.js';
 import { configure } from './plugins/configure.js';
@@ -14,14 +18,14 @@ import { hotUpdate } from './plugins/hot-update.js';
  * returns a list of plugins to handle svelte files
  * plugins are named `vite-plugin-svelte:<task>`
  *
- * @param {Partial<import('./public.d.ts').Options>} [inlineOptions]
- * @returns {import('vite').Plugin[]}
+ * @param {Partial<Options>} [inlineOptions]
+ * @returns {Plugin[]}
  */
 export function svelte(inlineOptions) {
 	if (process.env.DEBUG != null) {
 		log.setLevel('debug');
 	}
-	/** @type {import('./types/plugin-api.js').PluginAPI} */
+	/** @type {PluginAPI} */
 	// @ts-expect-error initialize empty to guard against early use
 	const api = {}; // initialized by configure plugin, used in others
 	return [

--- a/packages/vite-plugin-svelte/src/plugins/compile-module.js
+++ b/packages/vite-plugin-svelte/src/plugins/compile-module.js
@@ -1,3 +1,9 @@
+/** @import { ModuleIdParser } from '../types/id.js' */
+/** @import { ResolvedOptions } from '../types/options.js' */
+/** @import { PluginAPI } from '../types/plugin-api.js' */
+/** @import { CompileOptions, ModuleCompileOptions } from 'svelte/compiler' */
+/** @import { Plugin } from 'vite' */
+
 import { buildModuleIdFilter, buildModuleIdParser } from '../utils/id.js';
 import * as svelteCompiler from 'svelte/compiler';
 import { log, logCompilerWarnings } from '../utils/log.js';
@@ -5,25 +11,25 @@ import { toRollupError } from '../utils/error.js';
 import { isSvelteWithAsync } from '../utils/svelte-version.js';
 
 /**
- * @param {import('../types/plugin-api.d.ts').PluginAPI} api
- * @returns {import('vite').Plugin}
+ * @param {PluginAPI} api
+ * @returns {Plugin}
  */
 export function compileModule(api) {
 	/**
-	 * @type {import("../types/options.js").ResolvedOptions}
+	 * @type {ResolvedOptions}
 	 */
 	let options;
 	/**
-	 * @type {import("../types/id.js").ModuleIdParser}
+	 * @type {ModuleIdParser}
 	 */
 	let idParser;
 
 	/**
-	 * @type {import('svelte/compiler').ModuleCompileOptions}
+	 * @type {ModuleCompileOptions}
 	 */
 	let staticModuleCompileOptions;
 
-	/** @type {import('vite').Plugin} */
+	/** @type {Plugin} */
 	const plugin = {
 		name: 'vite-plugin-svelte:compile-module',
 		enforce: 'post',
@@ -42,7 +48,7 @@ export function compileModule(api) {
 					return;
 				}
 				const filename = moduleRequest.filename;
-				/** @type {import('svelte/compiler').CompileOptions} */
+				/** @type {CompileOptions} */
 				const compileOptions = {
 					...staticModuleCompileOptions,
 					dev: !this.environment.config.isProduction,
@@ -96,11 +102,11 @@ export function compileModule(api) {
 
 /**
  *
- * @param {import('svelte/compiler').CompileOptions} compilerOptions
- * @return {import('svelte/compiler').ModuleCompileOptions}
+ * @param {CompileOptions} compilerOptions
+ * @return {ModuleCompileOptions}
  */
 function filterNonModuleCompilerOptions(compilerOptions) {
-	/** @type {Array<keyof import('svelte/compiler').ModuleCompileOptions>} */
+	/** @type {Array<keyof ModuleCompileOptions>} */
 	const knownModuleCompileOptionNames = ['dev', 'generate', 'filename', 'rootDir', 'warningFilter'];
 	if (isSvelteWithAsync) {
 		knownModuleCompileOptionNames.push('experimental');
@@ -108,7 +114,7 @@ function filterNonModuleCompilerOptions(compilerOptions) {
 	// not typed but this is temporary until svelte itself ignores CompileOptions passed to compileModule
 	const experimentalModuleCompilerOptionNames = ['async'];
 
-	/** @type {import('svelte/compiler').ModuleCompileOptions} */
+	/** @type {ModuleCompileOptions} */
 	const filtered = filterByPropNames(compilerOptions, knownModuleCompileOptionNames);
 	if (filtered.experimental) {
 		filtered.experimental = filterByPropNames(

--- a/packages/vite-plugin-svelte/src/plugins/compile.js
+++ b/packages/vite-plugin-svelte/src/plugins/compile.js
@@ -1,21 +1,26 @@
+/** @import { CompileSvelte } from '../types/compile.js' */
+/** @import { ResolvedOptions } from '../types/options.js' */
+/** @import { PluginAPI } from '../types/plugin-api.js' */
+/** @import { Plugin } from 'vite' */
+
 import { toRollupError } from '../utils/error.js';
 import { logCompilerWarnings } from '../utils/log.js';
 
 /**
- * @param {import('../types/plugin-api.d.ts').PluginAPI} api
- * @returns {import('vite').Plugin}
+ * @param {PluginAPI} api
+ * @returns {Plugin}
  */
 export function compile(api) {
 	/**
-	 * @type {import("../types/options.js").ResolvedOptions}
+	 * @type {ResolvedOptions}
 	 */
 	let options;
 
 	/**
-	 * @type {import("../types/compile.d.ts").CompileSvelte}
+	 * @type {CompileSvelte}
 	 */
 	let compileSvelte;
-	/** @type {import('vite').Plugin} */
+	/** @type {Plugin} */
 	const plugin = {
 		name: 'vite-plugin-svelte:compile',
 		configResolved() {

--- a/packages/vite-plugin-svelte/src/plugins/configure.js
+++ b/packages/vite-plugin-svelte/src/plugins/configure.js
@@ -1,3 +1,8 @@
+/** @import { Options } from '../public.js' */
+/** @import { PreResolvedOptions } from '../types/options.js' */
+/** @import { PluginAPI } from '../types/plugin-api.js' */
+/** @import { Plugin } from 'vite' */
+
 import process from 'node:process';
 import { isDebugNamespaceEnabled, log } from '../utils/log.js';
 import { VitePluginSvelteStats } from '../utils/vite-plugin-svelte-stats.js';
@@ -13,19 +18,19 @@ import { buildIdFilter, buildIdParser } from '../utils/id.js';
 import { createCompileSvelte } from '../utils/compile.js';
 
 /**
- * @param {Partial<import('../public.d.ts').Options>} [inlineOptions]
- * @param {import('../types/plugin-api.d.ts').PluginAPI} api
- * @returns {import('vite').Plugin}
+ * @param {Partial<Options>} [inlineOptions]
+ * @param {PluginAPI} api
+ * @returns {Plugin}
  */
 export function configure(api, inlineOptions) {
 	validateInlineOptions(inlineOptions);
 
 	/**
-	 * @type {import("../types/options.d.ts").PreResolvedOptions}
+	 * @type {PreResolvedOptions}
 	 */
 	let preOptions;
 
-	/** @type {import('vite').Plugin} */
+	/** @type {Plugin} */
 	return {
 		name: 'vite-plugin-svelte:config',
 		api,

--- a/packages/vite-plugin-svelte/src/plugins/hot-update.js
+++ b/packages/vite-plugin-svelte/src/plugins/hot-update.js
@@ -1,18 +1,23 @@
+/** @import { IdParser } from '../types/id.js' */
+/** @import { ResolvedOptions } from '../types/options.js' */
+/** @import { PluginAPI } from '../types/plugin-api.js' */
+/** @import { Plugin } from 'vite' */
+
 import { log } from '../utils/log.js';
 import { setupWatchers } from '../utils/watch.js';
 import { SVELTE_VIRTUAL_STYLE_ID_REGEX } from '../utils/constants.js';
 
 /**
- * @param {import('../types/plugin-api.d.ts').PluginAPI} api
- * @returns {import('vite').Plugin}
+ * @param {PluginAPI} api
+ * @returns {Plugin}
  */
 export function hotUpdate(api) {
 	/**
-	 * @type {import("../types/options.js").ResolvedOptions}
+	 * @type {ResolvedOptions}
 	 */
 	let options;
 	/**
-	 * @type {import('../types/id.d.ts').IdParser}
+	 * @type {IdParser}
 	 */
 	let idParser;
 
@@ -22,7 +27,7 @@ export function hotUpdate(api) {
 	 */
 	const transformResultCache = new Map();
 
-	/** @type {import('vite').Plugin} */
+	/** @type {Plugin} */
 	const plugin = {
 		name: 'vite-plugin-svelte:hot-update',
 		enforce: 'post',

--- a/packages/vite-plugin-svelte/src/plugins/inspector/index.js
+++ b/packages/vite-plugin-svelte/src/plugins/inspector/index.js
@@ -1,3 +1,7 @@
+/** @import { InspectorOptions } from '../../public.js' */
+/** @import { PluginAPI } from '../../types/plugin-api.js' */
+/** @import { Plugin } from 'vite' */
+
 import { normalizePath } from 'vite';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -22,14 +26,14 @@ function getInspectorPath() {
 }
 
 /**
- * @param {import('../../types/plugin-api.d.ts').PluginAPI} api
- * @returns {import('vite').Plugin}
+ * @param {PluginAPI} api
+ * @returns {Plugin}
  */
 export function svelteInspector(api) {
 	const inspectorPath = getInspectorPath();
 	log.debug(`svelte inspector path: ${inspectorPath}`, null, 'inspector');
 
-	/** @type {import('../../public.d.ts').InspectorOptions} */
+	/** @type {InspectorOptions} */
 	let inspectorOptions;
 	let disabled = false;
 

--- a/packages/vite-plugin-svelte/src/plugins/inspector/options.js
+++ b/packages/vite-plugin-svelte/src/plugins/inspector/options.js
@@ -1,8 +1,11 @@
+/** @import { InspectorOptions } from '../../public.js' */
+/** @import { ResolvedConfig } from 'vite' */
+
 import process from 'node:process';
 import { loadEnv } from 'vite';
 import { log } from '../../utils/log.js';
 
-/** @type {import('../../public.d.ts').InspectorOptions} */
+/** @type {InspectorOptions} */
 export const defaultInspectorOptions = {
 	toggleKeyCombo: 'alt-x',
 	navKeys: { parent: 'ArrowUp', child: 'ArrowDown', next: 'ArrowRight', prev: 'ArrowLeft' },
@@ -15,8 +18,8 @@ export const defaultInspectorOptions = {
 };
 
 /**
- * @param {import('vite').ResolvedConfig} config
- * @returns {Partial<import('../../public.d.ts').InspectorOptions> | boolean | void}
+ * @param {ResolvedConfig} config
+ * @returns {Partial<InspectorOptions> | boolean | void}
  */
 export function parseEnvironmentOptions(config) {
 	const env = loadEnv(config.mode, config.envDir ?? process.cwd(), 'SVELTE_INSPECTOR');

--- a/packages/vite-plugin-svelte/src/plugins/load-compiled-css.js
+++ b/packages/vite-plugin-svelte/src/plugins/load-compiled-css.js
@@ -1,11 +1,14 @@
+/** @import { PluginAPI } from '../types/plugin-api.js' */
+/** @import { Plugin } from 'vite' */
+
 import { log } from '../utils/log.js';
 import { SVELTE_VIRTUAL_STYLE_ID_REGEX } from '../utils/constants.js';
 
 const filter = { id: SVELTE_VIRTUAL_STYLE_ID_REGEX };
 
 /**
- * @param {import('../types/plugin-api.d.ts').PluginAPI} api
- * @returns {import('vite').Plugin}
+ * @param {PluginAPI} api
+ * @returns {Plugin}
  */
 export function loadCompiledCss(api) {
 	let useLocalCache = false;

--- a/packages/vite-plugin-svelte/src/plugins/load-custom.js
+++ b/packages/vite-plugin-svelte/src/plugins/load-custom.js
@@ -1,3 +1,6 @@
+/** @import { PluginAPI } from '../types/plugin-api.js' */
+/** @import { Plugin } from 'vite' */
+
 import fs from 'node:fs';
 import { log } from '../utils/log.js';
 
@@ -5,11 +8,11 @@ import { log } from '../utils/log.js';
  * if svelte config includes files that vite treats as assets (e.g. .svg)
  * we have to manually load them to avoid getting urls
  *
- * @param {import('../types/plugin-api.d.ts').PluginAPI} api
- * @returns {import('vite').Plugin}
+ * @param {PluginAPI} api
+ * @returns {Plugin}
  */
 export function loadCustom(api) {
-	/** @type {import('vite').Plugin} */
+	/** @type {Plugin} */
 	const plugin = {
 		name: 'vite-plugin-svelte:load-custom',
 		enforce: 'pre', // must come before vites own asset handling or custom extensions like .svg won't work

--- a/packages/vite-plugin-svelte/src/plugins/preprocess.js
+++ b/packages/vite-plugin-svelte/src/plugins/preprocess.js
@@ -1,3 +1,10 @@
+/** @import { PreprocessSvelte } from '../types/compile.js' */
+/** @import { SvelteRequest } from '../types/id.js' */
+/** @import { ResolvedOptions } from '../types/options.js' */
+/** @import { PluginAPI } from '../types/plugin-api.js' */
+/** @import { PreprocessorGroup } from 'svelte/compiler' */
+/** @import { Plugin, ResolvedConfig, Rollup, ViteDevServer } from 'vite' */
+
 import { toRollupError } from '../utils/error.js';
 import { mapToRelative } from '../utils/sourcemaps.js';
 import * as svelte from 'svelte/compiler';
@@ -7,12 +14,12 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 /**
- * @param {import('../types/plugin-api.d.ts').PluginAPI} api
- * @returns {import('vite').Plugin}
+ * @param {PluginAPI} api
+ * @returns {Plugin}
  */
 export function preprocess(api) {
 	/**
-	 * @type {import("../types/options.js").ResolvedOptions}
+	 * @type {ResolvedOptions}
 	 */
 	let options;
 
@@ -22,11 +29,11 @@ export function preprocess(api) {
 	let dependenciesCache;
 
 	/**
-	 * @type {import("../types/compile.d.ts").PreprocessSvelte}
+	 * @type {PreprocessSvelte}
 	 */
 	let preprocessSvelte;
 
-	/** @type {import('vite').Plugin} */
+	/** @type {Plugin} */
 	const plugin = {
 		name: 'vite-plugin-svelte:preprocess',
 		enforce: 'pre',
@@ -73,7 +80,7 @@ export function preprocess(api) {
 						}
 					}
 
-					/** @type {import('vite').Rollup.SourceDescription}*/
+					/** @type {Rollup.SourceDescription}*/
 					const result = { code: preprocessed.code };
 					if (preprocessed.map) {
 						// @ts-expect-error type differs but should work
@@ -89,12 +96,12 @@ export function preprocess(api) {
 	return plugin;
 }
 /**
- * @param {import("../types/options.js").ResolvedOptions} options
- * @param {import("vite").ResolvedConfig} resolvedConfig
- * @returns {import('../types/compile.d.ts').PreprocessSvelte}
+ * @param {ResolvedOptions} options
+ * @param {ResolvedConfig} resolvedConfig
+ * @returns {PreprocessSvelte}
  */
 function createPreprocessSvelte(options, resolvedConfig) {
-	/** @type {Array<import('svelte/compiler').PreprocessorGroup>} */
+	/** @type {Array<PreprocessorGroup>} */
 	const preprocessors = arraify(options.preprocess);
 
 	for (const preprocessor of preprocessors) {
@@ -103,7 +110,7 @@ function createPreprocessSvelte(options, resolvedConfig) {
 		}
 	}
 
-	/** @type {import('../types/compile.d.ts').PreprocessSvelte} */
+	/** @type {PreprocessSvelte} */
 	return async function preprocessSvelte(svelteRequest, code) {
 		const { filename } = svelteRequest;
 		let preprocessed;
@@ -133,11 +140,11 @@ class DependenciesCache {
 	/** @type {Map<string, Set<string>>} */
 	#dependants = new Map();
 
-	/** @type {import('vite').ViteDevServer} */
+	/** @type {ViteDevServer} */
 	#server;
 	/**
 	 *
-	 * @param {import('vite').ViteDevServer} server
+	 * @param {ViteDevServer} server
 	 */
 	constructor(server) {
 		this.#server = server;
@@ -184,7 +191,7 @@ class DependenciesCache {
 
 	/**
 	 *
-	 * @param {import('../types/id.d.ts').SvelteRequest} svelteRequest
+	 * @param {SvelteRequest} svelteRequest
 	 * @param {string[]} dependencies
 	 */
 	update(svelteRequest, dependencies) {

--- a/packages/vite-plugin-svelte/src/plugins/setup-optimizer.js
+++ b/packages/vite-plugin-svelte/src/plugins/setup-optimizer.js
@@ -1,3 +1,10 @@
+/** @import { Code } from '../types/compile.js' */
+/** @import { ResolvedOptions } from '../types/options.js' */
+/** @import { PluginAPI } from '../types/plugin-api.js' */
+/** @import { StatCollection } from '../types/vite-plugin-svelte-stats.js' */
+/** @import { CompileOptions } from 'svelte/compiler' */
+/** @import { Plugin, ResolvedConfig, Rollup, UserConfig } from 'vite' */
+
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import * as svelte from 'svelte/compiler';
@@ -5,25 +12,25 @@ import { log } from '../utils/log.js';
 import { toRollupError } from '../utils/error.js';
 
 /**
- * @typedef {NonNullable<import('vite').Rollup.Plugin>} RollupPlugin
+ * @typedef {NonNullable<Rollup.Plugin>} RollupPlugin
  */
 
 const optimizeSveltePluginName = 'vite-plugin-svelte:optimize';
 const optimizeSvelteModulePluginName = 'vite-plugin-svelte:optimize-module';
 
 /**
- * @param {import('../types/plugin-api.d.ts').PluginAPI} api
- * @returns {import('vite').Plugin}
+ * @param {PluginAPI} api
+ * @returns {Plugin}
  */
 export function setupOptimizer(api) {
-	/** @type {import('vite').ResolvedConfig} */
+	/** @type {ResolvedConfig} */
 	let viteConfig;
 
 	return {
 		name: 'vite-plugin-svelte:setup-optimizer',
 		apply: 'serve',
 		config() {
-			/** @type {import('vite').UserConfig['optimizeDeps']} */
+			/** @type {UserConfig['optimizeDeps']} */
 			const optimizeDeps = {
 				// Experimental Vite API to allow these extensions to be scanned and prebundled
 				extensions: ['.svelte']
@@ -67,14 +74,14 @@ export function setupOptimizer(api) {
 
 /**
  * @param {RollupPlugin} plugin
- * @param {import('../types/options.d.ts').ResolvedOptions} options
+ * @param {ResolvedOptions} options
  */
 function patchRolldownOptimizerPlugin(plugin, options) {
 	const components = plugin.name === optimizeSveltePluginName;
 	const compileFn = components ? compileSvelte : compileSvelteModule;
 	const statsName = components ? 'prebundle library components' : 'prebundle library modules';
 	const includeRe = components ? /^[^?#]+\.svelte(?:[?#]|$)/ : /^[^?#]+\.svelte\.[jt]s(?:[?#]|$)/;
-	/** @type {import('../types/vite-plugin-svelte-stats.d.ts').StatCollection | undefined} */
+	/** @type {StatCollection | undefined} */
 	let statsCollection;
 
 	plugin.options = (opts) => {
@@ -114,10 +121,10 @@ function patchRolldownOptimizerPlugin(plugin, options) {
 }
 
 /**
- * @param {import('../types/options.d.ts').ResolvedOptions} options
+ * @param {ResolvedOptions} options
  * @param {{ filename: string, code: string }} input
- * @param {import('../types/vite-plugin-svelte-stats.d.ts').StatCollection} [statsCollection]
- * @returns {Promise<import('../types/compile.d.ts').Code>}
+ * @param {StatCollection} [statsCollection]
+ * @returns {Promise<Code>}
  */
 async function compileSvelte(options, { filename, code }, statsCollection) {
 	let css = options.compilerOptions.css;
@@ -125,7 +132,7 @@ async function compileSvelte(options, { filename, code }, statsCollection) {
 		// TODO ideally we'd be able to externalize prebundled styles too, but for now always put them in the js
 		css = 'injected';
 	}
-	/** @type {import('svelte/compiler').CompileOptions} */
+	/** @type {CompileOptions} */
 	const compileOptions = {
 		dev: true, // default to dev: true because prebundling is only used in dev
 		...options.compilerOptions,
@@ -180,10 +187,10 @@ async function compileSvelte(options, { filename, code }, statsCollection) {
 }
 
 /**
- * @param {import('../types/options.d.ts').ResolvedOptions} options
+ * @param {ResolvedOptions} options
  * @param {{ filename: string; code: string }} input
- * @param {import('../types/vite-plugin-svelte-stats.d.ts').StatCollection} [statsCollection]
- * @returns {Promise<import('../types/compile.d.ts').Code>}
+ * @param {StatCollection} [statsCollection]
+ * @returns {Promise<Code>}
  */
 async function compileSvelteModule(options, { filename, code }, statsCollection) {
 	const endStat = statsCollection?.start(filename);
@@ -202,7 +209,7 @@ async function compileSvelteModule(options, { filename, code }, statsCollection)
 }
 
 // List of options that changes the prebundling result
-/** @type {(keyof import('../types/options.d.ts').ResolvedOptions)[]} */
+/** @type {(keyof ResolvedOptions)[]} */
 const PREBUNDLE_SENSITIVE_OPTIONS = [
 	'compilerOptions',
 	'configFile',
@@ -215,7 +222,7 @@ const PREBUNDLE_SENSITIVE_OPTIONS = [
  * stores svelte metadata in cache dir and compares if it has changed
  *
  * @param {string} cacheDir
- * @param {import('../types/options.d.ts').ResolvedOptions} options
+ * @param {ResolvedOptions} options
  * @returns {Promise<boolean>} Whether the Svelte metadata has changed
  */
 async function svelteMetadataChanged(cacheDir, options) {
@@ -243,7 +250,7 @@ async function svelteMetadataChanged(cacheDir, options) {
 /**
  *
  * @param {string} name
- * @returns {import('vite').Rollup.Plugin}
+ * @returns {Rollup.Plugin}
  */
 function placeholderRolldownOptimizerPlugin(name) {
 	return {
@@ -256,8 +263,8 @@ function placeholderRolldownOptimizerPlugin(name) {
 }
 
 /**
- * @param {import('../types/options.d.ts').ResolvedOptions} options
- * @returns {Partial<import('../types/options.d.ts').ResolvedOptions>}
+ * @param {ResolvedOptions} options
+ * @returns {Partial<ResolvedOptions>}
  */
 function generateSvelteMetadata(options) {
 	/** @type {Record<string, any>} */

--- a/packages/vite-plugin-svelte/src/preprocess.js
+++ b/packages/vite-plugin-svelte/src/preprocess.js
@@ -1,3 +1,7 @@
+/** @import { VitePreprocessOptions } from './public.js' */
+/** @import { Preprocessor as SveltePreprocessor, PreprocessorGroup } from 'svelte/compiler' */
+/** @import { InlineConfig, ResolvedConfig } from 'vite' */
+
 import process from 'node:process';
 import * as vite from 'vite';
 import { mapToRelative, removeLangSuffix } from './utils/sourcemaps.js';
@@ -17,11 +21,11 @@ const supportedScriptLangs = ['ts'];
 export const lang_sep = '.vite-preprocess';
 
 /**
- * @param {import('./public.d.ts').VitePreprocessOptions} [opts]
- * @returns {import('svelte/compiler').PreprocessorGroup}
+ * @param {VitePreprocessOptions} [opts]
+ * @returns {PreprocessorGroup}
  */
 export function vitePreprocess(opts) {
-	/** @type {import('svelte/compiler').PreprocessorGroup} */
+	/** @type {PreprocessorGroup} */
 	const preprocessor = { name: 'vite-preprocess' };
 	if (opts?.script === true) {
 		preprocessor.script = viteScript().script;
@@ -34,7 +38,7 @@ export function vitePreprocess(opts) {
 }
 
 /**
- * @returns {{ script: import('svelte/compiler').Preprocessor }}
+ * @returns {{ script: SveltePreprocessor }}
  */
 function viteScript() {
 	return {
@@ -67,44 +71,45 @@ function viteScript() {
 }
 
 /**
- * @param {import('vite').ResolvedConfig | import('vite').InlineConfig} config
- * @returns {{ style: import('svelte/compiler').Preprocessor }}
+ * @param {ResolvedConfig | InlineConfig} config
+ * @returns {{ style: SveltePreprocessor }}
  */
 function viteStyle(config = {}) {
 	/** @type {Promise<CssTransform> | CssTransform} */
 	let cssTransform;
-	/** @type {import('svelte/compiler').Preprocessor} */
-	const style = async ({ attributes, content, filename = '' }) => {
-		const ext = attributes.lang ? `.${attributes.lang}` : '.css';
-		if (attributes.lang && !isCSSRequest(ext)) return;
-		if (!cssTransform) {
-			cssTransform = createCssTransform(style, config).then((t) => (cssTransform = t));
+	const style = /** @type {SveltePreprocessor} */ (
+		async ({ attributes, content, filename = '' }) => {
+			const ext = attributes.lang ? `.${attributes.lang}` : '.css';
+			if (attributes.lang && !isCSSRequest(ext)) return;
+			if (!cssTransform) {
+				cssTransform = createCssTransform(style, config).then((t) => (cssTransform = t));
+			}
+			const transform = await cssTransform;
+			const suffix = `${lang_sep}${ext}`;
+			const moduleId = `${filename}${suffix}`;
+			const { code, map, deps } = await transform(content, moduleId);
+			removeLangSuffix(map, suffix);
+			mapToRelative(map, filename);
+			const dependencies = deps ? Array.from(deps).filter((d) => !d.endsWith(suffix)) : undefined;
+			return {
+				code,
+				map: map ?? undefined,
+				dependencies
+			};
 		}
-		const transform = await cssTransform;
-		const suffix = `${lang_sep}${ext}`;
-		const moduleId = `${filename}${suffix}`;
-		const { code, map, deps } = await transform(content, moduleId);
-		removeLangSuffix(map, suffix);
-		mapToRelative(map, filename);
-		const dependencies = deps ? Array.from(deps).filter((d) => !d.endsWith(suffix)) : undefined;
-		return {
-			code,
-			map: map ?? undefined,
-			dependencies
-		};
-	};
+	);
 	// @ts-expect-error tag so can be found by v-p-s
 	style.__resolvedConfig = null;
 	return { style };
 }
 
 /**
- * @param {import('svelte/compiler').Preprocessor} style
- * @param {import('vite').ResolvedConfig | import('vite').InlineConfig} config
+ * @param {SveltePreprocessor} style
+ * @param {ResolvedConfig | InlineConfig} config
  * @returns {Promise<CssTransform>}
  */
 async function createCssTransform(style, config) {
-	/** @type {import('vite').ResolvedConfig} */
+	/** @type {ResolvedConfig} */
 	let resolvedConfig;
 	// @ts-expect-error special prop added if running in v-p-s
 	if (style.__resolvedConfig) {
@@ -126,7 +131,7 @@ async function createCssTransform(style, config) {
 
 /**
  * @param {any} config
- * @returns {config is import('vite').ResolvedConfig}
+ * @returns {config is ResolvedConfig}
  */
 function isResolvedConfig(config) {
 	return !!config.inlineConfig;

--- a/packages/vite-plugin-svelte/src/utils/compile.js
+++ b/packages/vite-plugin-svelte/src/utils/compile.js
@@ -1,3 +1,7 @@
+/** @import { CompileSvelte } from '../types/compile.js' */
+/** @import { StatCollection } from '../types/vite-plugin-svelte-stats.js' */
+/** @import { CompileOptions, CompileResult, Warning } from 'svelte/compiler' */
+
 import * as svelte from 'svelte/compiler';
 import { log } from './log.js';
 
@@ -11,16 +15,16 @@ const scriptLangRE =
 	/<!--[^]*?-->|<script\s+(?:[^>]*|(?:[^=>'"/]+=(?:"[^"]*"|'[^']*'|[^>\s]+)\s+)*)lang=(["'])?([^"' >]+)\1[^>]*>/g;
 
 /**
- * @returns {import('../types/compile.d.ts').CompileSvelte}
+ * @returns {CompileSvelte}
  */
 export function createCompileSvelte() {
-	/** @type {import('../types/vite-plugin-svelte-stats.d.ts').StatCollection | undefined} */
+	/** @type {StatCollection | undefined} */
 	let stats;
-	/** @type {import('../types/compile.d.ts').CompileSvelte} */
+	/** @type {CompileSvelte} */
 	return async function compileSvelte(svelteRequest, code, options, sourcemap) {
 		const { filename, normalizedFilename, cssId, ssr, raw } = svelteRequest;
 		const { emitCss = true } = options;
-		/** @type {import('svelte/compiler').Warning[]} */
+		/** @type {Warning[]} */
 		const warnings = [];
 
 		if (options.stats) {
@@ -48,7 +52,7 @@ export function createCompileSvelte() {
 			}
 		}
 
-		/** @type {import('svelte/compiler').CompileOptions} */
+		/** @type {CompileOptions} */
 		const compileOptions = {
 			...options.compilerOptions,
 			filename,
@@ -87,7 +91,7 @@ export function createCompileSvelte() {
 			finalCompileOptions.sourcemap = sourcemap;
 		}
 		const endStat = stats?.start(filename);
-		/** @type {import('svelte/compiler').CompileResult} */
+		/** @type {CompileResult} */
 		let compiled;
 		try {
 			compiled = svelte.compile(finalCode, { ...finalCompileOptions, filename });

--- a/packages/vite-plugin-svelte/src/utils/error.js
+++ b/packages/vite-plugin-svelte/src/utils/error.js
@@ -1,14 +1,19 @@
+/** @import { Options } from '../public.js' */
+/** @import { ResolvedOptions } from '../types/options.js' */
+/** @import { Warning } from 'svelte/compiler' */
+/** @import { Rollup } from 'vite' */
+
 import { buildExtendedLogMessage } from './log.js';
 
 /**
  * convert an error thrown by svelte.compile to a RollupError so that vite displays it in a user friendly way
- * @param {import('svelte/compiler').Warning & Error & {frame?: string}} error a svelte compiler error, which is a mix of Warning and an error
- * @param {import('../types/options.d.ts').ResolvedOptions} options
- * @returns {import('vite').Rollup.RollupError} the converted error
+ * @param {Warning & Error & {frame?: string}} error a svelte compiler error, which is a mix of Warning and an error
+ * @param {ResolvedOptions} options
+ * @returns {Rollup.RollupError} the converted error
  */
 export function toRollupError(error, options) {
 	const { filename, frame, start, code, name, stack } = error;
-	/** @type {import('vite').Rollup.RollupError} */
+	/** @type {Rollup.RollupError} */
 	const rollupError = {
 		name, // needed otherwise sveltekit coalesce_to_error turns it into a string
 		id: filename,
@@ -29,8 +34,8 @@ export function toRollupError(error, options) {
 
 /**
  * convert an error thrown by svelte.compile to an esbuild PartialMessage
- * @param {import('svelte/compiler').Warning & Error  & {frame?: string}} error a svelte compiler error, which is a mix of Warning and an error
- * @param {import('../types/options.d.ts').ResolvedOptions} options
+ * @param {Warning & Error  & {frame?: string}} error a svelte compiler error, which is a mix of Warning and an error
+ * @param {ResolvedOptions} options
  * @returns {any} the converted error as esbuild PartialMessage
  *
  * note: typed any to avoid esbuild devDependency for a single internal type import
@@ -114,9 +119,9 @@ function couldBeFixedByCssPreprocessor(code) {
 }
 
 /**
- * @param {import('svelte/compiler').Warning & Error} err a svelte compiler error, which is a mix of Warning and an error
+ * @param {Warning & Error} err a svelte compiler error, which is a mix of Warning and an error
  * @param {string} originalCode
- * @param {import('../public.d.ts').Options['preprocess']} [preprocessors]
+ * @param {Options['preprocess']} [preprocessors]
  */
 export function enhanceCompileError(err, originalCode, preprocessors) {
 	preprocessors = arraify(preprocessors ?? []);

--- a/packages/vite-plugin-svelte/src/utils/id.js
+++ b/packages/vite-plugin-svelte/src/utils/id.js
@@ -1,3 +1,6 @@
+/** @import { IdFilter, IdParser, ModuleIdParser, RequestQuery, SvelteModuleRequest, SvelteQueryTypes, SvelteRequest } from '../types/id.js' */
+/** @import { ResolvedOptions } from '../types/options.js' */
+
 import { normalizePath } from 'vite';
 import fs from 'node:fs';
 import process from 'node:process';
@@ -34,7 +37,7 @@ function splitId(id) {
  * @param {string} root
  * @param {number} timestamp
  * @param {boolean} ssr
- * @returns {import('../types/id.d.ts').SvelteRequest | undefined}
+ * @returns {SvelteRequest | undefined}
  */
 function parseToSvelteRequest(id, filename, rawQuery, root, timestamp, ssr) {
 	const query = parseRequestQuery(rawQuery);
@@ -62,7 +65,7 @@ function parseToSvelteRequest(id, filename, rawQuery, root, timestamp, ssr) {
 /**
  * @param {string} filename
  * @param {string} root
- * @param {import('../types/id.d.ts').SvelteQueryTypes} type
+ * @param {SvelteQueryTypes} type
  * @returns {string}
  */
 function createVirtualImportId(filename, root, type) {
@@ -83,7 +86,7 @@ function createVirtualImportId(filename, root, type) {
 
 /**
  * @param {string} rawQuery
- * @returns {import('../types/id.d.ts').RequestQuery}
+ * @returns {RequestQuery}
  */
 function parseRequestQuery(rawQuery) {
 	const query = Object.fromEntries(new URLSearchParams(rawQuery));
@@ -121,7 +124,7 @@ function parseRequestQuery(rawQuery) {
 		}
 	}
 
-	return /** @type {import('../types/id.d.ts').RequestQuery}*/ query;
+	return /** @type {RequestQuery}*/ query;
 }
 
 /**
@@ -168,8 +171,8 @@ function escapeRE(s) {
 }
 
 /**
- * @param {import('../types/options.d.ts').ResolvedOptions} options
- * @returns {import('../types/id.d.ts').IdFilter}
+ * @param {ResolvedOptions} options
+ * @returns {IdFilter}
  */
 export function buildIdFilter(options) {
 	const { include = [], exclude = [], extensions = DEFAULT_SVELTE_EXT } = options;
@@ -193,8 +196,8 @@ export function buildIdFilter(options) {
 }
 
 /**
- * @param {import('../types/options.d.ts').ResolvedOptions} options
- * @returns {import('../types/id.d.ts').IdParser}
+ * @param {ResolvedOptions} options
+ * @returns {IdParser}
  */
 export function buildIdParser(options) {
 	const normalizedRoot = normalizePath(options.root);
@@ -205,8 +208,8 @@ export function buildIdParser(options) {
 }
 
 /**
- * @param {import('../types/options.d.ts').ResolvedOptions} options
- * @returns {import('../types/id.d.ts').IdFilter}
+ * @param {ResolvedOptions} options
+ * @returns {IdFilter}
  */
 export function buildModuleIdFilter(options) {
 	const {
@@ -232,8 +235,8 @@ export function buildModuleIdFilter(options) {
 }
 
 /**
- * @param {import('../types/options.d.ts').ResolvedOptions} options
- * @returns {import('../types/id.d.ts').ModuleIdParser}
+ * @param {ResolvedOptions} options
+ * @returns {ModuleIdParser}
  */
 export function buildModuleIdParser(options) {
 	const root = options.root;
@@ -251,7 +254,7 @@ export function buildModuleIdParser(options) {
  * @param {string} root
  * @param {number} timestamp
  * @param {boolean} ssr
- * @returns {import('../types/id.d.ts').SvelteModuleRequest | undefined}
+ * @returns {SvelteModuleRequest | undefined}
  */
 function parseToSvelteModuleRequest(id, filename, rawQuery, root, timestamp, ssr) {
 	const query = parseRequestQuery(rawQuery);

--- a/packages/vite-plugin-svelte/src/utils/load-svelte-config.js
+++ b/packages/vite-plugin-svelte/src/utils/load-svelte-config.js
@@ -1,3 +1,6 @@
+/** @import { Options, SvelteConfig } from '../public.js' */
+/** @import { UserConfig } from 'vite' */
+
 import path from 'node:path';
 import process from 'node:process';
 import fs from 'node:fs';
@@ -17,9 +20,9 @@ async function dynamicImportDefault(filePath, timestamp) {
 }
 
 /**
- * @param {import('vite').UserConfig} [viteConfig]
- * @param {Partial<import('../public.d.ts').Options>} [inlineOptions]
- * @returns {Promise<Partial<import('../public.d.ts').SvelteConfig> | undefined>}
+ * @param {UserConfig} [viteConfig]
+ * @param {Partial<Options>} [inlineOptions]
+ * @returns {Promise<Partial<SvelteConfig> | undefined>}
  */
 export async function loadSvelteConfig(viteConfig, inlineOptions) {
 	if (inlineOptions?.configFile === false) {
@@ -48,8 +51,8 @@ export async function loadSvelteConfig(viteConfig, inlineOptions) {
 }
 
 /**
- * @param {import('vite').UserConfig | undefined} viteConfig
- * @param {Partial<import('../public.d.ts').Options> | undefined} inlineOptions
+ * @param {UserConfig | undefined} viteConfig
+ * @param {Partial<Options> | undefined} inlineOptions
  * @returns {string | undefined}
  */
 function findConfigToLoad(viteConfig, inlineOptions) {

--- a/packages/vite-plugin-svelte/src/utils/log.js
+++ b/packages/vite-plugin-svelte/src/utils/log.js
@@ -1,3 +1,8 @@
+/** @import { SvelteModuleRequest, SvelteRequest } from '../types/id.js' */
+/** @import { LogFn, LogLevel, SimpleLogFn, SvelteWarningsMessage } from '../types/log.js' */
+/** @import { ResolvedOptions } from '../types/options.js' */
+/** @import { Warning } from 'svelte/compiler' */
+
 /* eslint-disable no-console */
 
 // eslint-disable-next-line n/no-unsupported-features/node-builtins
@@ -8,10 +13,10 @@ const red = (/** @type {string} */ txt) => styleText('red', txt);
 
 import { createDebug, enabled } from 'obug';
 
-/** @type {import('../types/log.d.ts').LogLevel[]} */
+/** @type {LogLevel[]} */
 const levels = ['debug', 'info', 'warn', 'error', 'silent'];
 const prefix = 'vite-plugin-svelte';
-/** @type {Record<import('../types/log.d.ts').LogLevel, any>} */
+/** @type {Record<LogLevel, any>} */
 const loggers = {
 	debug: {
 		log: createDebug(`${prefix}`),
@@ -38,10 +43,10 @@ const loggers = {
 	}
 };
 
-/** @type {import('../types/log.d.ts').LogLevel} */
+/** @type {LogLevel} */
 let _level = 'info';
 /**
- * @param {import('../types/log.d.ts').LogLevel} level
+ * @param {LogLevel} level
  * @returns {void}
  */
 function setLevel(level) {
@@ -98,15 +103,15 @@ function _log(logger, message, payload, namespace) {
 }
 
 /**
- * @param {import('../types/log.d.ts').LogLevel} level
- * @returns {import('../types/log.d.ts').LogFn}
+ * @param {LogLevel} level
+ * @returns {LogFn}
  */
 function createLogger(level) {
 	const logger = loggers[level];
-	const logFn = /** @type {import('../types/log.d.ts').LogFn} */ (_log.bind(null, logger));
+	const logFn = /** @type {LogFn} */ (_log.bind(null, logger));
 	/** @type {Set<string>} */
 	const logged = new Set();
-	/** @type {import('../types/log.d.ts').SimpleLogFn} */
+	/** @type {SimpleLogFn} */
 	const once = function (message, payload, namespace) {
 		if (!logger.enabled || logged.has(message)) {
 			return;
@@ -136,20 +141,20 @@ export const log = {
 };
 
 /**
- * @param {import('../types/id.d.ts').SvelteRequest | import('../types/id.d.ts').SvelteModuleRequest} svelteRequest
- * @param {import('svelte/compiler').Warning[]} warnings
- * @param {import('../types/options.d.ts').ResolvedOptions} options
+ * @param {SvelteRequest | SvelteModuleRequest} svelteRequest
+ * @param {Warning[]} warnings
+ * @param {ResolvedOptions} options
  */
 export function logCompilerWarnings(svelteRequest, warnings, options) {
 	const { emitCss, onwarn, isBuild } = options;
 	const sendViaWS = !isBuild && options.experimental?.sendWarningsToBrowser;
 	let warn = isBuild ? warnBuild : warnDev;
-	/** @type {import('svelte/compiler').Warning[]} */
+	/** @type {Warning[]} */
 	const handledByDefaultWarn = [];
 	const allWarnings = warnings?.filter((w) => !ignoreCompilerWarning(w, isBuild, emitCss));
 	if (sendViaWS) {
 		const _warn = warn;
-		/** @type {(w: import('svelte/compiler').Warning) => void} */
+		/** @type {(w: Warning) => void} */
 		warn = (w) => {
 			handledByDefaultWarn.push(w);
 			_warn(w);
@@ -163,7 +168,7 @@ export function logCompilerWarnings(svelteRequest, warnings, options) {
 		}
 	});
 	if (sendViaWS) {
-		/** @type {import('../types/log.d.ts').SvelteWarningsMessage} */
+		/** @type {SvelteWarningsMessage} */
 		const message = {
 			id: svelteRequest.id,
 			filename: svelteRequest.filename,
@@ -179,7 +184,7 @@ export function logCompilerWarnings(svelteRequest, warnings, options) {
 }
 
 /**
- * @param {import('svelte/compiler').Warning} warning
+ * @param {Warning} warning
  * @param {boolean} isBuild
  * @param {boolean} [emitCss]
  * @returns {boolean}
@@ -193,7 +198,7 @@ function ignoreCompilerWarning(warning, isBuild, emitCss) {
 
 /**
  *
- * @param {import('svelte/compiler').Warning} warning
+ * @param {Warning} warning
  * @returns {boolean}
  */
 function isNoScopableElementWarning(warning) {
@@ -202,7 +207,7 @@ function isNoScopableElementWarning(warning) {
 }
 
 /**
- * @param {import('svelte/compiler').Warning} w
+ * @param {Warning} w
  */
 function warnDev(w) {
 	if (w.filename?.includes('node_modules')) {
@@ -215,7 +220,7 @@ function warnDev(w) {
 }
 
 /**
- * @param {import('svelte/compiler').Warning & {frame?: string}} w
+ * @param {Warning & {frame?: string}} w
  */
 function warnBuild(w) {
 	if (w.filename?.includes('node_modules')) {
@@ -228,7 +233,7 @@ function warnBuild(w) {
 }
 
 /**
- * @param {import('svelte/compiler').Warning} w
+ * @param {Warning} w
  */
 export function buildExtendedLogMessage(w) {
 	const parts = [];

--- a/packages/vite-plugin-svelte/src/utils/options.js
+++ b/packages/vite-plugin-svelte/src/utils/options.js
@@ -1,3 +1,8 @@
+/** @import { Options, SvelteConfig } from '../public.js' */
+/** @import { PreResolvedOptions, ResolvedOptions } from '../types/options.js' */
+/** @import { ConfigEnv, EnvironmentOptions, Plugin, ResolvedConfig, UserConfig } from 'vite' */
+/** @import { CrawlFrameworkPkgsResult } from 'vitefu' */
+
 import process from 'node:process';
 import * as vite from 'vite';
 const {
@@ -48,7 +53,7 @@ const knownRootOptions = new Set(['extensions', 'compilerOptions', 'preprocess',
 const allowedInlineOptions = new Set(['configFile', ...allowedPluginOptions, ...knownRootOptions]);
 
 /**
- * @param {Partial<import('../public.d.ts').Options>} [inlineOptions]
+ * @param {Partial<Options>} [inlineOptions]
  */
 export function validateInlineOptions(inlineOptions) {
 	const invalidKeys = Object.keys(inlineOptions || {}).filter(
@@ -60,8 +65,8 @@ export function validateInlineOptions(inlineOptions) {
 }
 
 /**
- * @param {Partial<import('../public.d.ts').SvelteConfig>} [config]
- * @returns {Partial<import('../public.d.ts').Options> | undefined}
+ * @param {Partial<SvelteConfig>} [config]
+ * @returns {Partial<Options> | undefined}
  */
 function convertPluginOptions(config) {
 	if (!config) {
@@ -111,7 +116,7 @@ function convertPluginOptions(config) {
 			delete pluginOptions[unkownOption];
 		});
 	}
-	/** @type {import('../public.d.ts').Options} */
+	/** @type {Options} */
 	const result = {
 		...config,
 		...pluginOptions
@@ -124,22 +129,22 @@ function convertPluginOptions(config) {
 
 /**
  * used in config phase, merges the default options, svelte config, and inline options
- * @param {Partial<import('../public.d.ts').Options> | undefined} inlineOptions
- * @param {import('vite').UserConfig} viteUserConfig
- * @param {import('vite').ConfigEnv} viteEnv
- * @returns {Promise<import('../types/options.d.ts').PreResolvedOptions>}
+ * @param {Partial<Options> | undefined} inlineOptions
+ * @param {UserConfig} viteUserConfig
+ * @param {ConfigEnv} viteEnv
+ * @returns {Promise<PreResolvedOptions>}
  */
 export async function preResolveOptions(inlineOptions, viteUserConfig, viteEnv) {
 	if (!inlineOptions) {
 		inlineOptions = {};
 	}
-	/** @type {import('vite').UserConfig} */
+	/** @type {UserConfig} */
 	const viteConfigWithResolvedRoot = {
 		...viteUserConfig,
 		root: resolveViteRoot(viteUserConfig)
 	};
 	const isBuild = viteEnv.command === 'build';
-	/** @type {Partial<import('../types/options.d.ts').PreResolvedOptions>} */
+	/** @type {Partial<PreResolvedOptions>} */
 	const defaultOptions = {
 		extensions: DEFAULT_SVELTE_EXT,
 		emitCss: true,
@@ -148,7 +153,7 @@ export async function preResolveOptions(inlineOptions, viteUserConfig, viteEnv) 
 	const svelteConfig = convertPluginOptions(
 		await loadSvelteConfig(viteConfigWithResolvedRoot, inlineOptions)
 	);
-	/** @type {Partial<import('../types/options.d.ts').PreResolvedOptions>} */
+	/** @type {Partial<PreResolvedOptions>} */
 	const extraOptions = {
 		root: viteConfigWithResolvedRoot.root,
 		isBuild,
@@ -156,7 +161,7 @@ export async function preResolveOptions(inlineOptions, viteUserConfig, viteEnv) 
 		isDebug: process.env.DEBUG != null
 	};
 
-	const merged = /** @type {import('../types/options.d.ts').PreResolvedOptions} */ (
+	const merged = /** @type {PreResolvedOptions} */ (
 		mergeConfigs(defaultOptions, svelteConfig, inlineOptions, extraOptions)
 	);
 	// configFile of svelteConfig contains the absolute path it was loaded from,
@@ -187,13 +192,13 @@ function mergeConfigs(...configs) {
 /**
  * used in configResolved phase, merges a contextual default config, pre-resolved options, and some preprocessors. also validates the final config.
  *
- * @param {import('../types/options.d.ts').PreResolvedOptions} preResolveOptions
- * @param {import('vite').ResolvedConfig} viteConfig
- * @returns {import('../types/options.d.ts').ResolvedOptions}
+ * @param {PreResolvedOptions} preResolveOptions
+ * @param {ResolvedConfig} viteConfig
+ * @returns {ResolvedOptions}
  */
 export function resolveOptions(preResolveOptions, viteConfig) {
 	const css = preResolveOptions.emitCss ? 'external' : 'injected';
-	/** @type {Partial<import('../public.d.ts').Options>} */
+	/** @type {Partial<Options>} */
 	const defaultOptions = {
 		compilerOptions: {
 			css,
@@ -206,12 +211,12 @@ export function resolveOptions(preResolveOptions, viteConfig) {
 		}
 	};
 
-	/** @type {Partial<import('../types/options.d.ts').ResolvedOptions>} */
+	/** @type {Partial<ResolvedOptions>} */
 	const extraOptions = {
 		root: viteConfig.root,
 		isProduction: viteConfig.isProduction
 	};
-	const merged = /** @type {import('../types/options.d.ts').ResolvedOptions}*/ (
+	const merged = /** @type {ResolvedOptions}*/ (
 		mergeConfigs(defaultOptions, preResolveOptions, extraOptions)
 	);
 
@@ -225,8 +230,8 @@ export function resolveOptions(preResolveOptions, viteConfig) {
 }
 
 /**
- * @param {import('../types/options.d.ts').ResolvedOptions} options
- * @param {import('vite').ResolvedConfig} viteConfig
+ * @param {ResolvedOptions} options
+ * @param {ResolvedConfig} viteConfig
  */
 function enforceOptionsForHmr(options, viteConfig) {
 	if (options.compilerOptions.hmr && viteConfig.server?.hmr === false) {
@@ -265,7 +270,7 @@ function enforceOptionsForHmr(options, viteConfig) {
 }
 
 /**
- * @param {import('../types/options.d.ts').ResolvedOptions} options
+ * @param {ResolvedOptions} options
  */
 function enforceOptionsForProduction(options) {
 	if (options.isProduction) {
@@ -285,7 +290,7 @@ function enforceOptionsForProduction(options) {
 }
 
 /**
- * @param {import('../types/options.d.ts').ResolvedOptions} options
+ * @param {ResolvedOptions} options
  */
 function removeIgnoredOptions(options) {
 	const ignoredCompilerOptions = ['generate', 'format', 'filename'];
@@ -305,7 +310,7 @@ function removeIgnoredOptions(options) {
 }
 
 /**
- * @param {import('../types/options.d.ts').ResolvedOptions} options
+ * @param {ResolvedOptions} options
  */
 function handleDeprecatedOptions(options) {
 	const experimental = /** @type {Record<string, any>} */ (options.experimental);
@@ -324,10 +329,10 @@ function handleDeprecatedOptions(options) {
 }
 
 /**
- * @param {import('vite').ResolvedConfig} config
+ * @param {ResolvedConfig} config
  */
 function logRemovedPluginAPI(config) {
-	/** @type {import('vite').Plugin[]} */
+	/** @type {Plugin[]} */
 	const pluginsWithPreprocessors = config.plugins.filter((p) => p?.api?.sveltePreprocess);
 
 	if (pluginsWithPreprocessors.length > 0) {
@@ -348,7 +353,7 @@ function logRemovedPluginAPI(config) {
  * @see https://github.com/sveltejs/vite-plugin-svelte/issues/113
  * @see https://github.com/vitejs/vite/blob/43c957de8a99bb326afd732c962f42127b0a4d1e/packages/vite/src/node/config.ts#L293
  *
- * @param {import('vite').UserConfig} viteConfig
+ * @param {UserConfig} viteConfig
  * @returns {string | undefined}
  */
 function resolveViteRoot(viteConfig) {
@@ -356,12 +361,12 @@ function resolveViteRoot(viteConfig) {
 }
 
 /**
- * @param {import('../types/options.d.ts').PreResolvedOptions} options
- * @param {import('vite').UserConfig} config
- * @returns {Promise<Partial<import('vite').UserConfig>>}
+ * @param {PreResolvedOptions} options
+ * @param {UserConfig} config
+ * @returns {Promise<Partial<UserConfig>>}
  */
 export async function buildExtraViteConfig(options, config) {
-	/** @type {Partial<import('vite').UserConfig>} */
+	/** @type {Partial<UserConfig>} */
 	const extraViteConfig = {
 		resolve: {
 			dedupe: [...SVELTE_IMPORTS]
@@ -414,9 +419,9 @@ export async function buildExtraViteConfig(options, config) {
 }
 
 /**
- * @param {Partial<import('vite').UserConfig>} extraViteConfig
- * @param {import('vite').UserConfig} config
- * @param {import('../types/options.d.ts').PreResolvedOptions} options
+ * @param {Partial<UserConfig>} extraViteConfig
+ * @param {UserConfig} config
+ * @param {PreResolvedOptions} options
  */
 function validateViteConfig(extraViteConfig, config, options) {
 	const { prebundleSvelteLibraries, isBuild } = options;
@@ -465,9 +470,9 @@ function validateViteConfig(extraViteConfig, config, options) {
 }
 
 /**
- * @param {import('../types/options.d.ts').PreResolvedOptions} options
- * @param {import('vite').UserConfig} config
- * @returns {Promise<import('vitefu').CrawlFrameworkPkgsResult>}
+ * @param {PreResolvedOptions} options
+ * @param {UserConfig} config
+ * @returns {Promise<CrawlFrameworkPkgsResult>}
  */
 async function buildExtraConfigForDependencies(options, config) {
 	// extra handling for svelte dependencies in the project
@@ -557,8 +562,8 @@ async function buildExtraConfigForDependencies(options, config) {
 }
 
 /**
- * @param {import('vite').UserConfig} config
- * @returns {import('vite').UserConfig & { optimizeDeps: { include: string[], exclude:string[] }, ssr: { noExternal:(string|RegExp)[], external: string[] } } }
+ * @param {UserConfig} config
+ * @returns {UserConfig & { optimizeDeps: { include: string[], exclude:string[] }, ssr: { noExternal:(string|RegExp)[], external: string[] } } }
  */
 function buildExtraConfigForSvelte(config) {
 	// include svelte imports for optimization unless explicitly excluded
@@ -604,7 +609,7 @@ function buildExtraConfigForSvelte(config) {
 /**
  * Mutates `config` to ensure `resolve.mainFields` is set. If unset, it emulates Vite's default fallback.
  * @param {string} name
- * @param {import('vite').EnvironmentOptions} config
+ * @param {EnvironmentOptions} config
  * @param {{ isSsrTargetWebworker?: boolean }} opts
  */
 export function ensureConfigEnvironmentMainFields(name, config, opts) {
@@ -622,7 +627,7 @@ export function ensureConfigEnvironmentMainFields(name, config, opts) {
 /**
  * Mutates `config` to ensure `resolve.conditions` is set. If unset, it emulates Vite's default fallback.
  * @param {string} name
- * @param {import('vite').EnvironmentOptions} config
+ * @param {EnvironmentOptions} config
  * @param {{ isSsrTargetWebworker?: boolean }} opts
  */
 export function ensureConfigEnvironmentConditions(name, config, opts) {

--- a/packages/vite-plugin-svelte/src/utils/vite-plugin-svelte-stats.js
+++ b/packages/vite-plugin-svelte/src/utils/vite-plugin-svelte-stats.js
@@ -1,3 +1,5 @@
+/** @import { CollectionOptions, PackageStats, Stat, StatCollection } from '../types/vite-plugin-svelte-stats.js' */
+
 import { log } from './log.js';
 import { performance } from 'node:perf_hooks';
 import { normalizePath } from 'vite';
@@ -5,7 +7,7 @@ import { findClosestPkgJsonPath } from 'vitefu';
 import { readFileSync } from 'node:fs';
 import { dirname } from 'node:path';
 
-/** @type {import('../types/vite-plugin-svelte-stats.d.ts').CollectionOptions} */
+/** @type {CollectionOptions} */
 const defaultCollectionOptions = {
 	// log after 500ms and more than one file processed
 	logInProgress: (c, now) => now - c.collectionStart > 500 && c.stats.length > 1,
@@ -23,7 +25,7 @@ function humanDuration(n) {
 }
 
 /**
- * @param {import('../types/vite-plugin-svelte-stats.d.ts').PackageStats[]} pkgStats
+ * @param {PackageStats[]} pkgStats
  * @returns {string}
  */
 function formatPackageStats(pkgStats) {
@@ -69,26 +71,26 @@ export class VitePluginSvelteStats {
 	/** @type {PackageInfo[]} */
 	#packageInfos = [];
 
-	/** @type {import('../types/vite-plugin-svelte-stats.d.ts').StatCollection[]} */
+	/** @type {StatCollection[]} */
 	#collections = [];
 
 	/**
 	 * @param {string} name
-	 * @param {Partial<import('../types/vite-plugin-svelte-stats.d.ts').CollectionOptions>} [opts]
-	 * @returns {import('../types/vite-plugin-svelte-stats.d.ts').StatCollection}
+	 * @param {Partial<CollectionOptions>} [opts]
+	 * @returns {StatCollection}
 	 */
 	startCollection(name, opts) {
 		const options = {
 			...defaultCollectionOptions,
 			...opts
 		};
-		/** @type {import('../types/vite-plugin-svelte-stats.d.ts').Stat[]} */
+		/** @type {Stat[]} */
 		const stats = [];
 		const collectionStart = performance.now();
 
 		const _this = this;
 		let hasLoggedProgress = false;
-		/** @type {import('../types/vite-plugin-svelte-stats.d.ts').StatCollection} */
+		/** @type {StatCollection} */
 		const collection = {
 			name,
 			options,
@@ -101,7 +103,7 @@ export class VitePluginSvelteStats {
 				}
 				file = normalizePath(file);
 				const start = performance.now();
-				/** @type {import('../types/vite-plugin-svelte-stats.d.ts').Stat} */
+				/** @type {Stat} */
 				const stat = { file, start, end: start };
 				return () => {
 					const now = performance.now();
@@ -126,7 +128,7 @@ export class VitePluginSvelteStats {
 	}
 
 	/**
-	 * @param {import('../types/vite-plugin-svelte-stats.d.ts').StatCollection} collection
+	 * @param {StatCollection} collection
 	 */
 	async #finish(collection) {
 		try {
@@ -138,9 +140,7 @@ export class VitePluginSvelteStats {
 				await this.#aggregateStatsResult(collection);
 				log.debug(
 					`${collection.name} done.\n${formatPackageStats(
-						/** @type {import('../types/vite-plugin-svelte-stats.d.ts').PackageStats[]}*/ (
-							collection.packageStats
-						)
+						/** @type {PackageStats[]}*/ (collection.packageStats)
 					)}`,
 					undefined,
 					'stats'
@@ -164,7 +164,7 @@ export class VitePluginSvelteStats {
 	}
 
 	/**
-	 * @param {import('../types/vite-plugin-svelte-stats.d.ts').StatCollection} collection
+	 * @param {StatCollection} collection
 	 */
 	async #aggregateStatsResult(collection) {
 		const stats = collection.stats;
@@ -173,7 +173,7 @@ export class VitePluginSvelteStats {
 		}
 
 		// group stats
-		/** @type {Record<string, import('../types/vite-plugin-svelte-stats.d.ts').PackageStats>} */
+		/** @type {Record<string, PackageStats>} */
 		const grouped = {};
 		stats.forEach((stat) => {
 			const pkg = /** @type {string} */ (stat.pkg);

--- a/packages/vite-plugin-svelte/src/utils/watch.js
+++ b/packages/vite-plugin-svelte/src/utils/watch.js
@@ -1,10 +1,13 @@
+/** @import { ResolvedOptions } from '../types/options.js' */
+/** @import { FSWatcher } from 'vite' */
+
 import fs from 'node:fs';
 import { log } from './log.js';
 import { knownSvelteConfigNames } from './load-svelte-config.js';
 import path from 'node:path';
 
 /**
- * @param {import('../types/options.d.ts').ResolvedOptions} options
+ * @param {ResolvedOptions} options
  * @returns {void}
  */
 export function setupWatchers(options) {
@@ -75,7 +78,7 @@ export function setupWatchers(options) {
 
 /**
  * taken from vite utils
- * @param {import('vite').FSWatcher} watcher
+ * @param {FSWatcher} watcher
  * @param {string | null} file
  * @param {string} root
  * @returns {void}

--- a/packages/vite-plugin-svelte/types/index.d.ts
+++ b/packages/vite-plugin-svelte/types/index.d.ts
@@ -1,5 +1,5 @@
 declare module '@sveltejs/vite-plugin-svelte' {
-	import type { InlineConfig, ResolvedConfig } from 'vite';
+	import type { InlineConfig, ResolvedConfig, Plugin, UserConfig } from 'vite';
 	import type { CompileOptions, Warning, PreprocessorGroup } from 'svelte/compiler';
 	export type Options = Omit<SvelteConfig, 'vitePlugin'> & PluginOptionsInline;
 
@@ -270,9 +270,9 @@ declare module '@sveltejs/vite-plugin-svelte' {
 	 * plugins are named `vite-plugin-svelte:<task>`
 	 *
 	 * */
-	export function svelte(inlineOptions?: Partial<Options>): import("vite").Plugin[];
-	export function vitePreprocess(opts?: VitePreprocessOptions): import("svelte/compiler").PreprocessorGroup;
-	export function loadSvelteConfig(viteConfig?: import("vite").UserConfig, inlineOptions?: Partial<Options>): Promise<Partial<SvelteConfig> | undefined>;
+	export function svelte(inlineOptions?: Partial<Options>): Plugin[];
+	export function vitePreprocess(opts?: VitePreprocessOptions): PreprocessorGroup;
+	export function loadSvelteConfig(viteConfig?: UserConfig, inlineOptions?: Partial<Options>): Promise<Partial<SvelteConfig> | undefined>;
 
 	export {};
 }

--- a/packages/vite-plugin-svelte/types/index.d.ts.map
+++ b/packages/vite-plugin-svelte/types/index.d.ts.map
@@ -27,6 +27,6 @@
 		null,
 		null
 	],
-	"mappings": ";;;aAGYA,OAAOA;;WAETC,mBAAmBA;;;;;;;;;;;kBAWZC,aAAaA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;kBAgFbC,YAAYA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;WAiDnBC,mBAAmBA;;;;;;;;;;;;;;;;WAgBnBC,oBAAoBA;;;;;;;;;;;;;;;MAezBC,SAASA;;kBAEGC,qBAAqBA;;;;;;;;;;;;;;kBAcrBC,gBAAgBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;iBC7KjBC,MAAMA;iBCGNC,cAAcA;iBCCRC,gBAAgBA",
+	"mappings": ";;;aAGYA,OAAOA;;WAETC,mBAAmBA;;;;;;;;;;;kBAWZC,aAAaA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;kBAgFbC,YAAYA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;WAiDnBC,mBAAmBA;;;;;;;;;;;;;;;;WAgBnBC,oBAAoBA;;;;;;;;;;;;;;;MAezBC,SAASA;;kBAEGC,qBAAqBA;;;;;;;;;;;;;;kBAcrBC,gBAAgBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;iBCzKjBC,MAAMA;iBCGNC,cAAcA;iBCARC,gBAAgBA",
 	"ignoreList": []
 }


### PR DESCRIPTION
we do it this way in our other repos, for the most part. makes code a lot less messy