### PR TITLE
chore: add `description` field to `package.json`

### DIFF
--- a/packages/vite-plugin-svelte/package.json
+++ b/packages/vite-plugin-svelte/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@sveltejs/vite-plugin-svelte",
+  "description": "The official Svelte plugin for Vite.",
   "version": "7.0.0",
   "license": "MIT",
   "files": [


### PR DESCRIPTION
Proposing this addition because it's the only package from the org not providing any, and that's the only way I can display it in Svelte Changelog

npmjs.org seems to read it from the README, and npmx reads it from the registry endpoint populated by npmjs with that very README.

I _could_, in theory, add an npmjs registry parser for my site, but that's a lot of refactoring and code to maintain for only one package out of 40-ish :(