### PR TITLE
fix: inspector rtl host styles

### DIFF
--- a/.changeset/tasty-eggs-stay.md
+++ b/.changeset/tasty-eggs-stay.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+fix: enforce ltr styles for inspector

--- a/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
+++ b/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
@@ -366,6 +366,10 @@
 	:global(.svelte-inspector-active-target) {
 		outline: 2px dashed #ff3e00 !important;
 	}
+	:global(html[dir='rtl'] #svelte-inspector-host) {
+		direction: ltr;
+		font-family: system-ui;
+	}
 
 	#svelte-inspector-overlay {
 		position: fixed;

--- a/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
+++ b/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
@@ -368,7 +368,6 @@
 	}
 	:global(#svelte-inspector-host) {
 		direction: ltr;
-		font-family: system-ui;
 	}
 
 	#svelte-inspector-overlay {

--- a/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
+++ b/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
@@ -366,7 +366,7 @@
 	:global(.svelte-inspector-active-target) {
 		outline: 2px dashed #ff3e00 !important;
 	}
-	:global(html[dir='rtl'] #svelte-inspector-host) {
+	:global(#svelte-inspector-host) {
 		direction: ltr;
 		font-family: system-ui;
 	}


### PR DESCRIPTION
inspector looks bad in rtl sites:
<img width="339" height="80" alt="image" src="https://github.com/user-attachments/assets/1a42fd80-440f-4c36-8c31-4a7698d21f04" />


## Summary
- add an RTL-specific override for `#svelte-inspector-host`
- force the inspector host to stay `ltr` and use `system-ui` so the overlay UI renders correctly in RTL documents

## Why
The inspector UI should not inherit RTL directionality from the page root, otherwise its own controls and text layout can become awkward or incorrect.

## Validation
- inspected the resulting diff
- attempted local prettier/eslint checks, but the binaries are not available in this checkout (`pnpm exec prettier` / `pnpm exec eslint` failed with command not found)
