### PR TITLE
fix: restore value imports stripped by oxc in script preprocessing

### DIFF
--- a/.changeset/preprocess-oxc-imports.md
+++ b/.changeset/preprocess-oxc-imports.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+fix: pass `typescript.onlyRemoveTypeImports` to `transformWithOxc` in `vitePreprocess` so that value imports are not dropped when they are only referenced in Svelte template markup

--- a/packages/vite-plugin-svelte/__tests__/preprocess.spec.js
+++ b/packages/vite-plugin-svelte/__tests__/preprocess.spec.js
@@ -108,9 +108,9 @@ describe('vitePreprocess', () => {
 			expect(processed).toBeDefined();
 			// helper is used in script, so it should be preserved by oxc
 			expect(processed.code).toContain('helper');
-			// Component is only used in template (not in script), oxc would strip it
-			// but vitePreprocess should restore it
-			expect(processed.code).toContain("import Component from './Component.svelte'");
+			// Component is only used in template (not in script), but onlyRemoveTypeImports
+			// ensures it is preserved
+			expect(processed.code).toContain('import Component from "./Component.svelte"');
 		});
 
 		it('does not duplicate imports that oxc preserves', async () => {
@@ -125,7 +125,7 @@ describe('vitePreprocess', () => {
 			expect(matches.length).toBe(2); // one in import, one in usage
 		});
 
-		it('does not restore type-only imports', async () => {
+		it('strips type-only imports', async () => {
 			const content = `
   import type { SomeType } from './types.js';
   import Component from './Component.svelte';
@@ -135,27 +135,24 @@ describe('vitePreprocess', () => {
 			expect(processed).toBeDefined();
 			// type import should be correctly stripped
 			expect(processed.code).not.toContain('SomeType');
-			// value import should be restored
-			expect(processed.code).toContain("import Component from './Component.svelte'");
+			// value import should be preserved
+			expect(processed.code).toContain('import Component from "./Component.svelte"');
 		});
 
-		it('restores only stripped named imports when some are used in script', async () => {
+		it('preserves value specifiers and strips type specifiers from mixed imports', async () => {
 			const content = `
-  import { Foo, bar } from './components.js';
-  const x = bar();`;
+  import { Foo, type Bar } from './components.js';
+  const x = 1;`;
 
 			const processed = await script(scriptArgs(content));
 			expect(processed).toBeDefined();
-			// bar is used in script so oxc keeps it
-			expect(processed.code).toContain('bar');
-			// Foo is unused in script but may be used in template - should be restored
+			// Foo is a value import - preserved even though unused in script
 			expect(processed.code).toContain('Foo');
+			// Bar is a type specifier - should be stripped
+			expect(processed.code).not.toContain('Bar');
 		});
 
-		it('restores stripped value identifiers from multi-line mixed imports', async () => {
-			// Simulates the @formatjs/icu-messageformat-parser case:
-			// TYPE is a value used only in template, parse is used in script,
-			// type MessageFormatElement is a type-only specifier
+		it('preserves value identifiers from multi-line mixed imports', async () => {
 			const content = `
   import {
     parse,
@@ -166,32 +163,33 @@ describe('vitePreprocess', () => {
 
 			const processed = await script(scriptArgs(content));
 			expect(processed).toBeDefined();
-			// parse is used in script, should be preserved by oxc
+			// parse is used in script, should be preserved
 			expect(processed.code).toContain('parse');
-			// TYPE is unused in script but used in template - should be restored
+			// TYPE is a value import unused in script - should be preserved
 			expect(processed.code).toContain('TYPE');
-			// type-only specifier should NOT be restored
+			// type-only specifier should be stripped
 			expect(processed.code).not.toContain('MessageFormatElement');
-			// The restored import should reference the correct source
-			expect(processed.code).toContain('@formatjs/icu-messageformat-parser');
 		});
 
-		it('restores default import when identifier only appears as substring elsewhere', async () => {
-			// Regression: "Label" should not be confused with "InputLabels", "labels", etc.
+		it('preserves import even when identifier appears in string literals', async () => {
 			const content = `
-  import Label from './Label.svelte';
-  import type { InputLabels } from './types.js';
-  let labels: InputLabels = {};
-  const defaultLabels = { optionalLabel: 'optional' };`;
+  import Select from '../Select.svelte';
+  import { untrack } from 'svelte';
+  let { withSelect = false } = $props();
+  const defaultLabels = {
+    ariaLabelSelectAllRows: "Select all rows",
+    ariaLabelSelectRow: "Select row",
+  };
+  untrack(() => {});`;
 
 			const processed = await script(scriptArgs(content));
 			expect(processed).toBeDefined();
-			expect(processed.code).toContain("import Label from './Label.svelte'");
+			expect(processed.code).toContain('import Select from "../Select.svelte"');
 		});
 
 		it('skips non-ts script blocks', async () => {
 			const result = await script({
-				content: `import Foo from './Foo.svelte';`,
+				content: "import Foo from './Foo.svelte';",
 				attributes: {},
 				markup: '',
 				filename: `${fixtureDir}/File.svelte`

--- a/packages/vite-plugin-svelte/__tests__/preprocess.spec.js
+++ b/packages/vite-plugin-svelte/__tests__/preprocess.spec.js
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { vitePreprocess } from '../src/preprocess.js';
 import path from 'node:path';
 import { normalizePath } from 'vite';
@@ -75,6 +75,128 @@ describe('vitePreprocess', () => {
 			expect(dependencies).toBeDefined();
 			expect(dependencies[0]).toBe(path.resolve(fixtureDir, 'foo.scss'));
 			expect(dependencies.length).toBe(1);
+		});
+	});
+
+	describe('script', () => {
+		/** @type {import('svelte/types/compiler/preprocess').Preprocessor} */
+		let script;
+
+		const scriptArgs = (/** @type {string} */ content) => ({
+			content,
+			attributes: { lang: 'ts' },
+			markup: '',
+			filename: `${fixtureDir}/File.svelte`
+		});
+
+		beforeEach(() => {
+			const preprocessorGroup = vitePreprocess({ script: true });
+			script = /** @type {import('svelte/types/compiler/preprocess').Preprocessor} */ (
+				preprocessorGroup.script
+			);
+		});
+
+		it('preserves value imports unused in script but potentially used in template', async () => {
+			const content = `
+  import Component from './Component.svelte';
+  import { helper } from './utils.js';
+  interface Props { value: string; }
+  let { value } = $props();
+  const x = helper(value);`;
+
+			const processed = await script(scriptArgs(content));
+			expect(processed).toBeDefined();
+			// helper is used in script, so it should be preserved by oxc
+			expect(processed.code).toContain('helper');
+			// Component is only used in template (not in script), oxc would strip it
+			// but vitePreprocess should restore it
+			expect(processed.code).toContain("import Component from './Component.svelte'");
+		});
+
+		it('does not duplicate imports that oxc preserves', async () => {
+			const content = `
+  import { writable } from 'svelte/store';
+  const store = writable(0);`;
+
+			const processed = await script(scriptArgs(content));
+			expect(processed).toBeDefined();
+			// writable is used in script, should appear exactly once as an import
+			const matches = processed.code.match(/writable/g);
+			expect(matches.length).toBe(2); // one in import, one in usage
+		});
+
+		it('does not restore type-only imports', async () => {
+			const content = `
+  import type { SomeType } from './types.js';
+  import Component from './Component.svelte';
+  let x: SomeType;`;
+
+			const processed = await script(scriptArgs(content));
+			expect(processed).toBeDefined();
+			// type import should be correctly stripped
+			expect(processed.code).not.toContain('SomeType');
+			// value import should be restored
+			expect(processed.code).toContain("import Component from './Component.svelte'");
+		});
+
+		it('restores only stripped named imports when some are used in script', async () => {
+			const content = `
+  import { Foo, bar } from './components.js';
+  const x = bar();`;
+
+			const processed = await script(scriptArgs(content));
+			expect(processed).toBeDefined();
+			// bar is used in script so oxc keeps it
+			expect(processed.code).toContain('bar');
+			// Foo is unused in script but may be used in template - should be restored
+			expect(processed.code).toContain('Foo');
+		});
+
+		it('restores stripped value identifiers from multi-line mixed imports', async () => {
+			// Simulates the @formatjs/icu-messageformat-parser case:
+			// TYPE is a value used only in template, parse is used in script,
+			// type MessageFormatElement is a type-only specifier
+			const content = `
+  import {
+    parse,
+    TYPE,
+    type MessageFormatElement,
+  } from "@formatjs/icu-messageformat-parser";
+  const ast = parse("hello");`;
+
+			const processed = await script(scriptArgs(content));
+			expect(processed).toBeDefined();
+			// parse is used in script, should be preserved by oxc
+			expect(processed.code).toContain('parse');
+			// TYPE is unused in script but used in template - should be restored
+			expect(processed.code).toContain('TYPE');
+			// type-only specifier should NOT be restored
+			expect(processed.code).not.toContain('MessageFormatElement');
+			// The restored import should reference the correct source
+			expect(processed.code).toContain('@formatjs/icu-messageformat-parser');
+		});
+
+		it('restores default import when identifier only appears as substring elsewhere', async () => {
+			// Regression: "Label" should not be confused with "InputLabels", "labels", etc.
+			const content = `
+  import Label from './Label.svelte';
+  import type { InputLabels } from './types.js';
+  let labels: InputLabels = {};
+  const defaultLabels = { optionalLabel: 'optional' };`;
+
+			const processed = await script(scriptArgs(content));
+			expect(processed).toBeDefined();
+			expect(processed.code).toContain("import Label from './Label.svelte'");
+		});
+
+		it('skips non-ts script blocks', async () => {
+			const result = await script({
+				content: `import Foo from './Foo.svelte';`,
+				attributes: {},
+				markup: '',
+				filename: `${fixtureDir}/File.svelte`
+			});
+			expect(result).toBeUndefined();
 		});
 	});
 });

--- a/packages/vite-plugin-svelte/src/preprocess.js
+++ b/packages/vite-plugin-svelte/src/preprocess.js
@@ -50,24 +50,130 @@ function viteScript() {
 			const { code, map } = await transformWithOxc(content, filename, {
 				lang,
 				target: 'esnext'
-				// TODO, how to pass tsconfig compilerOptions (or not needed as config is loaded for file
-				/*tsconfigRaw: {
-					compilerOptions: {
-						// svelte typescript needs this flag to work with type imports
-						importsNotUsedAsValues: 'preserve',
-						preserveValueImports: true
-					}
-				}*/
 			});
+
+			// oxc strips imports it considers unused, but some may be referenced in the Svelte
+			// template which oxc cannot see. Detect stripped value imports and re-add them.
+			const restoredCode = restoreStrippedImports(content, code);
 
 			mapToRelative(map, filename);
 
 			return {
-				code,
+				code: restoredCode,
 				map
 			};
 		}
 	};
+}
+
+/**
+ * @typedef {{ kind: 'default' | 'named' | 'namespace', local: string, imported?: string }} ImportedId
+ */
+
+/**
+ * Extracts imported value identifiers from an import statement.
+ * Skips type-only specifiers (e.g., `type Foo` inside `import { type Foo, Bar }`).
+ * @param {string} importStatement
+ * @returns {{ ids: ImportedId[], source: string } | null}
+ */
+function getImportedIdentifiers(importStatement) {
+	// skip `import type { ... }` or `import type Foo` entirely
+	if (/\bimport\s+type\b/.test(importStatement)) return null;
+
+	const sourceMatch = importStatement.match(/from\s+['"]([^'"]+)['"]/);
+	if (!sourceMatch) return null;
+	const source = sourceMatch[1];
+
+	/** @type {ImportedId[]} */
+	const ids = [];
+
+	// default import: import Foo from '...'
+	const defaultMatch = importStatement.match(/import\s+([A-Za-z_$][\w$]*)\s+from/);
+	if (defaultMatch) ids.push({ kind: 'default', local: defaultMatch[1] });
+
+	// named imports: import { a, b as c, type D } from '...'
+	const namedMatch = importStatement.match(/import\s*(?:[A-Za-z_$][\w$]*\s*,\s*)?\{([^}]+)\}/);
+	if (namedMatch) {
+		for (const specifier of namedMatch[1].split(',')) {
+			const trimmed = specifier.trim();
+			if (!trimmed) continue;
+			// skip type-only specifiers: `type Foo` or `type Foo as Bar`
+			if (/^type\s+/.test(trimmed)) continue;
+			const asMatch = trimmed.match(/^(\S+)\s+as\s+(\S+)$/);
+			if (asMatch) {
+				ids.push({ kind: 'named', imported: asMatch[1], local: asMatch[2] });
+			} else {
+				ids.push({ kind: 'named', local: trimmed });
+			}
+		}
+	}
+
+	// namespace import: import * as X from '...'
+	const nsMatch = importStatement.match(/import\s*\*\s*as\s+(\S+)/);
+	if (nsMatch) ids.push({ kind: 'namespace', local: nsMatch[1] });
+
+	return ids.length > 0 ? { ids, source } : null;
+}
+
+const importFromRe = /^\s*import\s+[\s\S]+?\s+from\s+['"][^'"]+['"]\s*;?\s*$/gm;
+
+/**
+ * Compares original script content with oxc output and re-adds value imports
+ * that were stripped because they appeared unused within the script block.
+ * These imports may be referenced in the Svelte template.
+ * Handles partial stripping: if an import has both used and unused identifiers,
+ * only the stripped ones are re-added.
+ * @param {string} original - original script block content
+ * @param {string} transformed - oxc-transformed output
+ * @returns {string}
+ */
+function restoreStrippedImports(original, transformed) {
+	const originalImports = original.match(importFromRe);
+	if (!originalImports) return transformed;
+
+	/** @type {string[]} */
+	const restoreStatements = [];
+
+	for (const imp of originalImports) {
+		const parsed = getImportedIdentifiers(imp);
+		if (!parsed) continue;
+
+		const missingIds = parsed.ids.filter(
+			(id) => !new RegExp(`\\b${id.local}\\b`).test(transformed)
+		);
+		if (missingIds.length === 0) continue;
+
+		// If ALL identifiers are missing, restore the original import as-is (single-lined)
+		if (missingIds.length === parsed.ids.length) {
+			restoreStatements.push(imp.replace(/\s*\n\s*/g, ' ').trim());
+			continue;
+		}
+
+		// Partial strip: rebuild import for only the missing identifiers
+		const defaultIds = missingIds.filter((id) => id.kind === 'default');
+		const namedIds = missingIds.filter((id) => id.kind === 'named');
+		const nsIds = missingIds.filter((id) => id.kind === 'namespace');
+
+		/** @type {string[]} */
+		const parts = [];
+		if (defaultIds.length > 0) parts.push(defaultIds[0].local);
+		if (namedIds.length > 0) {
+			const specifiers = namedIds.map((id) =>
+				id.imported ? `${id.imported} as ${id.local}` : id.local
+			);
+			parts.push(`{ ${specifiers.join(', ')} }`);
+		}
+		if (nsIds.length > 0) parts.push(`* as ${nsIds[0].local}`);
+
+		if (parts.length > 0) {
+			restoreStatements.push(`import ${parts.join(', ')} from '${parsed.source}';`);
+		}
+	}
+
+	if (restoreStatements.length > 0) {
+		return restoreStatements.join('\n') + '\n' + transformed;
+	}
+	return transformed;
 }
 
 /**

--- a/packages/vite-plugin-svelte/src/preprocess.js
+++ b/packages/vite-plugin-svelte/src/preprocess.js
@@ -49,131 +49,22 @@ function viteScript() {
 			const lang = /** @type {'ts'} */ (attributes.lang);
 			const { code, map } = await transformWithOxc(content, filename, {
 				lang,
-				target: 'esnext'
+				target: 'esnext',
+				// oxc strips value imports it considers unused, but in Svelte files
+				// these imports may be referenced in the template which oxc cannot see.
+				// onlyRemoveTypeImports tells oxc to only strip type-only imports
+				// (import type {...}, import { type X }) and preserve all value imports.
+				typescript: { onlyRemoveTypeImports: true }
 			});
-
-			// oxc strips imports it considers unused, but some may be referenced in the Svelte
-			// template which oxc cannot see. Detect stripped value imports and re-add them.
-			const restoredCode = restoreStrippedImports(content, code);
 
 			mapToRelative(map, filename);
 
 			return {
-				code: restoredCode,
+				code,
 				map
 			};
 		}
 	};
-}
-
-/**
- * @typedef {{ kind: 'default' | 'named' | 'namespace', local: string, imported?: string }} ImportedId
- */
-
-/**
- * Extracts imported value identifiers from an import statement.
- * Skips type-only specifiers (e.g., `type Foo` inside `import { type Foo, Bar }`).
- * @param {string} importStatement
- * @returns {{ ids: ImportedId[], source: string } | null}
- */
-function getImportedIdentifiers(importStatement) {
-	// skip `import type { ... }` or `import type Foo` entirely
-	if (/\bimport\s+type\b/.test(importStatement)) return null;
-
-	const sourceMatch = importStatement.match(/from\s+['"]([^'"]+)['"]/);
-	if (!sourceMatch) return null;
-	const source = sourceMatch[1];
-
-	/** @type {ImportedId[]} */
-	const ids = [];
-
-	// default import: import Foo from '...'
-	const defaultMatch = importStatement.match(/import\s+([A-Za-z_$][\w$]*)\s+from/);
-	if (defaultMatch) ids.push({ kind: 'default', local: defaultMatch[1] });
-
-	// named imports: import { a, b as c, type D } from '...'
-	const namedMatch = importStatement.match(/import\s*(?:[A-Za-z_$][\w$]*\s*,\s*)?\{([^}]+)\}/);
-	if (namedMatch) {
-		for (const specifier of namedMatch[1].split(',')) {
-			const trimmed = specifier.trim();
-			if (!trimmed) continue;
-			// skip type-only specifiers: `type Foo` or `type Foo as Bar`
-			if (/^type\s+/.test(trimmed)) continue;
-			const asMatch = trimmed.match(/^(\S+)\s+as\s+(\S+)$/);
-			if (asMatch) {
-				ids.push({ kind: 'named', imported: asMatch[1], local: asMatch[2] });
-			} else {
-				ids.push({ kind: 'named', local: trimmed });
-			}
-		}
-	}
-
-	// namespace import: import * as X from '...'
-	const nsMatch = importStatement.match(/import\s*\*\s*as\s+(\S+)/);
-	if (nsMatch) ids.push({ kind: 'namespace', local: nsMatch[1] });
-
-	return ids.length > 0 ? { ids, source } : null;
-}
-
-const importFromRe = /^\s*import\s+[\s\S]+?\s+from\s+['"][^'"]+['"]\s*;?\s*$/gm;
-
-/**
- * Compares original script content with oxc output and re-adds value imports
- * that were stripped because they appeared unused within the script block.
- * These imports may be referenced in the Svelte template.
- * Handles partial stripping: if an import has both used and unused identifiers,
- * only the stripped ones are re-added.
- * @param {string} original - original script block content
- * @param {string} transformed - oxc-transformed output
- * @returns {string}
- */
-function restoreStrippedImports(original, transformed) {
-	const originalImports = original.match(importFromRe);
-	if (!originalImports) return transformed;
-
-	/** @type {string[]} */
-	const restoreStatements = [];
-
-	for (const imp of originalImports) {
-		const parsed = getImportedIdentifiers(imp);
-		if (!parsed) continue;
-
-		const missingIds = parsed.ids.filter(
-			(id) => !new RegExp(`\\b${id.local}\\b`).test(transformed)
-		);
-		if (missingIds.length === 0) continue;
-
-		// If ALL identifiers are missing, restore the original import as-is (single-lined)
-		if (missingIds.length === parsed.ids.length) {
-			restoreStatements.push(imp.replace(/\s*\n\s*/g, ' ').trim());
-			continue;
-		}
-
-		// Partial strip: rebuild import for only the missing identifiers
-		const defaultIds = missingIds.filter((id) => id.kind === 'default');
-		const namedIds = missingIds.filter((id) => id.kind === 'named');
-		const nsIds = missingIds.filter((id) => id.kind === 'namespace');
-
-		/** @type {string[]} */
-		const parts = [];
-		if (defaultIds.length > 0) parts.push(defaultIds[0].local);
-		if (namedIds.length > 0) {
-			const specifiers = namedIds.map((id) =>
-				id.imported ? `${id.imported} as ${id.local}` : id.local
-			);
-			parts.push(`{ ${specifiers.join(', ')} }`);
-		}
-		if (nsIds.length > 0) parts.push(`* as ${nsIds[0].local}`);
-
-		if (parts.length > 0) {
-			restoreStatements.push(`import ${parts.join(', ')} from '${parsed.source}';`);
-		}
-	}
-
-	if (restoreStatements.length > 0) {
-		return restoreStatements.join('\n') + '\n' + transformed;
-	}
-	return transformed;
 }
 
 /**


### PR DESCRIPTION
When vitePreprocess uses transformWithOxc to strip TypeScript from <script lang="ts"> blocks, oxc removes value imports that appear unused within the script. However, these imports may be referenced in the Svelte template (e.g., imported components used only in markup). This causes ReferenceError during SSR in the development server.

Detect stripped value imports by comparing identifiers before and after the oxc transform, and re-prepend any that were removed. Type-only imports are correctly left stripped.

I found this migrating to vite 8 on a svelte app. It's a company software so I can't share the code, I can try to get a minimum reproducible example if needed.