### PR TITLE
feat: enable optimizer for server environments during dev

### DIFF
--- a/.changeset/wet-cats-study.md
+++ b/.changeset/wet-cats-study.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': minor
+---
+
+feat: enable optimizer for server environments during dev

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@eslint/markdown": "^7.5.1",
     "@stylistic/eslint-plugin": "^5.10.0",
     "@sveltejs/eslint-config": "^9.0.0",
-    "@sveltejs/kit": "https://pkg.pr.new/@sveltejs/kit@6fbbb7d",
+    "@sveltejs/kit": "catalog:",
     "@svitejs/changesets-changelog-github-compact": "^1.2.0",
     "@types/fs-extra": "^11.0.4",
     "@types/node": "^22.19.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@eslint/markdown": "^7.5.1",
     "@stylistic/eslint-plugin": "^5.10.0",
     "@sveltejs/eslint-config": "^9.0.0",
-    "@sveltejs/kit": "^2.55.0",
+    "@sveltejs/kit": "https://pkg.pr.new/@sveltejs/kit@6fbbb7d",
     "@svitejs/changesets-changelog-github-compact": "^1.2.0",
     "@types/fs-extra": "^11.0.4",
     "@types/node": "^22.19.1",

--- a/packages/e2e-tests/inspector-kit/package.json
+++ b/packages/e2e-tests/inspector-kit/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview"
   },
   "devDependencies": {
-    "@sveltejs/kit": "^2.55.0",
+    "@sveltejs/kit": "catalog:",
     "@sveltejs/vite-plugin-svelte": "workspace:^",
     "svelte": "^5.45.4",
     "vite": "catalog:"

--- a/packages/e2e-tests/kit-async/package.json
+++ b/packages/e2e-tests/kit-async/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@sveltejs/adapter-node": "^5.4.0",
-    "@sveltejs/kit": "^2.55.0",
+    "@sveltejs/kit": "catalog:",
     "@sveltejs/vite-plugin-svelte": "workspace:^",
     "svelte": "^5.45.4",
     "svelte-check": "^4.3.4",

--- a/packages/e2e-tests/kit-node/package.json
+++ b/packages/e2e-tests/kit-node/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@sveltejs/adapter-node": "^5.4.0",
-    "@sveltejs/kit": "^2.55.0",
+    "@sveltejs/kit": "catalog:",
     "@sveltejs/package": "^2.5.7",
     "@sveltejs/vite-plugin-svelte": "workspace:^",
     "e2e-test-dep-svelte-api-only": "file:../_test_dependencies/svelte-api-only",

--- a/packages/vite-plugin-svelte/src/plugins/setup-optimizer.js
+++ b/packages/vite-plugin-svelte/src/plugins/setup-optimizer.js
@@ -94,7 +94,7 @@ function rolldownOptimizerPlugin(api, consumer, components) {
 
 	plugin.options = (opts) => {
 		// @ts-expect-error plugins is an array here
-		const isScanner = opts.plugins.some(
+		const isScanner = opts.plugins?.some(
 			(/** @type {{ name: string; }} */ p) => p.name === 'vite:dep-scan:resolve'
 		);
 		if (isScanner) {

--- a/packages/vite-plugin-svelte/src/plugins/setup-optimizer.js
+++ b/packages/vite-plugin-svelte/src/plugins/setup-optimizer.js
@@ -94,8 +94,8 @@ function rolldownOptimizerPlugin(api, consumer, components) {
 
 	plugin.options = (opts) => {
 		// @ts-expect-error plugins is an array here
-		const isScanner = opts.plugins?.some(
-			(/** @type {{ name: string; }} */ p) => p.name === 'vite:dep-scan:resolve'
+		const isScanner = opts.plugins.some(
+			(/** @type {{ name: string; } | undefined} */ p) => p?.name === 'vite:dep-scan:resolve'
 		);
 		if (isScanner) {
 			delete plugin.buildStart;

--- a/packages/vite-plugin-svelte/src/plugins/setup-optimizer.js
+++ b/packages/vite-plugin-svelte/src/plugins/setup-optimizer.js
@@ -10,7 +10,6 @@ import path from 'node:path';
 import * as svelte from 'svelte/compiler';
 import { log } from '../utils/log.js';
 import { toRollupError } from '../utils/error.js';
-import { mapToRelative } from '../utils/sourcemaps.js';
 import { SVELTE_IMPORTS } from '../utils/constants.js';
 import { isDepExcluded } from 'vitefu';
 
@@ -189,7 +188,6 @@ async function compileSvelte(options, { filename, code }, generate, statsCollect
 	if (endStat) {
 		endStat();
 	}
-	mapToRelative(compiled.js?.map, filename);
 	return {
 		...compiled.js,
 		moduleType: 'js'
@@ -213,7 +211,6 @@ async function compileSvelteModule(options, { filename, code }, generate, statsC
 	if (endStat) {
 		endStat();
 	}
-	mapToRelative(compiled.js?.map, filename);
 	return {
 		...compiled.js,
 		moduleType: 'js'

--- a/packages/vite-plugin-svelte/src/plugins/setup-optimizer.js
+++ b/packages/vite-plugin-svelte/src/plugins/setup-optimizer.js
@@ -48,10 +48,7 @@ export function setupOptimizer(api) {
 				]
 			};
 
-			if (
-				config.consumer === 'server' &&
-				!isDepExcluded('svelte', config.optimizeDeps?.exclude ?? [])
-			) {
+			if (consumer === 'server' && !isDepExcluded('svelte', config.optimizeDeps?.exclude ?? [])) {
 				optimizeDeps.include = [...SVELTE_IMPORTS];
 			}
 

--- a/packages/vite-plugin-svelte/src/plugins/setup-optimizer.js
+++ b/packages/vite-plugin-svelte/src/plugins/setup-optimizer.js
@@ -11,6 +11,7 @@ import * as svelte from 'svelte/compiler';
 import { log } from '../utils/log.js';
 import { toRollupError } from '../utils/error.js';
 import { SVELTE_SERVER_IMPORTS } from '../utils/constants.js';
+import { isDepExcluded } from 'vitefu';
 
 /**
  * @typedef {NonNullable<Rolldown.Plugin>} RollupPlugin
@@ -47,7 +48,10 @@ export function setupOptimizer(api) {
 				]
 			};
 
-			if (config.consumer === 'server' && config.optimizeDeps?.noDiscovery) {
+			if (
+				config.consumer === 'server' &&
+				!isDepExcluded('svelte', config.optimizeDeps?.exclude ?? [])
+			) {
 				optimizeDeps.include = [...SVELTE_SERVER_IMPORTS];
 			}
 

--- a/packages/vite-plugin-svelte/src/plugins/setup-optimizer.js
+++ b/packages/vite-plugin-svelte/src/plugins/setup-optimizer.js
@@ -10,7 +10,7 @@ import path from 'node:path';
 import * as svelte from 'svelte/compiler';
 import { log } from '../utils/log.js';
 import { toRollupError } from '../utils/error.js';
-import { SVELTE_SERVER_IMPORTS } from '../utils/constants.js';
+import { SVELTE_IMPORTS } from '../utils/constants.js';
 import { isDepExcluded } from 'vitefu';
 
 /**
@@ -52,7 +52,7 @@ export function setupOptimizer(api) {
 				config.consumer === 'server' &&
 				!isDepExcluded('svelte', config.optimizeDeps?.exclude ?? [])
 			) {
-				optimizeDeps.include = [...SVELTE_SERVER_IMPORTS];
+				optimizeDeps.include = [...SVELTE_IMPORTS];
 			}
 
 			return { optimizeDeps };

--- a/packages/vite-plugin-svelte/src/plugins/setup-optimizer.js
+++ b/packages/vite-plugin-svelte/src/plugins/setup-optimizer.js
@@ -3,16 +3,17 @@
 /** @import { PluginAPI } from '../types/plugin-api.js' */
 /** @import { StatCollection } from '../types/vite-plugin-svelte-stats.js' */
 /** @import { CompileOptions } from 'svelte/compiler' */
-/** @import { Plugin, ResolvedConfig, Rollup, UserConfig } from 'vite' */
+/** @import { Plugin, ResolvedConfig, Rolldown, UserConfig } from 'vite' */
 
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import * as svelte from 'svelte/compiler';
 import { log } from '../utils/log.js';
 import { toRollupError } from '../utils/error.js';
+import { SVELTE_SERVER_IMPORTS } from '../utils/constants.js';
 
 /**
- * @typedef {NonNullable<Rollup.Plugin>} RollupPlugin
+ * @typedef {NonNullable<Rolldown.Plugin>} RollupPlugin
  */
 
 const optimizeSveltePluginName = 'vite-plugin-svelte:optimize';
@@ -29,36 +30,31 @@ export function setupOptimizer(api) {
 	return {
 		name: 'vite-plugin-svelte:setup-optimizer',
 		apply: 'serve',
-		config() {
+		configEnvironment(name, config) {
+			// fall back to vite behavior when consumer isn't set
+			const consumer = (config.consumer ?? name === 'client') ? 'client' : 'server';
 			/** @type {UserConfig['optimizeDeps']} */
 			const optimizeDeps = {
 				// Experimental Vite API to allow these extensions to be scanned and prebundled
 				extensions: ['.svelte']
 			};
-			// Add optimizer plugins to prebundle Svelte files.
-			// Currently, a placeholder as more information is needed after Vite config is resolved,
-			// the added plugins are patched in configResolved below
 
+			// Add optimizer plugins to prebundle Svelte files.
 			optimizeDeps.rolldownOptions = {
 				plugins: [
-					placeholderRolldownOptimizerPlugin(optimizeSveltePluginName),
-					placeholderRolldownOptimizerPlugin(optimizeSvelteModulePluginName)
+					rolldownOptimizerPlugin(api, consumer, true),
+					rolldownOptimizerPlugin(api, consumer, false)
 				]
 			};
+
+			if (config.consumer === 'server' && config.optimizeDeps?.noDiscovery) {
+				optimizeDeps.include = [...SVELTE_SERVER_IMPORTS];
+			}
 
 			return { optimizeDeps };
 		},
 		configResolved(c) {
 			viteConfig = c;
-			const optimizeDeps = c.optimizeDeps;
-			const plugins =
-				// @ts-expect-error not typed
-				optimizeDeps.rolldownOptions?.plugins?.filter((p) =>
-					[optimizeSveltePluginName, optimizeSvelteModulePluginName].includes(p.name)
-				) ?? [];
-			for (const plugin of plugins) {
-				patchRolldownOptimizerPlugin(plugin, api.options);
-			}
 		},
 		async buildStart() {
 			if (!api.options.prebundleSvelteLibraries) return;
@@ -73,16 +69,24 @@ export function setupOptimizer(api) {
 }
 
 /**
- * @param {RollupPlugin} plugin
- * @param {ResolvedOptions} options
+ * @param {import('../types/plugin-api.d.ts').PluginAPI} api
+ * @param {'server'|'client'} consumer
+ * @param {boolean} components
+ * @return {Rolldown.Plugin}
  */
-function patchRolldownOptimizerPlugin(plugin, options) {
-	const components = plugin.name === optimizeSveltePluginName;
+function rolldownOptimizerPlugin(api, consumer, components) {
+	const name = components ? optimizeSveltePluginName : optimizeSvelteModulePluginName;
 	const compileFn = components ? compileSvelte : compileSvelteModule;
 	const statsName = components ? 'prebundle library components' : 'prebundle library modules';
 	const includeRe = components ? /^[^?#]+\.svelte(?:[?#]|$)/ : /^[^?#]+\.svelte\.[jt]s(?:[?#]|$)/;
+	const generate = consumer === 'server' ? 'server' : 'client';
 	/** @type {StatCollection | undefined} */
 	let statsCollection;
+
+	/**@type {Rolldown.Plugin}*/
+	const plugin = {
+		name
+	};
 
 	plugin.options = (opts) => {
 		// @ts-expect-error plugins is an array here
@@ -102,14 +106,14 @@ function patchRolldownOptimizerPlugin(plugin, options) {
 				 */
 				async handler(code, filename) {
 					try {
-						return await compileFn(options, { filename, code }, statsCollection);
+						return await compileFn(api.options, { filename, code }, generate, statsCollection);
 					} catch (e) {
-						throw toRollupError(e, options);
+						throw toRollupError(e, api.options);
 					}
 				}
 			};
 			plugin.buildStart = () => {
-				statsCollection = options.stats?.startCollection(statsName, {
+				statsCollection = api.options.stats?.startCollection(statsName, {
 					logResult: (c) => c.stats.length > 1
 				});
 			};
@@ -118,15 +122,18 @@ function patchRolldownOptimizerPlugin(plugin, options) {
 			};
 		}
 	};
+
+	return plugin;
 }
 
 /**
  * @param {ResolvedOptions} options
  * @param {{ filename: string, code: string }} input
+ * @param {'client'|'server'} generate
  * @param {StatCollection} [statsCollection]
  * @returns {Promise<Code>}
  */
-async function compileSvelte(options, { filename, code }, statsCollection) {
+async function compileSvelte(options, { filename, code }, generate, statsCollection) {
 	let css = options.compilerOptions.css;
 	if (css !== 'injected') {
 		// TODO ideally we'd be able to externalize prebundled styles too, but for now always put them in the js
@@ -138,7 +145,7 @@ async function compileSvelte(options, { filename, code }, statsCollection) {
 		...options.compilerOptions,
 		css,
 		filename,
-		generate: 'client'
+		generate
 	};
 
 	let preprocessed;
@@ -189,15 +196,16 @@ async function compileSvelte(options, { filename, code }, statsCollection) {
 /**
  * @param {ResolvedOptions} options
  * @param {{ filename: string; code: string }} input
+ * @param {'client'|'server'} generate
  * @param {StatCollection} [statsCollection]
  * @returns {Promise<Code>}
  */
-async function compileSvelteModule(options, { filename, code }, statsCollection) {
+async function compileSvelteModule(options, { filename, code }, generate, statsCollection) {
 	const endStat = statsCollection?.start(filename);
 	const compiled = svelte.compileModule(code, {
 		dev: options.compilerOptions?.dev ?? true, // default to dev: true because prebundling is only used in dev
 		filename,
-		generate: 'client'
+		generate
 	});
 	if (endStat) {
 		endStat();
@@ -245,21 +253,6 @@ async function svelteMetadataChanged(cacheDir, options) {
 	await fs.mkdir(cacheDir, { recursive: true });
 	await fs.writeFile(svelteMetadataPath, currentSvelteMetadata);
 	return currentSvelteMetadata !== existingSvelteMetadata;
-}
-
-/**
- *
- * @param {string} name
- * @returns {Rollup.Plugin}
- */
-function placeholderRolldownOptimizerPlugin(name) {
-	return {
-		name,
-		options() {},
-		buildStart() {},
-		buildEnd() {},
-		transform: { filter: { id: /^$/ }, handler() {} }
-	};
 }
 
 /**

--- a/packages/vite-plugin-svelte/src/plugins/setup-optimizer.js
+++ b/packages/vite-plugin-svelte/src/plugins/setup-optimizer.js
@@ -10,6 +10,7 @@ import path from 'node:path';
 import * as svelte from 'svelte/compiler';
 import { log } from '../utils/log.js';
 import { toRollupError } from '../utils/error.js';
+import { mapToRelative } from '../utils/sourcemaps.js';
 import { SVELTE_IMPORTS } from '../utils/constants.js';
 import { isDepExcluded } from 'vitefu';
 
@@ -188,6 +189,7 @@ async function compileSvelte(options, { filename, code }, generate, statsCollect
 	if (endStat) {
 		endStat();
 	}
+	mapToRelative(compiled.js?.map, filename);
 	return {
 		...compiled.js,
 		moduleType: 'js'
@@ -211,6 +213,7 @@ async function compileSvelteModule(options, { filename, code }, generate, statsC
 	if (endStat) {
 		endStat();
 	}
+	mapToRelative(compiled.js?.map, filename);
 	return {
 		...compiled.js,
 		moduleType: 'js'

--- a/packages/vite-plugin-svelte/src/utils/constants.js
+++ b/packages/vite-plugin-svelte/src/utils/constants.js
@@ -27,6 +27,13 @@ const SVELTE_IMPORTS = Object.entries(sveltePkg.exports)
 		return { name: name.replace(/^\./, 'svelte'), config };
 	});
 
+export const SVELTE_DEDUPED_IMPORTS = SVELTE_IMPORTS.map(({ name }) => {
+	if (name === 'svelte/compiler') {
+		return '';
+	}
+	return name;
+}).filter((s) => s.length > 0);
+
 export const SVELTE_CLIENT_IMPORTS = SVELTE_IMPORTS.map(({ name }) => {
 	// ignore names
 	if (name === 'svelte/compiler' || name.endsWith('/server') || name.includes('/server/')) {

--- a/packages/vite-plugin-svelte/src/utils/constants.js
+++ b/packages/vite-plugin-svelte/src/utils/constants.js
@@ -1,25 +1,51 @@
 import { createRequire } from 'node:module';
 
+/** @type {import('svelte/package.json')} */
 const sveltePkg = createRequire(import.meta.url)('svelte/package.json');
 
 // list of svelte runtime dependencies to optimize together with svelte itself
-export const SVELTE_RUNTIME_DEPENDENCIES = [
+export const SVELTE_RUNTIME_DEPENDENCIES = /** @type {const} */ ([
 	'clsx' // avoids dev server restart after page load with npm + vite6 (see #1067)
-].filter((dep) => !!sveltePkg.dependencies?.[dep]);
+]).filter((dep) => !!sveltePkg.dependencies?.[dep]);
 
-export const SVELTE_IMPORTS = Object.entries(sveltePkg.exports)
-	.map(([name, config]) => {
-		// ignore type only
-		if (typeof config === 'object' && Object.keys(config).length === 1 && config.types) {
-			return '';
-		}
+const SVELTE_IMPORTS = Object.entries(sveltePkg.exports)
+	.filter(([name, config]) => {
 		// ignore names
-		if (name === './package.json' || name === './compiler') {
+		if (name === './package.json') {
 			return '';
 		}
-		return name.replace(/^\./, 'svelte');
+
+		// ignore type only
+		return !(
+			typeof config === 'object' &&
+			Object.keys(config).length === 1 &&
+			'types' in config &&
+			config.types
+		);
 	})
-	.filter((s) => s.length > 0);
+	.map(([name, config]) => {
+		return { name: name.replace(/^\./, 'svelte'), config };
+	});
+
+export const SVELTE_CLIENT_IMPORTS = SVELTE_IMPORTS.map(({ name }) => {
+	// ignore names
+	if (name === './compiler' || name.endsWith('/server') || name.includes('/server/')) {
+		return '';
+	}
+
+	return name;
+}).filter((s) => s.length > 0);
+
+export const SVELTE_SERVER_IMPORTS = SVELTE_IMPORTS.map(({ name, config }) => {
+	// ignore non-server imports
+	if (
+		!(name.endsWith('/server') || name.includes('/server/')) &&
+		((typeof config === 'object' && !('worker' in config)) || typeof config === 'string')
+	) {
+		return '';
+	}
+	return name;
+}).filter((s) => s.length > 0);
 
 export const SVELTE_EXPORT_CONDITIONS = ['svelte'];
 

--- a/packages/vite-plugin-svelte/src/utils/constants.js
+++ b/packages/vite-plugin-svelte/src/utils/constants.js
@@ -8,7 +8,7 @@ export const SVELTE_RUNTIME_DEPENDENCIES = /** @type {const} */ ([
 	'clsx' // avoids dev server restart after page load with npm + vite6 (see #1067)
 ]).filter((dep) => !!sveltePkg.dependencies?.[dep]);
 
-const SVELTE_IMPORTS = Object.entries(sveltePkg.exports)
+export const SVELTE_IMPORTS = Object.entries(sveltePkg.exports)
 	.filter(([name, config]) => {
 		// ignore names
 		if (name === './package.json') {
@@ -23,34 +23,23 @@ const SVELTE_IMPORTS = Object.entries(sveltePkg.exports)
 			config.types
 		);
 	})
-	.map(([name, config]) => {
-		return { name: name.replace(/^\./, 'svelte'), config };
+	.map(([name]) => {
+		return name.replace(/^\./, 'svelte');
 	});
 
-export const SVELTE_DEDUPED_IMPORTS = SVELTE_IMPORTS.map(({ name }) => {
+export const SVELTE_DEDUPED_IMPORTS = SVELTE_IMPORTS.map((name) => {
 	if (name === 'svelte/compiler') {
 		return '';
 	}
 	return name;
 }).filter((s) => s.length > 0);
 
-export const SVELTE_CLIENT_IMPORTS = SVELTE_IMPORTS.map(({ name }) => {
+export const SVELTE_CLIENT_IMPORTS = SVELTE_IMPORTS.map((name) => {
 	// ignore names
 	if (name === 'svelte/compiler' || name.endsWith('/server') || name.includes('/server/')) {
 		return '';
 	}
 
-	return name;
-}).filter((s) => s.length > 0);
-
-export const SVELTE_SERVER_IMPORTS = SVELTE_IMPORTS.map(({ name, config }) => {
-	// ignore non-server imports
-	if (
-		!(name.endsWith('/server') || name.includes('/server/')) &&
-		((typeof config === 'object' && !('worker' in config)) || typeof config === 'string')
-	) {
-		return '';
-	}
 	return name;
 }).filter((s) => s.length > 0);
 

--- a/packages/vite-plugin-svelte/src/utils/constants.js
+++ b/packages/vite-plugin-svelte/src/utils/constants.js
@@ -29,7 +29,7 @@ const SVELTE_IMPORTS = Object.entries(sveltePkg.exports)
 
 export const SVELTE_CLIENT_IMPORTS = SVELTE_IMPORTS.map(({ name }) => {
 	// ignore names
-	if (name === './compiler' || name.endsWith('/server') || name.includes('/server/')) {
+	if (name === 'svelte/compiler' || name.endsWith('/server') || name.includes('/server/')) {
 		return '';
 	}
 

--- a/packages/vite-plugin-svelte/src/utils/options.js
+++ b/packages/vite-plugin-svelte/src/utils/options.js
@@ -21,7 +21,7 @@ import {
 	FAQ_LINK_MISSING_EXPORTS_CONDITION,
 	LINK_TRANSFORM_WITH_PLUGIN,
 	SVELTE_EXPORT_CONDITIONS,
-	SVELTE_IMPORTS,
+	SVELTE_CLIENT_IMPORTS,
 	SVELTE_RUNTIME_DEPENDENCIES
 } from './constants.js';
 
@@ -369,7 +369,7 @@ export async function buildExtraViteConfig(options, config) {
 	/** @type {Partial<UserConfig>} */
 	const extraViteConfig = {
 		resolve: {
-			dedupe: [...SVELTE_IMPORTS]
+			dedupe: [...SVELTE_CLIENT_IMPORTS]
 		}
 		// this option is still awaiting a PR in vite to be supported
 		// see https://github.com/sveltejs/vite-plugin-svelte/issues/60
@@ -572,9 +572,7 @@ function buildExtraConfigForSvelte(config) {
 	/** @type {string[]} */
 	const exclude = [];
 	if (!isDepExcluded('svelte', config.optimizeDeps?.exclude ?? [])) {
-		const svelteImportsToInclude = SVELTE_IMPORTS.filter(
-			(si) => !(si.endsWith('/server') || si.includes('/server/'))
-		);
+		const svelteImportsToInclude = [...SVELTE_CLIENT_IMPORTS];
 		svelteImportsToInclude.push(...SVELTE_RUNTIME_DEPENDENCIES.map((dep) => `svelte > ${dep}`));
 		log.debug(
 			`adding bare svelte packages and runtime dependencies to optimizeDeps.include: ${svelteImportsToInclude.join(', ')} `,

--- a/packages/vite-plugin-svelte/src/utils/options.js
+++ b/packages/vite-plugin-svelte/src/utils/options.js
@@ -22,6 +22,7 @@ import {
 	LINK_TRANSFORM_WITH_PLUGIN,
 	SVELTE_EXPORT_CONDITIONS,
 	SVELTE_CLIENT_IMPORTS,
+	SVELTE_DEDUPED_IMPORTS,
 	SVELTE_RUNTIME_DEPENDENCIES
 } from './constants.js';
 
@@ -369,7 +370,7 @@ export async function buildExtraViteConfig(options, config) {
 	/** @type {Partial<UserConfig>} */
 	const extraViteConfig = {
 		resolve: {
-			dedupe: [...SVELTE_CLIENT_IMPORTS]
+			dedupe: [...SVELTE_DEDUPED_IMPORTS]
 		}
 		// this option is still awaiting a PR in vite to be supported
 		// see https://github.com/sveltejs/vite-plugin-svelte/issues/60

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@sveltejs/kit': https://pkg.pr.new/@sveltejs/kit@6fbbb7d
+  '@sveltejs/kit': ^2.59.1
   '@sveltejs/kit>@sveltejs/vite-plugin-svelte': workspace:^
   '@sveltejs/vite-plugin-svelte': workspace:^
   svelte: ^5.46.4
@@ -34,8 +34,8 @@ importers:
         specifier: ^9.0.0
         version: 9.0.0(@eslint/js@10.0.1(eslint@10.0.3))(@stylistic/eslint-plugin-js@4.4.1(eslint@10.0.3))(eslint-config-prettier@10.1.8(eslint@10.0.3))(eslint-plugin-n@17.24.0(eslint@10.0.3)(typescript@5.9.3))(eslint-plugin-svelte@3.15.2(eslint@10.0.3)(svelte@5.53.12))(eslint@10.0.3)(typescript-eslint@8.57.0(eslint@10.0.3)(typescript@5.9.3))(typescript@5.9.3)
       '@sveltejs/kit':
-        specifier: https://pkg.pr.new/@sveltejs/kit@6fbbb7d
-        version: https://pkg.pr.new/@sveltejs/kit@6fbbb7d(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.53.12)(typescript@5.9.3)(vite@8.0.9(@types/node@22.19.15)(sass@1.98.0)(stylus@0.64.0)(yaml@2.8.2))
+        specifier: ^2.59.1
+        version: 2.59.1(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.53.12)(typescript@5.9.3)(vite@8.0.9(@types/node@22.19.15)(sass@1.98.0)(stylus@0.64.0)(yaml@2.8.2))
       '@svitejs/changesets-changelog-github-compact':
         specifier: ^1.2.0
         version: 1.2.0
@@ -428,8 +428,8 @@ importers:
   packages/e2e-tests/inspector-kit:
     devDependencies:
       '@sveltejs/kit':
-        specifier: https://pkg.pr.new/@sveltejs/kit@6fbbb7d
-        version: https://pkg.pr.new/@sveltejs/kit@6fbbb7d(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.53.12)(typescript@5.9.3)(vite@8.0.9(@types/node@22.19.15)(sass@1.98.0)(stylus@0.64.0)(yaml@2.8.2))
+        specifier: ^2.59.1
+        version: 2.59.1(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.53.12)(typescript@5.9.3)(vite@8.0.9(@types/node@22.19.15)(sass@1.98.0)(stylus@0.64.0)(yaml@2.8.2))
       '@sveltejs/vite-plugin-svelte':
         specifier: workspace:^
         version: link:../../vite-plugin-svelte
@@ -456,10 +456,10 @@ importers:
     devDependencies:
       '@sveltejs/adapter-node':
         specifier: ^5.4.0
-        version: 5.5.4(@sveltejs/kit@https://pkg.pr.new/@sveltejs/kit@6fbbb7d(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.53.12)(typescript@5.9.3)(vite@8.0.9(@types/node@22.19.15)(sass@1.98.0)(stylus@0.64.0)(yaml@2.8.2)))
+        version: 5.5.4(@sveltejs/kit@2.59.1(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.53.12)(typescript@5.9.3)(vite@8.0.9(@types/node@22.19.15)(sass@1.98.0)(stylus@0.64.0)(yaml@2.8.2)))
       '@sveltejs/kit':
-        specifier: https://pkg.pr.new/@sveltejs/kit@6fbbb7d
-        version: https://pkg.pr.new/@sveltejs/kit@6fbbb7d(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.53.12)(typescript@5.9.3)(vite@8.0.9(@types/node@22.19.15)(sass@1.98.0)(stylus@0.64.0)(yaml@2.8.2))
+        specifier: ^2.59.1
+        version: 2.59.1(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.53.12)(typescript@5.9.3)(vite@8.0.9(@types/node@22.19.15)(sass@1.98.0)(stylus@0.64.0)(yaml@2.8.2))
       '@sveltejs/vite-plugin-svelte':
         specifier: workspace:^
         version: link:../../vite-plugin-svelte
@@ -480,10 +480,10 @@ importers:
     devDependencies:
       '@sveltejs/adapter-node':
         specifier: ^5.4.0
-        version: 5.5.4(@sveltejs/kit@https://pkg.pr.new/@sveltejs/kit@6fbbb7d(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.53.12)(typescript@5.9.3)(vite@8.0.9(@types/node@22.19.15)(sass@1.98.0)(stylus@0.64.0)(yaml@2.8.2)))
+        version: 5.5.4(@sveltejs/kit@2.59.1(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.53.12)(typescript@5.9.3)(vite@8.0.9(@types/node@22.19.15)(sass@1.98.0)(stylus@0.64.0)(yaml@2.8.2)))
       '@sveltejs/kit':
-        specifier: https://pkg.pr.new/@sveltejs/kit@6fbbb7d
-        version: https://pkg.pr.new/@sveltejs/kit@6fbbb7d(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.53.12)(typescript@5.9.3)(vite@8.0.9(@types/node@22.19.15)(sass@1.98.0)(stylus@0.64.0)(yaml@2.8.2))
+        specifier: ^2.59.1
+        version: 2.59.1(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.53.12)(typescript@5.9.3)(vite@8.0.9(@types/node@22.19.15)(sass@1.98.0)(stylus@0.64.0)(yaml@2.8.2))
       '@sveltejs/package':
         specifier: ^2.5.7
         version: 2.5.7(svelte@5.53.12)(typescript@5.9.3)
@@ -1515,9 +1515,8 @@ packages:
 
   '@sveltejs/adapter-node@5.5.4':
     resolution: {integrity: sha512-45X92CXW+2J8ZUzPv3eLlKWEzINKiiGeFWTjyER4ZN4sGgNoaoeSkCY/QYNxHpPXy71QPsctwccBo9jJs0ySPQ==}
-    version: 5.5.4
     peerDependencies:
-      '@sveltejs/kit': ^2.4.0
+      '@sveltejs/kit': ^2.59.1
 
   '@sveltejs/eslint-config@9.0.0':
     resolution: {integrity: sha512-3u9VUYlU0Mc/8Bhc7eRAPgJuUBMaKHzoE8r50WrnVujoxBLW4zfPckR/BFGGNeVUh0F7QGAtxGkV/5pL6CE1Ng==}
@@ -1531,9 +1530,8 @@ packages:
       typescript: '>= 5'
       typescript-eslint: '>= 8'
 
-  '@sveltejs/kit@https://pkg.pr.new/@sveltejs/kit@6fbbb7d':
-    resolution: {integrity: sha512-rEM9N1/ZvXyQ0DxMpINFwsZNc3nF1OSENP4YM+RLtp6oyKdnMTufj4PFcaPyxbZ8LHQDGvX5R1tWIkKVZIwhEQ==, tarball: https://pkg.pr.new/@sveltejs/kit@6fbbb7d}
-    version: 2.59.0
+  '@sveltejs/kit@2.59.1':
+    resolution: {integrity: sha512-d8OON70AphLdDesuTIl//M2O6fRTIicX8aYv8vhCiYEhTTI2OboKqey0Hu1A4VFhqwgqtq0vKDmPFGkw8kKmgw==}
     engines: {node: '>=18.13'}
     hasBin: true
     peerDependencies:
@@ -4320,12 +4318,12 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  '@sveltejs/adapter-node@5.5.4(@sveltejs/kit@https://pkg.pr.new/@sveltejs/kit@6fbbb7d(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.53.12)(typescript@5.9.3)(vite@8.0.9(@types/node@22.19.15)(sass@1.98.0)(stylus@0.64.0)(yaml@2.8.2)))':
+  '@sveltejs/adapter-node@5.5.4(@sveltejs/kit@2.59.1(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.53.12)(typescript@5.9.3)(vite@8.0.9(@types/node@22.19.15)(sass@1.98.0)(stylus@0.64.0)(yaml@2.8.2)))':
     dependencies:
       '@rollup/plugin-commonjs': 29.0.2(rollup@4.59.0)
       '@rollup/plugin-json': 6.1.0(rollup@4.59.0)
       '@rollup/plugin-node-resolve': 16.0.3(rollup@4.59.0)
-      '@sveltejs/kit': https://pkg.pr.new/@sveltejs/kit@6fbbb7d(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.53.12)(typescript@5.9.3)(vite@8.0.9(@types/node@22.19.15)(sass@1.98.0)(stylus@0.64.0)(yaml@2.8.2))
+      '@sveltejs/kit': 2.59.1(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.53.12)(typescript@5.9.3)(vite@8.0.9(@types/node@22.19.15)(sass@1.98.0)(stylus@0.64.0)(yaml@2.8.2))
       rollup: 4.59.0
 
   '@sveltejs/eslint-config@9.0.0(@eslint/js@10.0.1(eslint@10.0.3))(@stylistic/eslint-plugin-js@4.4.1(eslint@10.0.3))(eslint-config-prettier@10.1.8(eslint@10.0.3))(eslint-plugin-n@17.24.0(eslint@10.0.3)(typescript@5.9.3))(eslint-plugin-svelte@3.15.2(eslint@10.0.3)(svelte@5.53.12))(eslint@10.0.3)(typescript-eslint@8.57.0(eslint@10.0.3)(typescript@5.9.3))(typescript@5.9.3)':
@@ -4340,7 +4338,7 @@ snapshots:
       typescript: 5.9.3
       typescript-eslint: 8.57.0(eslint@10.0.3)(typescript@5.9.3)
 
-  '@sveltejs/kit@https://pkg.pr.new/@sveltejs/kit@6fbbb7d(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.53.12)(typescript@5.9.3)(vite@8.0.9(@types/node@22.19.15)(sass@1.98.0)(stylus@0.64.0)(yaml@2.8.2))':
+  '@sveltejs/kit@2.59.1(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.53.12)(typescript@5.9.3)(vite@8.0.9(@types/node@22.19.15)(sass@1.98.0)(stylus@0.64.0)(yaml@2.8.2))':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@sveltejs/acorn-typescript': 1.0.9(acorn@8.16.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@sveltejs/kit': ^2.55.0
+  '@sveltejs/kit': https://pkg.pr.new/@sveltejs/kit@6fbbb7d
   '@sveltejs/kit>@sveltejs/vite-plugin-svelte': workspace:^
   '@sveltejs/vite-plugin-svelte': workspace:^
   svelte: ^5.46.4
@@ -34,8 +34,8 @@ importers:
         specifier: ^9.0.0
         version: 9.0.0(@eslint/js@10.0.1(eslint@10.0.3))(@stylistic/eslint-plugin-js@4.4.1(eslint@10.0.3))(eslint-config-prettier@10.1.8(eslint@10.0.3))(eslint-plugin-n@17.24.0(eslint@10.0.3)(typescript@5.9.3))(eslint-plugin-svelte@3.15.2(eslint@10.0.3)(svelte@5.53.12))(eslint@10.0.3)(typescript-eslint@8.57.0(eslint@10.0.3)(typescript@5.9.3))(typescript@5.9.3)
       '@sveltejs/kit':
-        specifier: ^2.55.0
-        version: 2.55.0(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.53.12)(typescript@5.9.3)(vite@8.0.9(@types/node@22.19.15)(sass@1.98.0)(stylus@0.64.0)(yaml@2.8.2))
+        specifier: https://pkg.pr.new/@sveltejs/kit@6fbbb7d
+        version: https://pkg.pr.new/@sveltejs/kit@6fbbb7d(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.53.12)(typescript@5.9.3)(vite@8.0.9(@types/node@22.19.15)(sass@1.98.0)(stylus@0.64.0)(yaml@2.8.2))
       '@svitejs/changesets-changelog-github-compact':
         specifier: ^1.2.0
         version: 1.2.0
@@ -428,8 +428,8 @@ importers:
   packages/e2e-tests/inspector-kit:
     devDependencies:
       '@sveltejs/kit':
-        specifier: ^2.55.0
-        version: 2.55.0(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.53.12)(typescript@5.9.3)(vite@8.0.9(@types/node@22.19.15)(sass@1.98.0)(stylus@0.64.0)(yaml@2.8.2))
+        specifier: https://pkg.pr.new/@sveltejs/kit@6fbbb7d
+        version: https://pkg.pr.new/@sveltejs/kit@6fbbb7d(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.53.12)(typescript@5.9.3)(vite@8.0.9(@types/node@22.19.15)(sass@1.98.0)(stylus@0.64.0)(yaml@2.8.2))
       '@sveltejs/vite-plugin-svelte':
         specifier: workspace:^
         version: link:../../vite-plugin-svelte
@@ -456,10 +456,10 @@ importers:
     devDependencies:
       '@sveltejs/adapter-node':
         specifier: ^5.4.0
-        version: 5.5.4(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.53.12)(typescript@5.9.3)(vite@8.0.9(@types/node@22.19.15)(sass@1.98.0)(stylus@0.64.0)(yaml@2.8.2)))
+        version: 5.5.4(@sveltejs/kit@https://pkg.pr.new/@sveltejs/kit@6fbbb7d(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.53.12)(typescript@5.9.3)(vite@8.0.9(@types/node@22.19.15)(sass@1.98.0)(stylus@0.64.0)(yaml@2.8.2)))
       '@sveltejs/kit':
-        specifier: ^2.55.0
-        version: 2.55.0(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.53.12)(typescript@5.9.3)(vite@8.0.9(@types/node@22.19.15)(sass@1.98.0)(stylus@0.64.0)(yaml@2.8.2))
+        specifier: https://pkg.pr.new/@sveltejs/kit@6fbbb7d
+        version: https://pkg.pr.new/@sveltejs/kit@6fbbb7d(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.53.12)(typescript@5.9.3)(vite@8.0.9(@types/node@22.19.15)(sass@1.98.0)(stylus@0.64.0)(yaml@2.8.2))
       '@sveltejs/vite-plugin-svelte':
         specifier: workspace:^
         version: link:../../vite-plugin-svelte
@@ -480,10 +480,10 @@ importers:
     devDependencies:
       '@sveltejs/adapter-node':
         specifier: ^5.4.0
-        version: 5.5.4(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.53.12)(typescript@5.9.3)(vite@8.0.9(@types/node@22.19.15)(sass@1.98.0)(stylus@0.64.0)(yaml@2.8.2)))
+        version: 5.5.4(@sveltejs/kit@https://pkg.pr.new/@sveltejs/kit@6fbbb7d(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.53.12)(typescript@5.9.3)(vite@8.0.9(@types/node@22.19.15)(sass@1.98.0)(stylus@0.64.0)(yaml@2.8.2)))
       '@sveltejs/kit':
-        specifier: ^2.55.0
-        version: 2.55.0(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.53.12)(typescript@5.9.3)(vite@8.0.9(@types/node@22.19.15)(sass@1.98.0)(stylus@0.64.0)(yaml@2.8.2))
+        specifier: https://pkg.pr.new/@sveltejs/kit@6fbbb7d
+        version: https://pkg.pr.new/@sveltejs/kit@6fbbb7d(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.53.12)(typescript@5.9.3)(vite@8.0.9(@types/node@22.19.15)(sass@1.98.0)(stylus@0.64.0)(yaml@2.8.2))
       '@sveltejs/package':
         specifier: ^2.5.7
         version: 2.5.7(svelte@5.53.12)(typescript@5.9.3)
@@ -1515,8 +1515,9 @@ packages:
 
   '@sveltejs/adapter-node@5.5.4':
     resolution: {integrity: sha512-45X92CXW+2J8ZUzPv3eLlKWEzINKiiGeFWTjyER4ZN4sGgNoaoeSkCY/QYNxHpPXy71QPsctwccBo9jJs0ySPQ==}
+    version: 5.5.4
     peerDependencies:
-      '@sveltejs/kit': ^2.55.0
+      '@sveltejs/kit': ^2.4.0
 
   '@sveltejs/eslint-config@9.0.0':
     resolution: {integrity: sha512-3u9VUYlU0Mc/8Bhc7eRAPgJuUBMaKHzoE8r50WrnVujoxBLW4zfPckR/BFGGNeVUh0F7QGAtxGkV/5pL6CE1Ng==}
@@ -1530,15 +1531,16 @@ packages:
       typescript: '>= 5'
       typescript-eslint: '>= 8'
 
-  '@sveltejs/kit@2.55.0':
-    resolution: {integrity: sha512-MdFRjevVxmAknf2NbaUkDF16jSIzXMWd4Nfah0Qp8TtQVoSp3bV4jKt8mX7z7qTUTWvgSaxtR0EG5WJf53gcuA==}
+  '@sveltejs/kit@https://pkg.pr.new/@sveltejs/kit@6fbbb7d':
+    resolution: {integrity: sha512-rEM9N1/ZvXyQ0DxMpINFwsZNc3nF1OSENP4YM+RLtp6oyKdnMTufj4PFcaPyxbZ8LHQDGvX5R1tWIkKVZIwhEQ==, tarball: https://pkg.pr.new/@sveltejs/kit@6fbbb7d}
+    version: 2.59.0
     engines: {node: '>=18.13'}
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': ^1.0.0
       '@sveltejs/vite-plugin-svelte': workspace:^
       svelte: ^5.46.4
-      typescript: ^5.3.3
+      typescript: ^5.3.3 || ^6.0.0
       vite: ^8.0.9
     peerDependenciesMeta:
       '@opentelemetry/api':
@@ -4318,12 +4320,12 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  '@sveltejs/adapter-node@5.5.4(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.53.12)(typescript@5.9.3)(vite@8.0.9(@types/node@22.19.15)(sass@1.98.0)(stylus@0.64.0)(yaml@2.8.2)))':
+  '@sveltejs/adapter-node@5.5.4(@sveltejs/kit@https://pkg.pr.new/@sveltejs/kit@6fbbb7d(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.53.12)(typescript@5.9.3)(vite@8.0.9(@types/node@22.19.15)(sass@1.98.0)(stylus@0.64.0)(yaml@2.8.2)))':
     dependencies:
       '@rollup/plugin-commonjs': 29.0.2(rollup@4.59.0)
       '@rollup/plugin-json': 6.1.0(rollup@4.59.0)
       '@rollup/plugin-node-resolve': 16.0.3(rollup@4.59.0)
-      '@sveltejs/kit': 2.55.0(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.53.12)(typescript@5.9.3)(vite@8.0.9(@types/node@22.19.15)(sass@1.98.0)(stylus@0.64.0)(yaml@2.8.2))
+      '@sveltejs/kit': https://pkg.pr.new/@sveltejs/kit@6fbbb7d(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.53.12)(typescript@5.9.3)(vite@8.0.9(@types/node@22.19.15)(sass@1.98.0)(stylus@0.64.0)(yaml@2.8.2))
       rollup: 4.59.0
 
   '@sveltejs/eslint-config@9.0.0(@eslint/js@10.0.1(eslint@10.0.3))(@stylistic/eslint-plugin-js@4.4.1(eslint@10.0.3))(eslint-config-prettier@10.1.8(eslint@10.0.3))(eslint-plugin-n@17.24.0(eslint@10.0.3)(typescript@5.9.3))(eslint-plugin-svelte@3.15.2(eslint@10.0.3)(svelte@5.53.12))(eslint@10.0.3)(typescript-eslint@8.57.0(eslint@10.0.3)(typescript@5.9.3))(typescript@5.9.3)':
@@ -4338,7 +4340,7 @@ snapshots:
       typescript: 5.9.3
       typescript-eslint: 8.57.0(eslint@10.0.3)(typescript@5.9.3)
 
-  '@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.53.12)(typescript@5.9.3)(vite@8.0.9(@types/node@22.19.15)(sass@1.98.0)(stylus@0.64.0)(yaml@2.8.2))':
+  '@sveltejs/kit@https://pkg.pr.new/@sveltejs/kit@6fbbb7d(@sveltejs/vite-plugin-svelte@packages+vite-plugin-svelte)(svelte@5.53.12)(typescript@5.9.3)(vite@8.0.9(@types/node@22.19.15)(sass@1.98.0)(stylus@0.64.0)(yaml@2.8.2))':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@sveltejs/acorn-typescript': 1.0.9(acorn@8.16.0)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,12 +3,6 @@ packages:
   - 'packages/e2e-tests/*'
   - 'packages/e2e-tests/_test_dependencies/*'
 
-# pnpm catalogs are currently only suitable for dependencies that
-# wouldn't require publishing a new package version
-# see https://github.com/changesets/changesets/issues/1707
-catalog:
-  vite: ^8.0.9
-
 # package resolution settings
 minimumReleaseAge: 4320 #3 days
 
@@ -62,6 +56,13 @@ overrides:
   '@types/node@<=20.12.0': '20.19.14'
   'send@<0.19.0': '^0.19.1'
   '@sveltejs/kit>cookie@<0.7.0': '^0.7.2'
+
+# pnpm catalogs are currently only suitable for dependencies that
+# wouldn't require publishing a new package version
+# see https://github.com/changesets/changesets/issues/1707
+catalog:
+  '@sveltejs/kit': ^2.59.1
+  vite: ^8.0.9
 
 # needed for _test_dependencies
 dedupeInjectedDeps: false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -58,6 +58,7 @@ overrides:
   '@sveltejs/kit>@sveltejs/vite-plugin-svelte': 'workspace:^'
   '@sveltejs/vite-plugin-svelte': 'workspace:^'
   'svelte': '$svelte'
+  'vite': '$vite'
   '@types/node@<=20.12.0': '20.19.14'
   'send@<0.19.0': '^0.19.1'
   '@sveltejs/kit>cookie@<0.7.0': '^0.7.2'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -58,7 +58,6 @@ overrides:
   '@sveltejs/kit>@sveltejs/vite-plugin-svelte': 'workspace:^'
   '@sveltejs/vite-plugin-svelte': 'workspace:^'
   'svelte': '$svelte'
-  'vite': '$vite'
   '@types/node@<=20.12.0': '20.19.14'
   'send@<0.19.0': '^0.19.1'
   '@sveltejs/kit>cookie@<0.7.0': '^0.7.2'


### PR DESCRIPTION
building on top of https://github.com/sveltejs/vite-plugin-svelte/pull/1185

This PR ensures Svelte works correctly if the Vite dev server is in "full-bundle mode" (`optimizeDeps` on everything) such as when Cloudflare's Vite plugin is added. It ensures the dev server doesn't reload on initial page request and that Svelte is always bundled on the server unless specifically excluded.

The difference between this and the previous PR is an attempt to address Dominik's two concerns:
1. Instead of simply copying the client optimized deps, we are also including server-only Svelte exports
2. Moving the configuration from the setup plugin to the optimize plugin