### PR TITLE
fix: use correct pnpm catalog syntax

### DIFF
--- a/packages/e2e-tests/autoprefixer-browerslist/package.json
+++ b/packages/e2e-tests/autoprefixer-browerslist/package.json
@@ -17,7 +17,7 @@
     "postcss-load-config": "^6.0.1",
     "svelte": "^5.45.4",
     "svelte-preprocess": "^6.0.3",
-    "vite": ":catalog"
+    "vite": "catalog:"
   },
   "type": "module"
 }

--- a/packages/e2e-tests/build-multiple/package.json
+++ b/packages/e2e-tests/build-multiple/package.json
@@ -11,6 +11,6 @@
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "workspace:^",
     "svelte": "^5.45.4",
-    "vite": ":catalog"
+    "vite": "catalog:"
   }
 }

--- a/packages/e2e-tests/build-watch/package.json
+++ b/packages/e2e-tests/build-watch/package.json
@@ -16,7 +16,7 @@
     "e2e-test-dep-vite-plugins": "file:../_test_dependencies/vite-plugins",
     "node-fetch": "^3.3.2",
     "svelte": "^5.45.4",
-    "vite": ":catalog"
+    "vite": "catalog:"
   },
   "type": "module"
 }

--- a/packages/e2e-tests/configfile-custom/package.json
+++ b/packages/e2e-tests/configfile-custom/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "workspace:^",
     "svelte": "^5.45.4",
-    "vite": ":catalog"
+    "vite": "catalog:"
   },
   "type": "module"
 }

--- a/packages/e2e-tests/configfile-esm/package.json
+++ b/packages/e2e-tests/configfile-esm/package.json
@@ -14,7 +14,7 @@
     "@sveltejs/vite-plugin-svelte": "workspace:^",
     "svelte": "^5.45.4",
     "svelte-preprocess": "^6.0.3",
-    "vite": ":catalog"
+    "vite": "catalog:"
   },
   "type": "module"
 }

--- a/packages/e2e-tests/css-dev-sourcemap/package.json
+++ b/packages/e2e-tests/css-dev-sourcemap/package.json
@@ -12,6 +12,6 @@
     "@sveltejs/vite-plugin-svelte": "workspace:^",
     "sass": "^1.94.2",
     "svelte": "^5.45.4",
-    "vite": ":catalog"
+    "vite": "catalog:"
   }
 }

--- a/packages/e2e-tests/css-treeshake/package.json
+++ b/packages/e2e-tests/css-treeshake/package.json
@@ -12,6 +12,6 @@
     "@sveltejs/vite-plugin-svelte": "workspace:^",
     "sass": "^1.94.2",
     "svelte": "^5.45.4",
-    "vite": ":catalog"
+    "vite": "catalog:"
   }
 }

--- a/packages/e2e-tests/custom-extensions/package.json
+++ b/packages/e2e-tests/custom-extensions/package.json
@@ -10,7 +10,7 @@
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "workspace:^",
     "svelte": "^5.45.4",
-    "vite": ":catalog"
+    "vite": "catalog:"
   },
   "type": "module"
 }

--- a/packages/e2e-tests/dynamic-compile-options/package.json
+++ b/packages/e2e-tests/dynamic-compile-options/package.json
@@ -10,7 +10,7 @@
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "workspace:^",
     "svelte": "^5.45.4",
-    "vite": ":catalog"
+    "vite": "catalog:"
   },
   "type": "module"
 }

--- a/packages/e2e-tests/env/package.json
+++ b/packages/e2e-tests/env/package.json
@@ -10,7 +10,7 @@
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "workspace:^",
     "svelte": "^5.45.4",
-    "vite": ":catalog"
+    "vite": "catalog:"
   },
   "type": "module"
 }

--- a/packages/e2e-tests/hmr-css-first/package.json
+++ b/packages/e2e-tests/hmr-css-first/package.json
@@ -10,7 +10,7 @@
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "workspace:^",
     "svelte": "^5.45.4",
-    "vite": ":catalog"
+    "vite": "catalog:"
   },
   "type": "module"
 }

--- a/packages/e2e-tests/hmr/package.json
+++ b/packages/e2e-tests/hmr/package.json
@@ -15,7 +15,7 @@
     "e2e-test-dep-vite-plugins": "file:../_test_dependencies/vite-plugins",
     "node-fetch": "^3.3.2",
     "svelte": "^5.45.4",
-    "vite": ":catalog"
+    "vite": "catalog:"
   },
   "type": "module"
 }

--- a/packages/e2e-tests/import-queries/package.json
+++ b/packages/e2e-tests/import-queries/package.json
@@ -12,6 +12,6 @@
     "@sveltejs/vite-plugin-svelte": "workspace:^",
     "sass": "^1.94.2",
     "svelte": "^5.45.4",
-    "vite": ":catalog"
+    "vite": "catalog:"
   }
 }

--- a/packages/e2e-tests/inspector-kit/package.json
+++ b/packages/e2e-tests/inspector-kit/package.json
@@ -11,7 +11,7 @@
     "@sveltejs/kit": "^2.55.0",
     "@sveltejs/vite-plugin-svelte": "workspace:^",
     "svelte": "^5.45.4",
-    "vite": ":catalog"
+    "vite": "catalog:"
   },
   "type": "module"
 }

--- a/packages/e2e-tests/inspector-vite/package.json
+++ b/packages/e2e-tests/inspector-vite/package.json
@@ -11,6 +11,6 @@
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "workspace:^",
     "svelte": "^5.45.4",
-    "vite": ":catalog"
+    "vite": "catalog:"
   }
 }

--- a/packages/e2e-tests/kit-async/package.json
+++ b/packages/e2e-tests/kit-async/package.json
@@ -19,6 +19,6 @@
     "svelte": "^5.45.4",
     "svelte-check": "^4.3.4",
     "typescript": "^5.9.3",
-    "vite": ":catalog"
+    "vite": "catalog:"
   }
 }

--- a/packages/e2e-tests/kit-node/package.json
+++ b/packages/e2e-tests/kit-node/package.json
@@ -26,7 +26,7 @@
     "svelte-i18n": "^4.0.1",
     "tiny-glob": "^0.2.9",
     "typescript": "^5.9.3",
-    "vite": ":catalog"
+    "vite": "catalog:"
   },
   "type": "module"
 }

--- a/packages/e2e-tests/package-json-svelte-field/package.json
+++ b/packages/e2e-tests/package-json-svelte-field/package.json
@@ -15,7 +15,7 @@
     "@sveltejs/vite-plugin-svelte": "workspace:^",
     "sass": "^1.94.2",
     "svelte": "^5.45.4",
-    "vite": ":catalog"
+    "vite": "catalog:"
   },
   "type": "module"
 }

--- a/packages/e2e-tests/prebundle-svelte-deps/package.json
+++ b/packages/e2e-tests/prebundle-svelte-deps/package.json
@@ -21,6 +21,6 @@
     "sass": "^1.94.2",
     "svelte": "^5.45.4",
     "svelte-preprocess": "^6.0.3",
-    "vite": ":catalog"
+    "vite": "catalog:"
   }
 }

--- a/packages/e2e-tests/preprocess-with-vite/package.json
+++ b/packages/e2e-tests/preprocess-with-vite/package.json
@@ -14,7 +14,7 @@
     "sass": "^1.94.2",
     "stylus": "^0.64.0",
     "svelte": "^5.45.4",
-    "vite": ":catalog"
+    "vite": "catalog:"
   },
   "type": "module"
 }

--- a/packages/e2e-tests/resolve-exports-svelte/package.json
+++ b/packages/e2e-tests/resolve-exports-svelte/package.json
@@ -14,6 +14,6 @@
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "workspace:^",
     "svelte": "^5.45.4",
-    "vite": ":catalog"
+    "vite": "catalog:"
   }
 }

--- a/packages/e2e-tests/scan-deps/package.json
+++ b/packages/e2e-tests/scan-deps/package.json
@@ -11,6 +11,6 @@
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "workspace:^",
     "svelte": "^5.45.4",
-    "vite": ":catalog"
+    "vite": "catalog:"
   }
 }

--- a/packages/e2e-tests/svelte-preprocess/package.json
+++ b/packages/e2e-tests/svelte-preprocess/package.json
@@ -13,7 +13,7 @@
     "svelte": "^5.45.4",
     "svelte-preprocess": "^6.0.3",
     "typescript": "^5.9.3",
-    "vite": ":catalog"
+    "vite": "catalog:"
   },
   "type": "module"
 }

--- a/packages/e2e-tests/ts-type-import/package.json
+++ b/packages/e2e-tests/ts-type-import/package.json
@@ -13,7 +13,7 @@
     "@types/node": "^22.19.1",
     "svelte": "^5.45.4",
     "svelte-preprocess": "^6.0.3",
-    "vite": ":catalog"
+    "vite": "catalog:"
   },
   "type": "module"
 }

--- a/packages/e2e-tests/vite-ssr-esm/package.json
+++ b/packages/e2e-tests/vite-ssr-esm/package.json
@@ -18,6 +18,6 @@
     "polka": "1.0.0-next.28",
     "sirv": "^3.0.2",
     "svelte": "^5.45.4",
-    "vite": ":catalog"
+    "vite": "catalog:"
   }
 }

--- a/packages/vite-plugin-svelte/package.json
+++ b/packages/vite-plugin-svelte/package.json
@@ -51,6 +51,6 @@
     "@types/debug": "^4.1.12",
     "sass": "^1.94.2",
     "svelte": "^5.45.4",
-    "vite": ":catalog"
+    "vite": "catalog:"
   }
 }


### PR DESCRIPTION
It's `catalog:` not `:catalog` 🤦🏼 this should fix our ecosystem CI failures