### PR TITLE
fix(vitePreprocess): preserve value imports for transformWithOxc

### DIFF
--- a/.changeset/preprocess-oxc-imports.md
+++ b/.changeset/preprocess-oxc-imports.md
@@ -1,0 +1,5 @@
+---
+
+## '@sveltejs/vite-plugin-svelte': patch
+
+Pass `typescript.onlyRemoveTypeImports` to `transformWithOxc` in `vitePreprocess` so value imports are not dropped when they are only referenced in Svelte template markup ([1313](https://github.com/sveltejs/vite-plugin-svelte/issues/1313)).

--- a/.changeset/preprocess-oxc-imports.md
+++ b/.changeset/preprocess-oxc-imports.md
@@ -1,5 +1,5 @@
 ---
+'@sveltejs/vite-plugin-svelte': patch
+---
 
-## '@sveltejs/vite-plugin-svelte': patch
-
-Pass `typescript.onlyRemoveTypeImports` to `transformWithOxc` in `vitePreprocess` so value imports are not dropped when they are only referenced in Svelte template markup ([1313](https://github.com/sveltejs/vite-plugin-svelte/issues/1313)).
+fix: pass `typescript.onlyRemoveTypeImports` to `transformWithOxc` in `vitePreprocess` so that value imports are not dropped when they are only referenced in Svelte template markup

--- a/packages/e2e-tests/preprocess-with-vite/__tests__/preprocess-with-vite.spec.ts
+++ b/packages/e2e-tests/preprocess-with-vite/__tests__/preprocess-with-vite.spec.ts
@@ -10,6 +10,10 @@ test('should render App', async () => {
 	expect(await getText('#enum')).toBe('qoox');
 });
 
+test('should keep value imports used only in Svelte template after vitePreprocess (OXC)', async () => {
+	expect(await getText('#template-only-import')).toBe('template-only-import-preserved');
+});
+
 test('should not mangle code from esbuild pure annotations', async () => {
 	expect(browserLogs.some((log) => log.startsWith('pure test 1'))).toBe(true);
 	expect(browserLogs.some((log) => log.startsWith('pure test 2'))).toBe(true);

--- a/packages/e2e-tests/preprocess-with-vite/src/App.svelte
+++ b/packages/e2e-tests/preprocess-with-vite/src/App.svelte
@@ -2,6 +2,7 @@
 	import Foo from './Foo.svelte';
 	import Bar from './Bar.svelte';
 	import Preprocess from './Preprocess.svelte';
+	import TemplateOnlyImport from './TemplateOnlyImport.svelte';
 	export let hello: string;
 	const world: string = 'world'; // edit world and save to see hmr update
 	enum Baz {
@@ -17,6 +18,7 @@
 <p id="enum">{qoox}</p>
 
 <Preprocess />
+<TemplateOnlyImport />
 
 <style lang="scss">
 	@use 'sass:color';

--- a/packages/e2e-tests/preprocess-with-vite/src/TemplateOnlyImport.svelte
+++ b/packages/e2e-tests/preprocess-with-vite/src/TemplateOnlyImport.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	// templateOnlyMarker is intentionally not referenced in this script block;
+	// it is only used in the template below. vitePreprocess must not strip this import.
+	import { templateOnlyMarker } from './types.ts';
+</script>
+
+<p id="template-only-import">{templateOnlyMarker}</p>

--- a/packages/e2e-tests/preprocess-with-vite/src/types.ts
+++ b/packages/e2e-tests/preprocess-with-vite/src/types.ts
@@ -1,1 +1,4 @@
 export type Hello = 'Hello';
+
+/** Value only referenced from Svelte template markup (not from script). Regression #1313. */
+export const templateOnlyMarker = 'template-only-import-preserved';

--- a/packages/vite-plugin-svelte/src/preprocess.js
+++ b/packages/vite-plugin-svelte/src/preprocess.js
@@ -49,15 +49,12 @@ function viteScript() {
 			const lang = /** @type {'ts'} */ (attributes.lang);
 			const { code, map } = await transformWithOxc(content, filename, {
 				lang,
-				target: 'esnext'
-				// TODO, how to pass tsconfig compilerOptions (or not needed as config is loaded for file
-				/*tsconfigRaw: {
-					compilerOptions: {
-						// svelte typescript needs this flag to work with type imports
-						importsNotUsedAsValues: 'preserve',
-						preserveValueImports: true
-					}
-				}*/
+				target: 'esnext',
+				// OXC cannot see the Svelte template, so it must not strip value imports that look
+				// unused in the script but are referenced in markup (fixes e.g. sveltejs/vite-plugin-svelte#1313).
+				typescript: {
+					onlyRemoveTypeImports: true
+				}
 			});
 
 			mapToRelative(map, filename);


### PR DESCRIPTION
Pass `typescript.onlyRemoveTypeImports` so OXC does not drop imports that appear unused in the script but are referenced in Svelte template markup.

Fixes #1313