### PR TITLE
chore: remove `send` override

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,6 @@ overrides:
   svelte: ^5.46.4
   vite: ^8.0.9
   '@types/node@<=20.12.0': 20.19.39
-  send@<0.19.0: ^0.19.1
   '@sveltejs/kit>cookie@<0.7.0': ^0.7.2
 
 importers:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -54,7 +54,6 @@ overrides:
   'svelte': '$svelte'
   'vite': '$vite'
   '@types/node@<=20.12.0': '20.19.39'
-  'send@<0.19.0': '^0.19.1'
   '@sveltejs/kit>cookie@<0.7.0': '^0.7.2'
 
 # pnpm catalogs are currently only suitable for dependencies that


### PR DESCRIPTION
No idea when `send` was used or if it was ever a transitive dep we had, but I can't find any mention of it in the pnpm lock file aside from the override. Might as well remove it