### PR TITLE
fix: always retrieve CSS using component filename first

### DIFF
--- a/.changeset/full-steaks-cry.md
+++ b/.changeset/full-steaks-cry.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+fix: correctly resolve compiled CSS on the server for dependencies with Svelte files

--- a/packages/vite-plugin-svelte/src/plugins/load-compiled-css.js
+++ b/packages/vite-plugin-svelte/src/plugins/load-compiled-css.js
@@ -40,12 +40,10 @@ export function loadCompiledCss(api) {
 					return;
 				}
 
-				// node_modules svelte files will have their filename as the module ID...
 				let cachedCss = this.getModuleInfo(svelteRequest.filename)?.meta.svelte?.css;
 				if (!cachedCss) {
-					// ...but user files, which are prone to changes, have a ?v=... query
-					// string suffix on the server so that they can be easily invalidated.
-					// We can get this unique module ID by running resolve again
+					// some module IDs have a ?v=... query string suffix in addition to the
+					// filename. We can retrieve this by running resolve again
 					const resolvedId = await this.resolve(svelteRequest.filename);
 					if (resolvedId?.id) {
 						cachedCss = this.getModuleInfo(resolvedId.id)?.meta.svelte?.css;

--- a/packages/vite-plugin-svelte/src/plugins/load-compiled-css.js
+++ b/packages/vite-plugin-svelte/src/plugins/load-compiled-css.js
@@ -39,18 +39,26 @@ export function loadCompiledCss(api) {
 				if (!svelteRequest) {
 					return;
 				}
-				// we need to re-resolve the ID in case the dep has been optimised by Vite
-				// since it would now have a ?v=... query string suffix
-				const resolvedId = await this.resolve(svelteRequest.filename);
-				const moduleId = resolvedId?.id ?? svelteRequest.filename;
-				let cachedCss = this.getModuleInfo(moduleId)?.meta.svelte?.css;
+
+				// node_modules svelte files will have their filename as the module ID...
+				let cachedCss = this.getModuleInfo(svelteRequest.filename)?.meta.svelte?.css;
+				if (!cachedCss) {
+					// ...but user files, which are prone to changes, have a ?v=... query
+					// string suffix on the server so that they can be easily invalidated.
+					// We can get this unique module ID by running resolve again
+					const resolvedId = await this.resolve(svelteRequest.filename);
+					if (resolvedId?.id) {
+						cachedCss = this.getModuleInfo(resolvedId.id)?.meta.svelte?.css;
+					}
+				}
+
 				// in `build --watch` or dev ssr reloads getModuleInfo only returns changed module data.
 				// To ensure virtual css is loaded unchanged, we cache it here separately
 				if (useLocalCache) {
 					if (cachedCss) {
-						buildWatchCssCache.set(moduleId, cachedCss);
+						buildWatchCssCache.set(svelteRequest.filename, cachedCss);
 					} else {
-						cachedCss = buildWatchCssCache.get(moduleId);
+						cachedCss = buildWatchCssCache.get(svelteRequest.filename);
 					}
 				}
 


### PR DESCRIPTION
fixes the issue reported in https://github.com/sveltejs/vite-plugin-svelte/pull/1336#issuecomment-4386638546

This PR changes it so that we get the compiled CSS using the component filename first _then_ fallback to the optimised dep ID with the ?v= query string. For some reason, the inspector uses the former but not the latter.

Also, we should always cache using the component filename (without the unique query string)

No test because I can't figure out how to add one. I could only reproduce it in a fresh project with tailwindcss vite plugin + inspector enabled.