### PR TITLE
fix(inspector): activate under Vite+ by matching its client module path

### DIFF
--- a/.changeset/inspector-vite-plus-client.md
+++ b/.changeset/inspector-vite-plus-client.md
@@ -2,4 +2,4 @@
 '@sveltejs/vite-plugin-svelte': patch
 ---
 
-fix: activate the inspector under Vite+ by also matching its dev client module path (`dist/vite/client/client.mjs`)
+fix: ensure the inspector is injected into the client correctly for Vite+ projects

--- a/.changeset/inspector-vite-plus-client.md
+++ b/.changeset/inspector-vite-plus-client.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+fix: activate the inspector under Vite+ by also matching its dev client module path (`dist/vite/client/client.mjs`)

--- a/packages/vite-plugin-svelte/src/plugins/inspector/index.js
+++ b/packages/vite-plugin-svelte/src/plugins/inspector/index.js
@@ -115,7 +115,10 @@ export function svelteInspector(api) {
 			}
 		},
 		transform: {
-			filter: { id: /(?:vite\/dist|dist\/vite)\/client\/client\.mjs(?:\?|$)/ },
+			// Vite+ projects install vite@npm:@voidzero-dev/vite-plus-core@latest which
+			// changes the path from `vite/dist/client/client.mjs` to `vite/dist/vite/client/client.mjs`
+			// so we need to also account for the additional `vite` subdirectory
+			filter: { id: /vite\/dist\/(?:vite\/)?client\/client\.mjs(?:\?|$)/ },
 			handler(code) {
 				if (disabled) {
 					return;

--- a/packages/vite-plugin-svelte/src/plugins/inspector/index.js
+++ b/packages/vite-plugin-svelte/src/plugins/inspector/index.js
@@ -115,7 +115,7 @@ export function svelteInspector(api) {
 			}
 		},
 		transform: {
-			filter: { id: /vite\/dist\/client\/client\.mjs(?:\?|$)/ },
+			filter: { id: /(?:vite\/dist|dist\/vite)\/client\/client\.mjs(?:\?|$)/ },
 			handler(code) {
 				if (disabled) {
 					return;


### PR DESCRIPTION
## Problem
With `vitePlugin: { inspector: true }`, the Svelte Inspector doesn't activate under
[Vite+](https://viteplus.dev) — holding the toggle key (default Alt+X) does nothing.
The same config works under stock Vite.

## Cause
The inspector injects its runtime by appending an import to the dev client module,
matched by a path filter in `inspector/index.js`:

    filter: { id: /vite\/dist\/client\/client\.mjs(?:\?|$)/ }

This matches stock Vite's `…/vite/dist/client/client.mjs`. Vite+ resolves its client
to `…/@voidzero-dev/vite-plus-core/dist/vite/client/client.mjs`
(`CLIENT_ENTRY = path.join(VITE_PACKAGE_DIR, "dist/vite/client/client.mjs")`) — the
`vite` and `dist` segments are in the opposite order, so the filter doesn't match and
the loader import is never appended.

The client module still passes through the transform pipeline under Vite+ (only
`vite:dynamic-import-vars` / `vite:asset-import-meta-url` exclude it, as in stock
Vite), so widening the filter is enough.

## Change
Accept both segment orders:

    filter: { id: /(?:vite\/dist|dist\/vite)\/client\/client\.mjs(?:\?|$)/ }

## Verification
On a SvelteKit app running Vite+, `/@vite/client` then contains the injected
`load-inspector` import and the inspector mounts (Alt+X works). Stock Vite still
matches via the `vite/dist` branch.

This looked like the smallest change that covers it, and it held up in testing — but
whether to support Vite+, and how, is your call.
