### PR TITLE
chore: migrate to pnpm 11

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "prettier": "^3.7.3",
     "prettier-plugin-svelte": "^3.4.0",
     "publint": "^0.3.15",
+    "svelte": "catalog:",
     "svelte-eslint-parser": "^1.6.0",
     "tinyexec": "^1.1.2",
     "typescript": "^5.9.3",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@eslint/markdown": "^7.5.1",
     "@stylistic/eslint-plugin": "^5.10.0",
     "@sveltejs/eslint-config": "^10.0.0",
+    "@sveltejs/kit": "catalog:",
     "@svitejs/changesets-changelog-github-compact": "^1.2.0",
     "@types/node": "^20.19.39",
     "dts-buddy": "^0.8.0",
@@ -50,6 +51,7 @@
     "tinyexec": "^1.1.2",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.57.0",
+    "vite": "catalog:",
     "vitest": "^4.1.0"
   },
   "nano-staged": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "@eslint/markdown": "^7.5.1",
     "@stylistic/eslint-plugin": "^5.10.0",
     "@sveltejs/eslint-config": "^10.0.0",
-    "@sveltejs/kit": "catalog:",
     "@svitejs/changesets-changelog-github-compact": "^1.2.0",
     "@types/node": "^20.19.39",
     "dts-buddy": "^0.8.0",
@@ -38,7 +37,6 @@
     "eslint-plugin-n": "^17.24.0",
     "eslint-plugin-prettier": "^5.5.4",
     "eslint-plugin-svelte": "^3.15.2",
-    "tinyexec": "^1.1.2",
     "globals": "^17.0.0",
     "husky": "^9.1.7",
     "nano-staged": "^1.0.2",
@@ -47,11 +45,10 @@
     "prettier": "^3.7.3",
     "prettier-plugin-svelte": "^3.4.0",
     "publint": "^0.3.15",
-    "svelte": "^5.46.4",
     "svelte-eslint-parser": "^1.6.0",
+    "tinyexec": "^1.1.2",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.57.0",
-    "vite": "catalog:",
     "vitest": "^4.1.0"
   },
   "nano-staged": {
@@ -59,9 +56,8 @@
     "*": "prettier --cache --ignore-path .gitignore --ignore-unknown --write",
     "packages/*/src/**/*": "pnpm generate:types-staged"
   },
-  "packageManager": "pnpm@10.34.3",
+  "packageManager": "pnpm@11.6.0+sha512.9a36518224080c6fe5165afdcfe79bfa118c29be703f3f462b1e32efe1e98e47e8750b148e08286250aad4113cc7993ca413c4e2cd447752708c2ee5751bc95f",
   "engines": {
-    "pnpm": "^10.2.0",
     "node": "^20.19 || ^22.12 || >=24"
   }
 }

--- a/packages/e2e-tests/_test_dependencies/svelte-api-only/package.json
+++ b/packages/e2e-tests/_test_dependencies/svelte-api-only/package.json
@@ -15,6 +15,6 @@
   },
   "type": "module",
   "dependencies": {
-    "svelte": "^5.45.4"
+    "svelte": "catalog:"
   }
 }

--- a/packages/e2e-tests/_test_dependencies/svelte-api-only/package.json
+++ b/packages/e2e-tests/_test_dependencies/svelte-api-only/package.json
@@ -15,6 +15,6 @@
   },
   "type": "module",
   "dependencies": {
-    "svelte": "catalog:"
+    "svelte": "^5.56.3"
   }
 }

--- a/packages/e2e-tests/autoprefixer-browerslist/package.json
+++ b/packages/e2e-tests/autoprefixer-browerslist/package.json
@@ -15,7 +15,7 @@
     "autoprefixer": "^10.4.22",
     "postcss": "^8.5.6",
     "postcss-load-config": "^6.0.1",
-    "svelte": "^5.45.4",
+    "svelte": "catalog:",
     "svelte-preprocess": "^6.0.3",
     "vite": "catalog:"
   },

--- a/packages/e2e-tests/build-multiple/package.json
+++ b/packages/e2e-tests/build-multiple/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "workspace:^",
-    "svelte": "^5.45.4",
+    "svelte": "catalog:",
     "vite": "catalog:"
   }
 }

--- a/packages/e2e-tests/build-watch/package.json
+++ b/packages/e2e-tests/build-watch/package.json
@@ -15,7 +15,7 @@
     "@sveltejs/vite-plugin-svelte": "workspace:^",
     "e2e-test-dep-vite-plugins": "file:../_test_dependencies/vite-plugins",
     "node-fetch": "^3.3.2",
-    "svelte": "^5.45.4",
+    "svelte": "catalog:",
     "vite": "catalog:"
   },
   "type": "module"

--- a/packages/e2e-tests/configfile-custom/package.json
+++ b/packages/e2e-tests/configfile-custom/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "workspace:^",
-    "svelte": "^5.45.4",
+    "svelte": "catalog:",
     "vite": "catalog:"
   },
   "type": "module"

--- a/packages/e2e-tests/configfile-esm/package.json
+++ b/packages/e2e-tests/configfile-esm/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "workspace:^",
-    "svelte": "^5.45.4",
+    "svelte": "catalog:",
     "svelte-preprocess": "^6.0.3",
     "vite": "catalog:"
   },

--- a/packages/e2e-tests/css-dev-sourcemap/package.json
+++ b/packages/e2e-tests/css-dev-sourcemap/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "workspace:^",
     "sass": "^1.94.2",
-    "svelte": "^5.45.4",
+    "svelte": "catalog:",
     "vite": "catalog:"
   }
 }

--- a/packages/e2e-tests/css-treeshake/package.json
+++ b/packages/e2e-tests/css-treeshake/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "workspace:^",
     "sass": "^1.94.2",
-    "svelte": "^5.45.4",
+    "svelte": "catalog:",
     "vite": "catalog:"
   }
 }

--- a/packages/e2e-tests/custom-extensions/package.json
+++ b/packages/e2e-tests/custom-extensions/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "workspace:^",
-    "svelte": "^5.45.4",
+    "svelte": "catalog:",
     "vite": "catalog:"
   },
   "type": "module"

--- a/packages/e2e-tests/dynamic-compile-options/package.json
+++ b/packages/e2e-tests/dynamic-compile-options/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "workspace:^",
-    "svelte": "^5.45.4",
+    "svelte": "catalog:",
     "vite": "catalog:"
   },
   "type": "module"

--- a/packages/e2e-tests/e2e-server.js
+++ b/packages/e2e-tests/e2e-server.js
@@ -146,7 +146,6 @@ export async function serve(root, testMode, port) {
 			const buildProcess = x('pnpm', ['build'], {
 				nodeOptions: {
 					cwd: root,
-					stdio: 'pipe',
 					env: {
 						NODE_ENV: 'production'
 					}
@@ -156,6 +155,8 @@ export async function serve(root, testMode, port) {
 			logs.build = { out, err };
 			collectLogs(buildProcess.process, logs.build);
 			await buildProcess;
+			// first element is always the command that was run e.g., `$ pnpm build`
+			err.shift();
 		} catch (e) {
 			buildResult = e;
 			if (buildResult.stdout) {
@@ -176,8 +177,7 @@ export async function serve(root, testMode, port) {
 	if (testMode === 'build:watch') {
 		watchProcess = x('pnpm', ['build', '--watch'], {
 			nodeOptions: {
-				cwd: root,
-				stdio: 'pipe'
+				cwd: root
 			},
 			throwOnError: true
 		});
@@ -192,8 +192,7 @@ export async function serve(root, testMode, port) {
 		[testMode === 'serve' ? 'dev' : 'preview', '--port', port.toString(), '--strictPort'],
 		{
 			nodeOptions: {
-				cwd: root,
-				stdio: 'pipe'
+				cwd: root
 			},
 			throwOnError: true
 		}

--- a/packages/e2e-tests/env/package.json
+++ b/packages/e2e-tests/env/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "workspace:^",
-    "svelte": "^5.45.4",
+    "svelte": "catalog:",
     "vite": "catalog:"
   },
   "type": "module"

--- a/packages/e2e-tests/hmr-css-first/package.json
+++ b/packages/e2e-tests/hmr-css-first/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "workspace:^",
-    "svelte": "^5.45.4",
+    "svelte": "catalog:",
     "vite": "catalog:"
   },
   "type": "module"

--- a/packages/e2e-tests/hmr/package.json
+++ b/packages/e2e-tests/hmr/package.json
@@ -14,7 +14,7 @@
     "@sveltejs/vite-plugin-svelte": "workspace:^",
     "e2e-test-dep-vite-plugins": "file:../_test_dependencies/vite-plugins",
     "node-fetch": "^3.3.2",
-    "svelte": "^5.45.4",
+    "svelte": "catalog:",
     "vite": "catalog:"
   },
   "type": "module"

--- a/packages/e2e-tests/import-queries/package.json
+++ b/packages/e2e-tests/import-queries/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "workspace:^",
     "sass": "^1.94.2",
-    "svelte": "^5.45.4",
+    "svelte": "catalog:",
     "vite": "catalog:"
   }
 }

--- a/packages/e2e-tests/inspector-kit/package.json
+++ b/packages/e2e-tests/inspector-kit/package.json
@@ -10,7 +10,7 @@
   "devDependencies": {
     "@sveltejs/kit": "catalog:",
     "@sveltejs/vite-plugin-svelte": "workspace:^",
-    "svelte": "^5.45.4",
+    "svelte": "catalog:",
     "vite": "catalog:"
   },
   "type": "module"

--- a/packages/e2e-tests/inspector-vite/package.json
+++ b/packages/e2e-tests/inspector-vite/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "workspace:^",
-    "svelte": "^5.45.4",
+    "svelte": "catalog:",
     "vite": "catalog:"
   }
 }

--- a/packages/e2e-tests/kit-async/package.json
+++ b/packages/e2e-tests/kit-async/package.json
@@ -16,7 +16,7 @@
     "@sveltejs/adapter-node": "^5.4.0",
     "@sveltejs/kit": "catalog:",
     "@sveltejs/vite-plugin-svelte": "workspace:^",
-    "svelte": "^5.45.4",
+    "svelte": "catalog:",
     "svelte-check": "^4.3.4",
     "typescript": "^5.9.3",
     "vite": "catalog:"

--- a/packages/e2e-tests/kit-node/package.json
+++ b/packages/e2e-tests/kit-node/package.json
@@ -21,7 +21,7 @@
     "e2e-test-dep-svelte-nested-workspace-devdep": "link:../_test_dependencies/svelte-nested-workspace-devdep",
     "e2e-test-dep-vite-plugins": "file:../_test_dependencies/vite-plugins",
     "sass": "^1.94.2",
-    "svelte": "^5.45.4",
+    "svelte": "catalog:",
     "svelte-check": "^4.3.4",
     "svelte-i18n": "^4.0.1",
     "tiny-glob": "^0.2.9",

--- a/packages/e2e-tests/package-json-svelte-field/package.json
+++ b/packages/e2e-tests/package-json-svelte-field/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "workspace:^",
     "sass": "^1.94.2",
-    "svelte": "^5.45.4",
+    "svelte": "catalog:",
     "vite": "catalog:"
   },
   "type": "module"

--- a/packages/e2e-tests/prebundle-svelte-deps/package.json
+++ b/packages/e2e-tests/prebundle-svelte-deps/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "workspace:^",
     "sass": "^1.94.2",
-    "svelte": "^5.45.4",
+    "svelte": "catalog:",
     "svelte-preprocess": "^6.0.3",
     "vite": "catalog:"
   }

--- a/packages/e2e-tests/preprocess-with-vite/package.json
+++ b/packages/e2e-tests/preprocess-with-vite/package.json
@@ -13,7 +13,7 @@
     "magic-string": "^0.30.21",
     "sass": "^1.94.2",
     "stylus": "^0.64.0",
-    "svelte": "^5.45.4",
+    "svelte": "catalog:",
     "vite": "catalog:"
   },
   "type": "module"

--- a/packages/e2e-tests/resolve-exports-svelte/package.json
+++ b/packages/e2e-tests/resolve-exports-svelte/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "workspace:^",
-    "svelte": "^5.45.4",
+    "svelte": "catalog:",
     "vite": "catalog:"
   }
 }

--- a/packages/e2e-tests/scan-deps/package.json
+++ b/packages/e2e-tests/scan-deps/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "workspace:^",
-    "svelte": "^5.45.4",
+    "svelte": "catalog:",
     "vite": "catalog:"
   }
 }

--- a/packages/e2e-tests/svelte-preprocess/package.json
+++ b/packages/e2e-tests/svelte-preprocess/package.json
@@ -10,7 +10,7 @@
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "workspace:^",
     "sass": "^1.94.2",
-    "svelte": "^5.45.4",
+    "svelte": "catalog:",
     "svelte-preprocess": "^6.0.3",
     "typescript": "^5.9.3",
     "vite": "catalog:"

--- a/packages/e2e-tests/testUtils.ts
+++ b/packages/e2e-tests/testUtils.ts
@@ -382,7 +382,9 @@ function filterMessages(arr) {
 	}
 	const excludes = [];
 	excludes.push(
-		'`optimizeDeps.esbuildOptions`' //TODO: remove after sveltekit is updated
+		// somehow the command that was run is always the first log to stderr e.g., `$ vite preview`
+		'$ vite',
+		'$ svelte-kit sync'
 	);
 	if (excludes.length > 0) {
 		return arr.filter((m) => !excludes.some((e) => m.includes(e)));

--- a/packages/e2e-tests/ts-type-import/package.json
+++ b/packages/e2e-tests/ts-type-import/package.json
@@ -11,7 +11,7 @@
     "@sveltejs/vite-plugin-svelte": "workspace:^",
     "@tsconfig/svelte": "^5.0.6",
     "@types/node": "^22.19.1",
-    "svelte": "^5.45.4",
+    "svelte": "catalog:",
     "svelte-preprocess": "^6.0.3",
     "vite": "catalog:"
   },

--- a/packages/e2e-tests/vite-ssr-esm/package.json
+++ b/packages/e2e-tests/vite-ssr-esm/package.json
@@ -17,7 +17,7 @@
     "npm-run-all2": "^8.0.4",
     "polka": "1.0.0-next.28",
     "sirv": "^3.0.2",
-    "svelte": "^5.45.4",
+    "svelte": "catalog:",
     "vite": "catalog:"
   }
 }

--- a/packages/vite-plugin-svelte/package.json
+++ b/packages/vite-plugin-svelte/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "@types/debug": "^4.1.12",
     "sass": "^1.94.2",
-    "svelte": "^5.45.4",
+    "svelte": "catalog:",
     "vite": "catalog:"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   '@sveltejs/kit': ^2.59.1
   '@sveltejs/kit>@sveltejs/vite-plugin-svelte': workspace:^
   '@sveltejs/vite-plugin-svelte': workspace:^
-  svelte: ^5.46.4
+  svelte: ^5.56.3
   vite: ^8.0.9
   '@types/node@<=20.12.0': 20.19.43
   '@sveltejs/kit>cookie@<0.7.0': ^0.7.2
@@ -32,9 +32,6 @@ importers:
       '@sveltejs/eslint-config':
         specifier: ^10.0.0
         version: 10.0.1(@eslint/js@10.0.1(eslint@10.5.0))(@stylistic/eslint-plugin@5.10.0(eslint@10.5.0))(eslint-config-prettier@10.1.8(eslint@10.5.0))(eslint-plugin-n@17.24.0(eslint@10.5.0)(typescript@5.9.3))(eslint-plugin-svelte@3.19.0(eslint@10.5.0)(svelte@5.56.3(@typescript-eslint/types@8.61.0)))(eslint@10.5.0)(typescript-eslint@8.61.0(eslint@10.5.0)(typescript@5.9.3))(typescript@5.9.3)
-      '@sveltejs/kit':
-        specifier: ^2.59.1
-        version: 2.59.1(svelte@5.56.3(@typescript-eslint/types@8.61.0))(typescript@5.9.3)(vite@8.0.16(@types/node@20.19.43)(sass@1.101.0)(stylus@0.64.0)(yaml@2.8.2))
       '@svitejs/changesets-changelog-github-compact':
         specifier: ^1.2.0
         version: 1.2.0
@@ -83,9 +80,6 @@ importers:
       publint:
         specifier: ^0.3.15
         version: 0.3.21
-      svelte:
-        specifier: ^5.46.4
-        version: 5.56.3(@typescript-eslint/types@8.61.0)
       svelte-eslint-parser:
         specifier: ^1.6.0
         version: 1.8.0(svelte@5.56.3(@typescript-eslint/types@8.61.0))
@@ -98,9 +92,6 @@ importers:
       typescript-eslint:
         specifier: ^8.57.0
         version: 8.61.0(eslint@10.5.0)(typescript@5.9.3)
-      vite:
-        specifier: ^8.0.9
-        version: 8.0.16(@types/node@20.19.43)(sass@1.101.0)(stylus@0.64.0)(yaml@2.8.2)
       vitest:
         specifier: ^4.1.0
         version: 4.1.8(@types/node@20.19.43)(jsdom@26.1.0)(vite@8.0.16(@types/node@20.19.43)(sass@1.101.0)(stylus@0.64.0)(yaml@2.8.2))
@@ -130,7 +121,7 @@ importers:
   packages/e2e-tests/_test_dependencies/svelte-api-only:
     dependencies:
       svelte:
-        specifier: ^5.46.4
+        specifier: ^5.56.3
         version: 5.56.3(@typescript-eslint/types@8.61.0)
 
   packages/e2e-tests/_test_dependencies/svelte-exports-simple:
@@ -207,7 +198,7 @@ importers:
         specifier: ^6.0.1
         version: 6.0.1(postcss@8.5.15)(yaml@2.8.2)
       svelte:
-        specifier: ^5.46.4
+        specifier: ^5.56.3
         version: 5.56.3(@typescript-eslint/types@8.61.0)
       svelte-preprocess:
         specifier: ^6.0.3
@@ -222,7 +213,7 @@ importers:
         specifier: workspace:^
         version: link:../../vite-plugin-svelte
       svelte:
-        specifier: ^5.46.4
+        specifier: ^5.56.3
         version: 5.56.3(@typescript-eslint/types@8.61.0)
       vite:
         specifier: ^8.0.9
@@ -244,7 +235,7 @@ importers:
         specifier: ^3.3.2
         version: 3.3.2
       svelte:
-        specifier: ^5.46.4
+        specifier: ^5.56.3
         version: 5.56.3(@typescript-eslint/types@8.61.0)
       vite:
         specifier: ^8.0.9
@@ -260,7 +251,7 @@ importers:
         specifier: workspace:^
         version: link:../../vite-plugin-svelte
       svelte:
-        specifier: ^5.46.4
+        specifier: ^5.56.3
         version: 5.56.3(@typescript-eslint/types@8.61.0)
       vite:
         specifier: ^8.0.9
@@ -276,7 +267,7 @@ importers:
         specifier: workspace:^
         version: link:../../vite-plugin-svelte
       svelte:
-        specifier: ^5.46.4
+        specifier: ^5.56.3
         version: 5.56.3(@typescript-eslint/types@8.61.0)
       svelte-preprocess:
         specifier: ^6.0.3
@@ -294,7 +285,7 @@ importers:
         specifier: ^1.94.2
         version: 1.101.0
       svelte:
-        specifier: ^5.46.4
+        specifier: ^5.56.3
         version: 5.56.3(@typescript-eslint/types@8.61.0)
       vite:
         specifier: ^8.0.9
@@ -309,7 +300,7 @@ importers:
         specifier: ^1.94.2
         version: 1.101.0
       svelte:
-        specifier: ^5.46.4
+        specifier: ^5.56.3
         version: 5.56.3(@typescript-eslint/types@8.61.0)
       vite:
         specifier: ^8.0.9
@@ -321,7 +312,7 @@ importers:
         specifier: workspace:^
         version: link:../../vite-plugin-svelte
       svelte:
-        specifier: ^5.46.4
+        specifier: ^5.56.3
         version: 5.56.3(@typescript-eslint/types@8.61.0)
       vite:
         specifier: ^8.0.9
@@ -351,7 +342,7 @@ importers:
         specifier: workspace:^
         version: link:../../vite-plugin-svelte
       svelte:
-        specifier: ^5.46.4
+        specifier: ^5.56.3
         version: 5.56.3(@typescript-eslint/types@8.61.0)
       vite:
         specifier: ^8.0.9
@@ -363,7 +354,7 @@ importers:
         specifier: workspace:^
         version: link:../../vite-plugin-svelte
       svelte:
-        specifier: ^5.46.4
+        specifier: ^5.56.3
         version: 5.56.3(@typescript-eslint/types@8.61.0)
       vite:
         specifier: ^8.0.9
@@ -385,7 +376,7 @@ importers:
         specifier: ^3.3.2
         version: 3.3.2
       svelte:
-        specifier: ^5.46.4
+        specifier: ^5.56.3
         version: 5.56.3(@typescript-eslint/types@8.61.0)
       vite:
         specifier: ^8.0.9
@@ -397,7 +388,7 @@ importers:
         specifier: workspace:^
         version: link:../../vite-plugin-svelte
       svelte:
-        specifier: ^5.46.4
+        specifier: ^5.56.3
         version: 5.56.3(@typescript-eslint/types@8.61.0)
       vite:
         specifier: ^8.0.9
@@ -412,7 +403,7 @@ importers:
         specifier: ^1.94.2
         version: 1.101.0
       svelte:
-        specifier: ^5.46.4
+        specifier: ^5.56.3
         version: 5.56.3(@typescript-eslint/types@8.61.0)
       vite:
         specifier: ^8.0.9
@@ -427,7 +418,7 @@ importers:
         specifier: workspace:^
         version: link:../../vite-plugin-svelte
       svelte:
-        specifier: ^5.46.4
+        specifier: ^5.56.3
         version: 5.56.3(@typescript-eslint/types@8.61.0)
       vite:
         specifier: ^8.0.9
@@ -439,7 +430,7 @@ importers:
         specifier: workspace:^
         version: link:../../vite-plugin-svelte
       svelte:
-        specifier: ^5.46.4
+        specifier: ^5.56.3
         version: 5.56.3(@typescript-eslint/types@8.61.0)
       vite:
         specifier: ^8.0.9
@@ -457,7 +448,7 @@ importers:
         specifier: workspace:^
         version: link:../../vite-plugin-svelte
       svelte:
-        specifier: ^5.46.4
+        specifier: ^5.56.3
         version: 5.56.3(@typescript-eslint/types@8.61.0)
       svelte-check:
         specifier: ^4.3.4
@@ -496,7 +487,7 @@ importers:
         specifier: ^1.94.2
         version: 1.101.0
       svelte:
-        specifier: ^5.46.4
+        specifier: ^5.56.3
         version: 5.56.3(@typescript-eslint/types@8.61.0)
       svelte-check:
         specifier: ^4.3.4
@@ -530,7 +521,7 @@ importers:
         specifier: ^1.94.2
         version: 1.101.0
       svelte:
-        specifier: ^5.46.4
+        specifier: ^5.56.3
         version: 5.56.3(@typescript-eslint/types@8.61.0)
       vite:
         specifier: ^8.0.9
@@ -564,7 +555,7 @@ importers:
         specifier: ^1.94.2
         version: 1.101.0
       svelte:
-        specifier: ^5.46.4
+        specifier: ^5.56.3
         version: 5.56.3(@typescript-eslint/types@8.61.0)
       svelte-preprocess:
         specifier: ^6.0.3
@@ -591,7 +582,7 @@ importers:
         specifier: ^0.64.0
         version: 0.64.0
       svelte:
-        specifier: ^5.46.4
+        specifier: ^5.56.3
         version: 5.56.3(@typescript-eslint/types@8.61.0)
       vite:
         specifier: ^8.0.9
@@ -607,7 +598,7 @@ importers:
         specifier: workspace:^
         version: link:../../vite-plugin-svelte
       svelte:
-        specifier: ^5.46.4
+        specifier: ^5.56.3
         version: 5.56.3(@typescript-eslint/types@8.61.0)
       vite:
         specifier: ^8.0.9
@@ -619,7 +610,7 @@ importers:
         specifier: workspace:^
         version: link:../../vite-plugin-svelte
       svelte:
-        specifier: ^5.46.4
+        specifier: ^5.56.3
         version: 5.56.3(@typescript-eslint/types@8.61.0)
       vite:
         specifier: ^8.0.9
@@ -634,7 +625,7 @@ importers:
         specifier: ^1.94.2
         version: 1.101.0
       svelte:
-        specifier: ^5.46.4
+        specifier: ^5.56.3
         version: 5.56.3(@typescript-eslint/types@8.61.0)
       svelte-preprocess:
         specifier: ^6.0.3
@@ -658,7 +649,7 @@ importers:
         specifier: ^22.19.1
         version: 22.19.21
       svelte:
-        specifier: ^5.46.4
+        specifier: ^5.56.3
         version: 5.56.3(@typescript-eslint/types@8.61.0)
       svelte-preprocess:
         specifier: ^6.0.3
@@ -691,7 +682,7 @@ importers:
         specifier: ^3.0.2
         version: 3.0.2
       svelte:
-        specifier: ^5.46.4
+        specifier: ^5.56.3
         version: 5.56.3(@typescript-eslint/types@8.61.0)
       vite:
         specifier: ^8.0.9
@@ -719,7 +710,7 @@ importers:
         specifier: ^1.94.2
         version: 1.101.0
       svelte:
-        specifier: ^5.46.4
+        specifier: ^5.56.3
         version: 5.56.3(@typescript-eslint/types@8.61.0)
       vite:
         specifier: ^8.0.9
@@ -1528,7 +1519,7 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.0.0
       '@sveltejs/vite-plugin-svelte': workspace:^
-      svelte: ^5.46.4
+      svelte: ^5.56.3
       typescript: ^5.3.3 || ^6.0.0
       vite: ^8.0.9
     peerDependenciesMeta:
@@ -1546,7 +1537,7 @@ packages:
     engines: {node: ^16.14 || >=18}
     hasBin: true
     peerDependencies:
-      svelte: ^5.46.4
+      svelte: ^5.56.3
 
   '@svitejs/changesets-changelog-github-compact@1.2.0':
     resolution: {integrity: sha512-08eKiDAjj4zLug1taXSIJ0kGL5cawjVCyJkBb6EWSg5fEPX6L+Wtr0CH2If4j5KYylz85iaZiFlUItvgJvll5g==}
@@ -2092,7 +2083,7 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.1 || ^9.0.0 || ^10.0.0
-      svelte: ^5.46.4
+      svelte: ^5.56.3
     peerDependenciesMeta:
       svelte:
         optional: true
@@ -2981,7 +2972,7 @@ packages:
     resolution: {integrity: sha512-ItFouLvzSFE3ulNl4DKoWM3BGcbDCNVpIyy/Y3F2gC3aNiGLxtFUdffVqO5Z5hhYG+DFT5KULWaxmeFFpdbvaQ==}
     peerDependencies:
       prettier: ^3.0.0
-      svelte: ^5.46.4
+      svelte: ^5.56.3
 
   prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
@@ -3174,14 +3165,14 @@ packages:
     engines: {node: '>= 18.0.0'}
     hasBin: true
     peerDependencies:
-      svelte: ^5.46.4
+      svelte: ^5.56.3
       typescript: '>=5.0.0'
 
   svelte-eslint-parser@1.8.0:
     resolution: {integrity: sha512-mikR1qwIVy3t5WthUoAXkMwxkXvabZP9FJgdx35Ei7EbGWmctva1Pih16Koeor/bdNNq8NXHlwKGS6NkYTawLg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0, pnpm: 10.34.1}
     peerDependencies:
-      svelte: ^5.46.4
+      svelte: ^5.56.3
     peerDependenciesMeta:
       svelte:
         optional: true
@@ -3191,7 +3182,7 @@ packages:
     engines: {node: '>= 16'}
     hasBin: true
     peerDependencies:
-      svelte: ^5.46.4
+      svelte: ^5.56.3
 
   svelte-preprocess@6.0.5:
     resolution: {integrity: sha512-sgwew5yV/2eMeQobIWgAxCNarKwiTUDIc3siAUbq3sp0G6ONtzk0W+wJihMdqjbYb3iGU3ubpGv0usnnuXT3qg==}
@@ -3206,7 +3197,7 @@ packages:
       sass: ^1.26.8
       stylus: '>=0.55'
       sugarss: ^2.0.0 || ^3.0.0 || ^4.0.0
-      svelte: ^5.46.4
+      svelte: ^5.56.3
       typescript: ^5.0.0 || ^6.0.0
     peerDependenciesMeta:
       '@babel/core':
@@ -3233,7 +3224,7 @@ packages:
   svelte2tsx@0.7.56:
     resolution: {integrity: sha512-NTvqqL+goYlW8gWNajk81L07+uu7jw5V2m1Az5MZbYm3GEydcHXh+uTrLHM9SuGuaqCtF90vlMXkOVBotfH94g==}
     peerDependencies:
-      svelte: ^5.46.4
+      svelte: ^5.56.3
       typescript: ^4.9.4 || ^5.0.0 || ^6.0.0
 
   svelte@5.56.3:
@@ -4309,25 +4300,6 @@ snapshots:
       sirv: 3.0.2
       svelte: 5.56.3(@typescript-eslint/types@8.61.0)
       vite: 8.0.16(@types/node@22.19.21)(sass@1.101.0)(stylus@0.64.0)(yaml@2.8.2)
-    optionalDependencies:
-      typescript: 5.9.3
-
-  '@sveltejs/kit@2.59.1(svelte@5.56.3(@typescript-eslint/types@8.61.0))(typescript@5.9.3)(vite@8.0.16(@types/node@20.19.43)(sass@1.101.0)(stylus@0.64.0)(yaml@2.8.2))':
-    dependencies:
-      '@standard-schema/spec': 1.1.0
-      '@sveltejs/acorn-typescript': 1.0.10(acorn@8.17.0)
-      '@types/cookie': 0.6.0
-      acorn: 8.17.0
-      cookie: 0.7.2
-      devalue: 5.8.1
-      esm-env: 1.2.2
-      kleur: 4.1.5
-      magic-string: 0.30.21
-      mrmime: 2.0.1
-      set-cookie-parser: 3.0.1
-      sirv: 3.0.2
-      svelte: 5.56.3(@typescript-eslint/types@8.61.0)
-      vite: 8.0.16(@types/node@20.19.43)(sass@1.101.0)(stylus@0.64.0)(yaml@2.8.2)
     optionalDependencies:
       typescript: 5.9.3
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@sveltejs/eslint-config':
         specifier: ^10.0.0
         version: 10.0.1(@eslint/js@10.0.1(eslint@10.5.0))(@stylistic/eslint-plugin@5.10.0(eslint@10.5.0))(eslint-config-prettier@10.1.8(eslint@10.5.0))(eslint-plugin-n@17.24.0(eslint@10.5.0)(typescript@5.9.3))(eslint-plugin-svelte@3.19.0(eslint@10.5.0)(svelte@5.56.3(@typescript-eslint/types@8.61.0)))(eslint@10.5.0)(typescript-eslint@8.61.0(eslint@10.5.0)(typescript@5.9.3))(typescript@5.9.3)
+      '@sveltejs/kit':
+        specifier: ^2.59.1
+        version: 2.59.1(svelte@5.56.3(@typescript-eslint/types@8.61.0))(typescript@5.9.3)(vite@8.0.16(@types/node@20.19.43)(sass@1.101.0)(stylus@0.64.0)(yaml@2.8.2))
       '@svitejs/changesets-changelog-github-compact':
         specifier: ^1.2.0
         version: 1.2.0
@@ -95,6 +98,9 @@ importers:
       typescript-eslint:
         specifier: ^8.57.0
         version: 8.61.0(eslint@10.5.0)(typescript@5.9.3)
+      vite:
+        specifier: ^8.0.9
+        version: 8.0.16(@types/node@20.19.43)(sass@1.101.0)(stylus@0.64.0)(yaml@2.8.2)
       vitest:
         specifier: ^4.1.0
         version: 4.1.8(@types/node@20.19.43)(jsdom@26.1.0)(vite@8.0.16(@types/node@20.19.43)(sass@1.101.0)(stylus@0.64.0)(yaml@2.8.2))
@@ -4303,6 +4309,25 @@ snapshots:
       sirv: 3.0.2
       svelte: 5.56.3(@typescript-eslint/types@8.61.0)
       vite: 8.0.16(@types/node@22.19.21)(sass@1.101.0)(stylus@0.64.0)(yaml@2.8.2)
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@sveltejs/kit@2.59.1(svelte@5.56.3(@typescript-eslint/types@8.61.0))(typescript@5.9.3)(vite@8.0.16(@types/node@20.19.43)(sass@1.101.0)(stylus@0.64.0)(yaml@2.8.2))':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@sveltejs/acorn-typescript': 1.0.10(acorn@8.17.0)
+      '@types/cookie': 0.6.0
+      acorn: 8.17.0
+      cookie: 0.7.2
+      devalue: 5.8.1
+      esm-env: 1.2.2
+      kleur: 4.1.5
+      magic-string: 0.30.21
+      mrmime: 2.0.1
+      set-cookie-parser: 3.0.1
+      sirv: 3.0.2
+      svelte: 5.56.3(@typescript-eslint/types@8.61.0)
+      vite: 8.0.16(@types/node@20.19.43)(sass@1.101.0)(stylus@0.64.0)(yaml@2.8.2)
     optionalDependencies:
       typescript: 5.9.3
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       publint:
         specifier: ^0.3.15
         version: 0.3.21
+      svelte:
+        specifier: ^5.56.3
+        version: 5.56.3(@typescript-eslint/types@8.61.0)
       svelte-eslint-parser:
         specifier: ^1.6.0
         version: 1.8.0(svelte@5.56.3(@typescript-eslint/types@8.61.0))

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,14 +16,6 @@ minimumReleaseAgeExclude:
   - svelte-check
   - esm-env
 
-onlyBuiltDependencies:
-  - esbuild
-ignoredBuiltDependencies:
-  - '@parcel/watcher'
-  - 'carbon-components-svelte'
-  - 'es5-ext'
-  - 'svelte-preprocess'
-
 auditConfig:
   ignoreGhsas:
     - 'GHSA-67mh-4wv8-2f99'
@@ -33,12 +25,11 @@ auditConfig:
     - 'GHSA-f886-m6hf-6m8v' # belongs to an optional peer dependency of Vite
 
 overrides:
-  # $ prefixed package names take their version from root package.json - this is like catalogs but without them
-  '@sveltejs/kit': '$@sveltejs/kit'
+  '@sveltejs/kit': 'catalog:'
   '@sveltejs/kit>@sveltejs/vite-plugin-svelte': 'workspace:^'
   '@sveltejs/vite-plugin-svelte': 'workspace:^'
-  'svelte': '$svelte'
-  'vite': '$vite'
+  'svelte': 'catalog:'
+  'vite': 'catalog:'
   '@types/node@<=20.12.0': '20.19.43'
   '@sveltejs/kit>cookie@<0.7.0': '^0.7.2'
 
@@ -47,6 +38,7 @@ overrides:
 # see https://github.com/changesets/changesets/issues/1707
 catalog:
   '@sveltejs/kit': ^2.59.1
+  svelte: ^5.56.3
   vite: ^8.0.9
 
 # needed for _test_dependencies
@@ -61,3 +53,9 @@ shellEmulator: true
 # However, they do work and are valid options
 aggregateOutput: true
 reporter: append-only
+allowBuilds:
+  esbuild: true
+  '@parcel/watcher': false
+  carbon-components-svelte: false
+  es5-ext: false
+  svelte-preprocess: false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,6 +16,13 @@ minimumReleaseAgeExclude:
   - svelte-check
   - esm-env
 
+allowBuilds:
+  esbuild: true
+  '@parcel/watcher': false
+  carbon-components-svelte: false
+  es5-ext: false
+  svelte-preprocess: false
+
 auditConfig:
   ignoreGhsas:
     - 'GHSA-67mh-4wv8-2f99'
@@ -53,9 +60,3 @@ shellEmulator: true
 # However, they do work and are valid options
 aggregateOutput: true
 reporter: append-only
-allowBuilds:
-  esbuild: true
-  '@parcel/watcher': false
-  carbon-components-svelte: false
-  es5-ext: false
-  svelte-preprocess: false


### PR DESCRIPTION
pnpm 11 only works on node 22 or newer so we can't merge this until the min supported version is 22 or we just drop the 20 tests because most people would have upgraded already