### PR TITLE
Revert "feat: support `.svelte.mjs` and `.svelte.mts` files"

### DIFF
--- a/.changeset/real-insects-yell.md
+++ b/.changeset/real-insects-yell.md
@@ -1,5 +1,0 @@
----
-'@sveltejs/vite-plugin-svelte': minor
----
-
-feat: support `.svelte.mjs` and `.svelte.mts` files

--- a/docs/config.md
+++ b/docs/config.md
@@ -335,4 +335,4 @@ export default {
 - **Type** `CompileModuleOptions`
 - **Default:** `undefined`
 
-  set custom compile options for compilation of Svelte modules (`.svelte.js`, `.svelte.ts`, `.svelte.mjs`, and `.svelte.mts` files).
+  set custom compile options for compilation of Svelte modules (`.svelte.js` files).

--- a/packages/vite-plugin-svelte/__tests__/id.spec.js
+++ b/packages/vite-plugin-svelte/__tests__/id.spec.js
@@ -34,28 +34,20 @@ describe('buildIdFilter', () => {
 });
 
 describe('buildModuleIdFilter', () => {
-	it('default filter matches .svelte.*.js/ts/mjs/mts files', () => {
+	it('default filter matches .svelte.*.js/ts files', () => {
 		const filter = buildModuleIdFilter({});
 		expect(passes(filter, '/src/foo.svelte.js')).toBe(true);
 		expect(passes(filter, '/src/foo.svelte.ts')).toBe(true);
-		expect(passes(filter, '/src/foo.svelte.mjs')).toBe(true);
-		expect(passes(filter, '/src/foo.svelte.mts')).toBe(true);
 		expect(passes(filter, '/src/foo.svelte.test.js')).toBe(true);
 		expect(passes(filter, '/src/foo.svelte.test.ts')).toBe(true);
-		expect(passes(filter, '/src/foo.svelte.test.mjs')).toBe(true);
-		expect(passes(filter, '/src/foo.svelte.test.mts')).toBe(true);
 	});
 
-	it('default filter does not match \\0 tagged .svelte.*.js/ts/mjs/mts files', () => {
+	it('default filter does not match \\0 tagged .svelte.*.js/ts files', () => {
 		const filter = buildModuleIdFilter({});
 		expect(passes(filter, '\0/src/foo.svelte.js')).toBe(false);
 		expect(passes(filter, '\0/src/foo.svelte.ts')).toBe(false);
-		expect(passes(filter, '\0/src/foo.svelte.mjs')).toBe(false);
-		expect(passes(filter, '\0/src/foo.svelte.mts')).toBe(false);
 		expect(passes(filter, '\0/src/foo.svelte.test.js')).toBe(false);
 		expect(passes(filter, '\0/src/foo.svelte.test.ts')).toBe(false);
-		expect(passes(filter, '\0/src/foo.svelte.test.mjs')).toBe(false);
-		expect(passes(filter, '\0/src/foo.svelte.test.mts')).toBe(false);
 	});
 
 	it('default filter does not match files without .svelte.', () => {

--- a/packages/vite-plugin-svelte/src/plugins/setup-optimizer.js
+++ b/packages/vite-plugin-svelte/src/plugins/setup-optimizer.js
@@ -79,7 +79,7 @@ function rolldownOptimizerPlugin(api, consumer, components) {
 	const name = components ? optimizeSveltePluginName : optimizeSvelteModulePluginName;
 	const compileFn = components ? compileSvelte : compileSvelteModule;
 	const statsName = components ? 'prebundle library components' : 'prebundle library modules';
-	const includeRe = components ? /^[^?#]+\.svelte(?:[?#]|$)/ : /^[^?#]+\.svelte\.m?[jt]s(?:[?#]|$)/;
+	const includeRe = components ? /^[^?#]+\.svelte(?:[?#]|$)/ : /^[^?#]+\.svelte\.[jt]s(?:[?#]|$)/;
 	const generate = consumer === 'server' ? 'server' : 'client';
 	/** @type {StatCollection | undefined} */
 	let statsCollection;

--- a/packages/vite-plugin-svelte/src/public.d.ts
+++ b/packages/vite-plugin-svelte/src/public.d.ts
@@ -167,7 +167,7 @@ interface CompileModuleOptions {
 	infixes?: string[];
 	/**
 	 * module extensions
-	 * @default ['.ts','.js','.mjs']
+	 * @default ['.ts','.js']
 	 */
 	extensions?: string[];
 	include?: Arrayable<string | RegExp>;

--- a/packages/vite-plugin-svelte/src/utils/constants.js
+++ b/packages/vite-plugin-svelte/src/utils/constants.js
@@ -54,6 +54,6 @@ export const LINK_TRANSFORM_WITH_PLUGIN =
 
 export const DEFAULT_SVELTE_EXT = ['.svelte'];
 export const DEFAULT_SVELTE_MODULE_INFIX = ['.svelte.'];
-export const DEFAULT_SVELTE_MODULE_EXT = ['.js', '.ts', '.mjs', '.mts'];
+export const DEFAULT_SVELTE_MODULE_EXT = ['.js', '.ts'];
 
 export const SVELTE_VIRTUAL_STYLE_ID_REGEX = /[?&]svelte&type=style&lang.css$/;

--- a/packages/vite-plugin-svelte/types/index.d.ts
+++ b/packages/vite-plugin-svelte/types/index.d.ts
@@ -167,7 +167,7 @@ declare module '@sveltejs/vite-plugin-svelte' {
 		infixes?: string[];
 		/**
 		 * module extensions
-		 * @default ['.ts','.js','.mjs']
+		 * @default ['.ts','.js']
 		 */
 		extensions?: string[];
 		include?: Arrayable<string | RegExp>;


### PR DESCRIPTION
Reverts sveltejs/vite-plugin-svelte#1293. We shouldn't support `.mjs` and `.mts`, those file extensions should die