### PR TITLE
feat: context menu with component stack

### DIFF
--- a/.changeset/inspector-wrapper-chain.md
+++ b/.changeset/inspector-wrapper-chain.md
@@ -2,6 +2,4 @@
 '@sveltejs/vite-plugin-svelte': minor
 ---
 
-feat(inspector): add a wrapper-chain dropdown (alt-c) to jump to where a component is used
-
-While the inspector is active, `alt-c` enters "chain mode": clicking a node opens a dropdown of its wrapper chain — every ancestor `<Component>` with its exact `file:line` call site (walked from Svelte dev's `__svelte_meta.parent`). Hovering a row outlines that component's DOM; clicking opens it via the same `/__open-in-editor` call. `alt-x` keeps its original single-element behavior.
+feat(inspector): add a context menu with current component stack

--- a/.changeset/inspector-wrapper-chain.md
+++ b/.changeset/inspector-wrapper-chain.md
@@ -1,0 +1,7 @@
+---
+'@sveltejs/vite-plugin-svelte': minor
+---
+
+feat(inspector): add a wrapper-chain dropdown (alt-c) to jump to where a component is used
+
+While the inspector is active, `alt-c` enters "chain mode": clicking a node opens a dropdown of its wrapper chain — every ancestor `<Component>` with its exact `file:line` call site (walked from Svelte dev's `__svelte_meta.parent`). Hovering a row outlines that component's DOM; clicking opens it via the same `/__open-in-editor` call. `alt-x` keeps its original single-element behavior.

--- a/docs/inspector.md
+++ b/docs/inspector.md
@@ -1,8 +1,6 @@
 # Inspector
 
-`@sveltejs/vite-plugin-svelte-inspector` is a Vite plugin that adds a Svelte inspector in the browser. It shows the file location where the element under cursor is defined and you can click to quickly open your code editor at this location.
-
-While the inspector is active you can also press `alt-c` to open the **wrapper chain** of the selected node — a dropdown of every wrapping `<Component>` and the `file:line` where it is used, so you can jump to where a component is _used_, not just where the hovered element is defined.
+`@sveltejs/vite-plugin-svelte-inspector` is a Vite plugin that adds a Svelte inspector in the browser. It shows the file location where the element under cursor is defined and you can click to quickly open your code editor at this location, or right-click to show a context menu with additional options.
 
 Note that `@sveltejs/vite-plugin-svelte` needs to be installed as a peer dependency as the inspector brings in Svelte components to be compiled.
 

--- a/docs/inspector.md
+++ b/docs/inspector.md
@@ -2,6 +2,8 @@
 
 `@sveltejs/vite-plugin-svelte-inspector` is a Vite plugin that adds a Svelte inspector in the browser. It shows the file location where the element under cursor is defined and you can click to quickly open your code editor at this location.
 
+While the inspector is active you can also press `alt-c` to open the **wrapper chain** of the selected node — a dropdown of every wrapping `<Component>` and the `file:line` where it is used, so you can jump to where a component is _used_, not just where the hovered element is defined.
+
 Note that `@sveltejs/vite-plugin-svelte` needs to be installed as a peer dependency as the inspector brings in Svelte components to be compiled.
 
 ## Setup

--- a/docs/inspector.md
+++ b/docs/inspector.md
@@ -84,6 +84,13 @@ SVELTE_INSPECTOR_OPTIONS=true
 
   Define key to open the editor for the currently selected dom node.
 
+### openMenuKey
+
+- **Type:** `string`
+- **Default:** `' '`
+
+  Define key to open the context menu for the currently selected dom node.
+
 ### escapeKeys
 
 - **Type:** `string[]`

--- a/packages/e2e-tests/inspector-vite/__tests__/inspector.vite.spec.ts
+++ b/packages/e2e-tests/inspector-vite/__tests__/inspector.vite.spec.ts
@@ -11,6 +11,26 @@ describe('inspector-vite', () => {
 				.waitFor({ state: 'visible', timeout: isCI ? 2000 : 500 });
 			expect(await getEl('#svelte-inspector-toggle')).not.toBe(null);
 		});
+
+		it('should open the wrapper-chain dropdown for the clicked node', async () => {
+			// enter chain mode (alt-c). A synthetic keydown is dispatched because
+			// headless modifier+letter key synthesis is unreliable; it still runs
+			// through the real key handler.
+			await page.evaluate(() =>
+				document.body.dispatchEvent(
+					new KeyboardEvent('keydown', { key: 'c', code: 'KeyC', altKey: true, bubbles: true })
+				)
+			);
+			// click the <button> rendered by <Counter /> to open its wrapper chain
+			await page.locator('button', { hasText: 'Clicks' }).click();
+			const menu = page.locator('#svelte-inspector-menu');
+			await menu.waitFor({ state: 'visible', timeout: isCI ? 2000 : 1000 });
+			// the chain reaches the <Counter> call site in App.svelte, not just the
+			// button's own file — which the element location alone cannot provide
+			const text = await menu.innerText();
+			expect(text).toContain('Counter.svelte');
+			expect(text).toContain('App.svelte');
+		});
 	} else {
 		it('should not show inspector toggle during preview', async () => {
 			expect(await getEl('#svelte-inspector-toggle')).toBe(null);

--- a/packages/e2e-tests/inspector-vite/__tests__/inspector.vite.spec.ts
+++ b/packages/e2e-tests/inspector-vite/__tests__/inspector.vite.spec.ts
@@ -12,21 +12,18 @@ describe('inspector-vite', () => {
 			expect(await getEl('#svelte-inspector-toggle')).not.toBe(null);
 		});
 
-		it('should open the wrapper-chain dropdown for the clicked node', async () => {
-			// enter chain mode (alt-c). A synthetic keydown is dispatched because
-			// headless modifier+letter key synthesis is unreliable; it still runs
-			// through the real key handler.
+		it('should open a context menu', async () => {
 			await page.evaluate(() =>
 				document.body.dispatchEvent(
-					new KeyboardEvent('keydown', { key: 'c', code: 'KeyC', altKey: true, bubbles: true })
+					new KeyboardEvent('keydown', { key: 'x', code: 'KeyX', altKey: true, bubbles: true })
 				)
 			);
-			// click the <button> rendered by <Counter /> to open its wrapper chain
-			await page.locator('button', { hasText: 'Clicks' }).click();
-			const menu = page.locator('#svelte-inspector-menu');
+
+			await page.locator('#counter').click({ button: 'right' });
+
+			const menu = page.locator('#svelte-inspector-overlay');
 			await menu.waitFor({ state: 'visible', timeout: isCI ? 2000 : 1000 });
-			// the chain reaches the <Counter> call site in App.svelte, not just the
-			// button's own file — which the element location alone cannot provide
+
 			const text = await menu.innerText();
 			expect(text).toContain('Counter.svelte');
 			expect(text).toContain('App.svelte');

--- a/packages/e2e-tests/inspector-vite/src/App.svelte
+++ b/packages/e2e-tests/inspector-vite/src/App.svelte
@@ -1,1 +1,6 @@
+<script>
+	import Counter from './lib/Counter.svelte';
+</script>
+
 <h1>Hello Inspector!</h1>
+<Counter />

--- a/packages/e2e-tests/inspector-vite/src/lib/Counter.svelte
+++ b/packages/e2e-tests/inspector-vite/src/lib/Counter.svelte
@@ -5,7 +5,7 @@
 	};
 </script>
 
-<button on:click={increment}>
+<button id="counter" on:click={increment}>
 	Clicks: {count}
 </button>
 

--- a/packages/vite-plugin-svelte/src/plugins/inspector/options.js
+++ b/packages/vite-plugin-svelte/src/plugins/inspector/options.js
@@ -11,6 +11,7 @@ export const defaultInspectorOptions = {
 	navKeys: { parent: 'ArrowUp', child: 'ArrowDown', next: 'ArrowRight', prev: 'ArrowLeft' },
 	escapeKeys: ['Backspace', 'Escape'],
 	openKey: 'Enter',
+	openMenuKey: ' ',
 	holdMode: true,
 	showToggleButton: 'active',
 	toggleButtonPos: 'top-right',

--- a/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
+++ b/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
@@ -174,11 +174,6 @@
 		menu = { x: e.clientX, y: e.clientY, stack: get_stack(active_el) };
 	}
 
-	function open_loc(item, e) {
-		stop(e);
-		send(item);
-	}
-
 	function send(loc) {
 		fetch(
 			`${options.__internal.base}/__open-in-editor?file=${encodeURIComponent(
@@ -436,11 +431,7 @@
 			<ul class="svelte-inspector-grid">
 				{#each menu.stack as item, i (item.file + item.line + i)}
 					<li>
-						<button
-							type="button"
-							class="svelte-inspector-menu-row"
-							onclick={(e) => open_loc(item, e)}
-						>
+						<button type="button" class="svelte-inspector-menu-row" onclick={() => send(item)}>
 							<span class="svelte-inspector-tag">&lt;{item.tag}&gt;</span>
 							<span class="svelte-inspector-file">{item.file}:{item.line}</span>
 						</button>

--- a/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
+++ b/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
@@ -420,8 +420,7 @@
 
 <svelte:window
 	onclick={() => {
-		menu = null;
-		active_el = null;
+		disable();
 	}}
 />
 
@@ -447,7 +446,25 @@
 		bind:offsetHeight={h}
 	>
 		{#if menu}
-			<ul>
+			<button aria-label="close" class="svelte-inspector-button">
+				<span>close</span>
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					role="img"
+					width="1em"
+					height="1em"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					stroke-width="2"
+					stroke-linecap="round"
+					stroke-linejoin="round"><path d="M18 6 6 18" /><path d="m6 6 12 12" /></svg
+				>
+			</button>
+
+			<hr />
+
+			<ul class="svelte-inspector-grid">
 				{#each menu.chain as item, i (item.file + item.line + i)}
 					<li>
 						<button
@@ -464,9 +481,11 @@
 		{:else}
 			{@const loc = active_el.__svelte_meta.loc}
 
-			<div class="svelte-inspector-menu-row">
-				<span class="svelte-inspector-tag">&lt;{active_el.tagName.toLowerCase()}&gt;</span>
-				<span class="svelte-inspector-file">{loc.file}:{loc.line + 1}</span>
+			<div class="svelte-inspector-grid">
+				<div class="svelte-inspector-menu-row">
+					<span class="svelte-inspector-tag">&lt;{active_el.tagName.toLowerCase()}&gt;</span>
+					<span class="svelte-inspector-file">{loc.file}:{loc.line + 1}</span>
+				</div>
 			</div>
 
 			<div id="svelte-inspector-announcer" aria-live="assertive" aria-atomic="true">
@@ -488,10 +507,6 @@
 	}
 
 	#svelte-inspector-overlay {
-		display: grid;
-		grid-template-columns: max-content 1fr;
-		column-gap: 8px;
-		row-gap: 4px;
 		position: fixed;
 		padding: 4px;
 		margin: 0;
@@ -503,7 +518,14 @@
 		z-index: 999999;
 		background-color: #161616;
 		color: #fff;
-		pointer-events: none;
+		cursor: auto;
+	}
+
+	.svelte-inspector-grid {
+		display: grid;
+		grid-template-columns: max-content 1fr;
+		column-gap: 8px;
+		row-gap: 4px;
 	}
 
 	#svelte-inspector-toggle {
@@ -562,6 +584,29 @@
 		}
 	}
 
+	button {
+		background: transparent;
+		border: none;
+		color: inherit;
+		pointer-events: all;
+		font: inherit;
+		align-items: center;
+	}
+
+	hr {
+		margin: 2px 4px;
+		background: rgb(255 255 255 / 0.2);
+		border: none;
+		height: 1px;
+	}
+
+	.svelte-inspector-button {
+		display: flex;
+		justify-content: space-between;
+		width: 100%;
+		padding: 4px 8px;
+	}
+
 	.svelte-inspector-menu-row {
 		all: unset;
 		display: grid;
@@ -571,9 +616,7 @@
 		align-items: baseline;
 		width: 100%;
 		padding: 4px 8px;
-		color: #fff;
 		cursor: pointer;
-		pointer-events: all;
 
 		&:hover {
 			background-color: rgb(255 255 255 / 0.1);

--- a/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
+++ b/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
@@ -173,6 +173,7 @@
 	}
 
 	function open_menu(e) {
+		active_el ??= find_selectable_parent(e.target);
 		if (!active_el) return;
 
 		stop(e);

--- a/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
+++ b/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
@@ -123,7 +123,7 @@
 		}
 		if (el) {
 			const { file, line, column } = el.__svelte_meta.loc;
-			file_loc = `${file}:${line + 1}:${column + 1}`;
+			file_loc = `${file}:${line}:${column + 1}`;
 		} else {
 			file_loc = null;
 		}
@@ -165,22 +165,28 @@
 	function build_chain(target) {
 		const el = find_selectable_parent(target, true);
 		const meta = el?.__svelte_meta;
-		if (!meta) return [];
-		const chain = [];
-		const add = (file, line, column, tag) => {
-			if (!file || file.includes('node_modules/') || file.includes('.svelte-kit')) return;
-			const last = chain[chain.length - 1];
-			if (last && last.file === file && last.line === line) return;
-			chain.push({ file, line, column, tag });
-		};
-		if (meta.loc) {
-			add(meta.loc.file, meta.loc.line + 1, meta.loc.column + 1, el.tagName.toLowerCase());
-		}
-		for (let entry = meta.parent; entry; entry = entry.parent) {
-			if (entry.type === 'component') {
-				add(entry.file, entry.line, entry.column + 1, entry.componentTag);
+
+		const chain = [
+			{
+				file: meta.loc.file,
+				line: meta.loc.line,
+				column: meta.loc.column + 1,
+				tag: el.tagName.toLowerCase()
 			}
+		];
+
+		let entry = meta;
+		while ((entry = entry.parent)) {
+			if (entry.type !== 'component') continue;
+
+			chain.push({
+				file: entry.file,
+				line: entry.line,
+				column: entry.column + 1,
+				tag: entry.componentTag
+			});
 		}
+
 		return chain;
 	}
 
@@ -480,7 +486,7 @@
 			<div class="svelte-inspector-grid">
 				<div class="svelte-inspector-menu-row">
 					<span class="svelte-inspector-tag">&lt;{active_el.tagName.toLowerCase()}&gt;</span>
-					<span class="svelte-inspector-file">{loc.file}:{loc.line + 1}</span>
+					<span class="svelte-inspector-file">{loc.file}:{loc.line}</span>
 				</div>
 			</div>
 

--- a/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
+++ b/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
@@ -165,14 +165,8 @@
 	}
 
 	function on_contextmenu(e) {
-		if (e.target?.closest?.('#svelte-inspector-overlay')) {
-			return; // a menu row was clicked — let its own handler run
-		}
 		e.preventDefault();
-		open_menu(e);
-	}
 
-	function open_menu(e) {
 		active_el ??= find_selectable_parent(e.target);
 		if (!active_el) return;
 

--- a/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
+++ b/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
@@ -174,10 +174,6 @@
 		menu = { x: e.clientX, y: e.clientY, stack: get_stack(active_el) };
 	}
 
-	function close_menu() {
-		menu = null;
-	}
-
 	function open_loc(item, e) {
 		stop(e);
 		send(item);
@@ -190,7 +186,7 @@
 			)}`
 		);
 		has_opened = true;
-		close_menu();
+		menu = null;
 		if (options.holdMode && is_holding()) {
 			disable();
 		}

--- a/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
+++ b/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
@@ -422,6 +422,13 @@
 	});
 </script>
 
+<svelte:window
+	onclick={() => {
+		menu = null;
+		active_el = null;
+	}}
+/>
+
 {#if show_toggle}
 	<button
 		id="svelte-inspector-toggle"

--- a/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
+++ b/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
@@ -142,6 +142,10 @@
 	}
 
 	function open_editor(e) {
+		if (menu) {
+			return;
+		}
+
 		if (file_loc) {
 			stop(e);
 			fetch(`${options.__internal.base}/__open-in-editor?file=${encodeURIComponent(file_loc)}`);
@@ -195,15 +199,12 @@
 
 	// Route a click by mode — the stock combo opens the innermost element
 	// (original behaviour), the chain combo opens the wrapper dropdown.
-	function on_click(e) {
+	function on_contextmenu(e) {
 		if (e.target?.closest?.('#svelte-inspector-menu')) {
 			return; // a menu row was clicked — let its own handler run
 		}
-		if (chain_mode) {
-			open_menu(e);
-		} else {
-			open_editor(e);
-		}
+		e.preventDefault();
+		open_menu(e);
 	}
 
 	function open_menu(e) {
@@ -351,7 +352,8 @@
 		const l = enabled ? body.addEventListener : body.removeEventListener;
 		l('mousemove', mousemove);
 		l('mouseover', mouseover);
-		l('click', on_click, true);
+		l('click', open_editor, true);
+		l('contextmenu', on_contextmenu, true);
 	}
 
 	function enable() {

--- a/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
+++ b/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
@@ -30,7 +30,8 @@
 	// cursor pos and width for file_loc overlay positioning
 	let x = $state(),
 		y = $state(),
-		w = $state();
+		w = $state(),
+		h = $state();
 
 	let active_el = $state();
 
@@ -436,34 +437,35 @@
 		aria-label={`${enabled ? 'disable' : 'enable'} svelte-inspector`}
 	></button>
 {/if}
+
 {#if enabled && active_el && file_loc && !menu}
 	{@const loc = active_el.__svelte_meta.loc}
 	<div
 		id="svelte-inspector-overlay"
 		style:left="{Math.min(x + 3, document.documentElement.clientWidth - w - 10)}px"
-		style:top="{document.documentElement.clientHeight < y + 50 ? y - 30 : y + 30}px"
+		style:top="{document.documentElement.clientHeight < y + h + 40 ? y - h - 10 : y + 30}px"
 		bind:offsetWidth={w}
+		bind:offsetHeight={h}
 	>
-		&lt;{active_el.tagName.toLowerCase()}&gt;&nbsp;{file_loc}
+		<span class="svelte-inspector-tag">&lt;{active_el.tagName.toLowerCase()}&gt;</span>
+		<span class="svelte-inspector-file">{loc.file}:{loc.line + 1}</span>
 	</div>
 	<div id="svelte-inspector-announcer" aria-live="assertive" aria-atomic="true">
 		{active_el.tagName.toLowerCase()} in file {loc.file} on line {loc.line} column {loc.column}
 	</div>
-{/if}
-{#if enabled && menu}
+{:else if enabled && menu}
 	<ul
 		id="svelte-inspector-menu"
-		style:left="{Math.min(menu.x + 4, document.documentElement.clientWidth - 330)}px"
-		style:top="{Math.min(
-			menu.y + 4,
-			document.documentElement.clientHeight - 12 - menu.chain.length * 28
-		)}px"
+		style:left="{Math.min(menu.x + 3, document.documentElement.clientWidth - w - 10)}px"
+		style:top="{document.documentElement.clientHeight < y + h + 40 ? y - h - 10 : y + 30}px"
+		bind:offsetWidth={w}
+		bind:offsetHeight={h}
 	>
 		{#each menu.chain as item, i (item.file + item.line + i)}
 			<li>
 				<button type="button" class="svelte-inspector-menu-row" onclick={(e) => open_loc(item, e)}>
-					<span class="svelte-inspector-menu-tag">&lt;{item.tag}&gt;</span>
-					<span class="svelte-inspector-menu-file">{item.file}:{item.line}</span>
+					<span class="svelte-inspector-tag">&lt;{item.tag}&gt;</span>
+					<span class="svelte-inspector-file">{item.file}:{item.line}</span>
 				</button>
 			</li>
 		{/each}
@@ -481,14 +483,27 @@
 		direction: ltr;
 	}
 
-	#svelte-inspector-overlay {
+	#svelte-inspector-overlay,
+	#svelte-inspector-menu {
+		display: grid;
+		grid-template-columns: max-content 1fr;
+		gap: 8px;
 		position: fixed;
-		background-color: rgba(0, 0, 0, 0.8);
-		color: #fff;
-		padding: 2px 4px;
-		border-radius: 5px;
+		padding: 4px;
+		margin: 0;
+		border-radius: 2px;
+		filter: drop-shadow(2px 2px 4px rgb(0 0 0 / 0.1));
+		font-family: ui-monospace, 'SF Mono', Menlo, monospace;
+		font-size: 12px;
+		line-height: 1.4;
 		z-index: 999999;
+		background-color: #161616;
+		color: #fff;
+	}
+
+	#svelte-inspector-overlay {
 		pointer-events: none;
+		padding: 8px 12px;
 	}
 
 	#svelte-inspector-toggle {
@@ -523,21 +538,23 @@
 		background-color: #facece;
 	}
 
+	.svelte-inspector-tag {
+		white-space: nowrap;
+		font-weight: 600;
+	}
+
+	.svelte-inspector-file {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		color: #ddd;
+	}
+
 	#svelte-inspector-menu {
 		position: fixed;
 		z-index: 1000000;
-		min-width: 240px;
 		max-width: 480px;
 		list-style: none;
-		padding: 4px;
-		background-color: #161616;
-		border-radius: 2px;
-		filter: drop-shadow(2px 2px 4px rgb(0 0 0 / 0.1));
-		font-family: ui-monospace, 'SF Mono', Menlo, monospace;
-		font-size: 12px;
-		line-height: 1.4;
-		display: grid;
-		grid-template-columns: max-content 1fr;
 
 		li {
 			display: contents;
@@ -550,7 +567,6 @@
 			grid-template-columns: subgrid;
 			box-sizing: border-box;
 			align-items: baseline;
-			gap: 8px;
 			width: 100%;
 			padding: 4px 8px;
 			color: #fff;
@@ -558,20 +574,6 @@
 
 			&:hover {
 				background-color: rgb(255 255 255 / 0.1);
-			}
-
-			.svelte-inspector-menu-tag {
-				white-space: nowrap;
-				font-weight: 600;
-			}
-
-			.svelte-inspector-menu-file {
-				flex: 1;
-				min-width: 0;
-				overflow: hidden;
-				text-overflow: ellipsis;
-				white-space: nowrap;
-				color: #ddd;
 			}
 		}
 	}

--- a/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
+++ b/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
@@ -6,6 +6,10 @@
 
 	import options from 'virtual:svelte-inspector-options';
 	const toggle_combo = options.toggleKeyCombo?.toLowerCase().split('-');
+	// A second toggle, separate from the stock one. The stock combo (alt-x) keeps
+	// its original behaviour (click opens the innermost element); this combo
+	// enables "chain mode" where a click opens the wrapper-chain dropdown instead.
+	const chain_combo = ['alt', 'c'];
 	const escape_keys = options.escapeKeys?.map((k) => k.toLowerCase());
 	const nav_keys = Object.values(options.navKeys).map((k) => k?.toLowerCase());
 	const open_key = options.openKey?.toLowerCase();
@@ -34,6 +38,12 @@
 
 	let active_el = $state();
 
+	// Wrapper-chain dropdown: null when closed, else { x, y, chain }.
+	let menu = $state(null);
+	// True while the chain combo is the active mode — a click then opens the
+	// dropdown instead of the stock single-element open.
+	let chain_mode = $state(false);
+
 	let hold_start_ts = $state();
 
 	let show_toggle = $derived(
@@ -41,6 +51,7 @@
 	);
 
 	function mousemove(e) {
+		if (menu) return;
 		x = e.x;
 		y = e.y;
 	}
@@ -102,6 +113,7 @@
 	}
 
 	function mouseover({ target }) {
+		if (menu) return;
 		const el = find_selectable_parent(target, true);
 		activate(el, false);
 	}
@@ -140,6 +152,88 @@
 		}
 	}
 
+	// --- Wrapper-chain dropdown --------------------------------------------
+	// Stock inspector opens only the innermost element on click. This builds the
+	// component-instantiation chain so the click opens a dropdown of every
+	// wrapper, each pointing at the EXACT `<Component>` call site — not the leaf
+	// primitive, and not the nearest DOM ancestor.
+	//
+	// Source: Svelte dev attaches `el.__svelte_meta = { loc, parent }`. `loc` is
+	// the element's own tag location (0-based); `parent` is the dev_stack — a
+	// linked list of block/component entries. Each `type:'component'` entry holds
+	// `{ file, line, column, componentTag }` where file/line are the call site in
+	// the PARENT template (line 1-based, column 0-based; see the compiler's
+	// `getLocator(..., { offsetLine: 1 })`). Walking it points a click on a nested
+	// primitive at the `<Component>` that renders it, e.g. "<Button> Card.svelte:42".
+
+	function build_chain(target) {
+		const el = find_selectable_parent(target, true);
+		const meta = el?.__svelte_meta;
+		if (!meta) return [];
+		const chain = [];
+		const add = (file, line, column, tag) => {
+			if (!file || file.includes('node_modules/')) return;
+			const last = chain[chain.length - 1];
+			if (last && last.file === file && last.line === line) return;
+			chain.push({ file, line, column, tag });
+		};
+		if (meta.loc) {
+			add(meta.loc.file, meta.loc.line + 1, meta.loc.column + 1, el.tagName.toLowerCase());
+		}
+		for (let entry = meta.parent; entry; entry = entry.parent) {
+			if (entry.type === 'component') {
+				add(entry.file, entry.line, entry.column + 1, entry.componentTag);
+			}
+		}
+		return chain;
+	}
+
+	function short_path(file) {
+		const parts = file.split('/');
+		return parts.slice(-2).join('/');
+	}
+
+	// Route a click by mode — the stock combo opens the innermost element
+	// (original behaviour), the chain combo opens the wrapper dropdown.
+	function on_click(e) {
+		if (e.target?.closest?.('#svelte-inspector-menu')) {
+			return; // a menu row was clicked — let its own handler run
+		}
+		if (chain_mode) {
+			open_menu(e);
+		} else {
+			open_editor(e);
+		}
+	}
+
+	function open_menu(e) {
+		const chain = build_chain(e.target);
+		if (chain.length === 0) {
+			close_menu();
+			return;
+		}
+		stop(e);
+		menu = { x: e.clientX, y: e.clientY, chain };
+	}
+
+	function close_menu() {
+		menu = null;
+	}
+
+	function open_loc(item, e) {
+		stop(e);
+		fetch(
+			`${options.__internal.base}/__open-in-editor?file=${encodeURIComponent(
+				`${item.file}:${item.line}:${item.column}`
+			)}`
+		);
+		has_opened = true;
+		close_menu();
+		if (options.holdMode && is_holding()) {
+			disable();
+		}
+	}
+
 	function is_active(key, e) {
 		switch (key) {
 			case 'shift':
@@ -154,6 +248,14 @@
 
 	function is_combo(e) {
 		return toggle_combo?.every((k) => is_active(k, e));
+	}
+
+	function is_chain_combo(e) {
+		return chain_combo.every((k) => is_active(k, e));
+	}
+
+	function is_chain_toggle(e) {
+		return chain_combo.some((k) => is_active(k, e));
 	}
 
 	function is_escape(e) {
@@ -183,13 +285,27 @@
 	}
 
 	function keydown(e) {
-		if (e.repeat || e.key == null || (!enabled && !is_toggle(e))) {
+		if (e.repeat || e.key == null || (!enabled && !is_toggle(e) && !is_chain_toggle(e))) {
 			return;
 		}
 		if (is_combo(e)) {
+			chain_mode = false;
 			toggle();
 			if (options.holdMode && enabled) {
 				hold_start_ts = Date.now();
+			}
+		} else if (is_chain_combo(e)) {
+			// chain mode is a sticky toggle (no hold) so you can release the keys
+			// and still click rows in the dropdown.
+			stop(e);
+			if (enabled && chain_mode) {
+				disable();
+			} else {
+				chain_mode = true;
+				if (!enabled) {
+					enable();
+				}
+				hold_start_ts = null;
 			}
 		} else if (enabled) {
 			if (is_nav(e)) {
@@ -235,7 +351,7 @@
 		const l = enabled ? body.addEventListener : body.removeEventListener;
 		l('mousemove', mousemove);
 		l('mouseover', mouseover);
-		l('click', open_editor, true);
+		l('click', on_click, true);
 	}
 
 	function enable() {
@@ -277,6 +393,8 @@
 		enabled = false;
 		has_opened = false;
 		hold_start_ts = null;
+		menu = null;
+		chain_mode = false;
 		const b = document.body;
 		listeners(b, enabled);
 		if (options.customStyles) {
@@ -344,7 +462,7 @@
 		aria-label={`${enabled ? 'disable' : 'enable'} svelte-inspector`}
 	></button>
 {/if}
-{#if enabled && active_el && file_loc}
+{#if enabled && active_el && file_loc && !menu}
 	{@const loc = active_el.__svelte_meta.loc}
 	<div
 		id="svelte-inspector-overlay"
@@ -356,6 +474,25 @@
 	</div>
 	<div id="svelte-inspector-announcer" aria-live="assertive" aria-atomic="true">
 		{active_el.tagName.toLowerCase()} in file {loc.file} on line {loc.line} column {loc.column}
+	</div>
+{/if}
+{#if enabled && menu}
+	<div
+		id="svelte-inspector-menu"
+		style:left="{Math.min(menu.x + 4, document.documentElement.clientWidth - 330)}px"
+		style:top="{Math.min(
+			menu.y + 4,
+			document.documentElement.clientHeight - 12 - menu.chain.length * 28
+		)}px"
+	>
+		<div id="svelte-inspector-menu-head">wrapper chain · {menu.chain.length}</div>
+		{#each menu.chain as item, i (item.file + item.line + i)}
+			<button type="button" class="svelte-inspector-menu-row" onclick={(e) => open_loc(item, e)}>
+				<span class="svelte-inspector-menu-tag">&lt;{item.tag}&gt;</span>
+				<span class="svelte-inspector-menu-file">{short_path(item.file)}</span>
+				<span class="svelte-inspector-menu-line">:{item.line}</span>
+			</button>
+		{/each}
 	</div>
 {/if}
 
@@ -407,5 +544,62 @@
 	}
 	#svelte-inspector-toggle:hover {
 		background-color: #facece;
+	}
+
+	#svelte-inspector-menu {
+		position: fixed;
+		z-index: 1000000;
+		min-width: 240px;
+		max-width: 320px;
+		padding: 4px;
+		background-color: #161616;
+		border: 1px solid rgba(255, 62, 0, 0.5);
+		border-radius: 8px;
+		box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+		font-family: ui-monospace, 'SF Mono', Menlo, monospace;
+		font-size: 12px;
+		line-height: 1.4;
+	}
+	#svelte-inspector-menu-head {
+		padding: 4px 8px 6px;
+		color: #ff3e00;
+		text-transform: uppercase;
+		font-size: 10px;
+		letter-spacing: 0.04em;
+	}
+	.svelte-inspector-menu-row {
+		all: unset;
+		box-sizing: border-box;
+		display: flex;
+		align-items: baseline;
+		gap: 8px;
+		width: 100%;
+		padding: 5px 8px;
+		border-radius: 5px;
+		color: #fff;
+		cursor: pointer;
+	}
+	.svelte-inspector-menu-row:hover {
+		background-color: rgba(255, 62, 0, 0.18);
+	}
+	.svelte-inspector-menu-tag {
+		flex-shrink: 0;
+		max-width: 11rem;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		font-weight: 600;
+	}
+	.svelte-inspector-menu-file {
+		flex: 1;
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		color: #aaa;
+	}
+	.svelte-inspector-menu-line {
+		flex-shrink: 0;
+		color: #ff8a5c;
 	}
 </style>

--- a/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
+++ b/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
@@ -132,7 +132,7 @@
 
 		if (active_el) {
 			stop(e);
-			open_in_editor(active_el.__svelte_meta.loc);
+			send(active_el.__svelte_meta.loc);
 		}
 	}
 
@@ -185,10 +185,10 @@
 
 	function open_loc(item, e) {
 		stop(e);
-		open_in_editor(item);
+		send(item);
 	}
 
-	function open_in_editor(loc) {
+	function send(loc) {
 		fetch(
 			`${options.__internal.base}/__open-in-editor?file=${encodeURIComponent(
 				`${loc.file}:${loc.line}:${loc.column + 1}`
@@ -260,9 +260,7 @@
 					stop(e);
 				}
 			} else if (is_open(e)) {
-				if (!menu) {
-					open_editor(e);
-				}
+				open_editor(e);
 			} else if (is_holding() || is_escape(e)) {
 				// is_holding() checks for unhandled additional key pressed
 				// while holding the toggle keys, which is possibly another

--- a/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
+++ b/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
@@ -591,6 +591,10 @@
 		pointer-events: all;
 		font: inherit;
 		align-items: center;
+
+		&:focus-visible {
+			outline: 2px solid #ff3e00;
+		}
 	}
 
 	hr {

--- a/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
+++ b/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
@@ -9,6 +9,7 @@
 	const escape_keys = options.escapeKeys?.map((k) => k.toLowerCase());
 	const nav_keys = Object.values(options.navKeys).map((k) => k?.toLowerCase());
 	const open_key = options.openKey?.toLowerCase();
+	const open_menu_key = options.openMenuKey?.toLowerCase();
 
 	let enabled = $state(false);
 	let has_opened = $state(false);
@@ -219,6 +220,10 @@
 		return open_key && is_active(open_key, e);
 	}
 
+	function is_open_menu(e) {
+		return open_menu_key && is_active(open_menu_key, e);
+	}
+
 	function is_holding() {
 		return hold_start_ts && Date.now() - hold_start_ts > 250;
 	}
@@ -247,6 +252,8 @@
 				}
 			} else if (is_open(e)) {
 				open_editor(e);
+			} else if (is_open_menu(e)) {
+				on_contextmenu(e);
 			} else if (is_holding() || is_escape(e)) {
 				// is_holding() checks for unhandled additional key pressed
 				// while holding the toggle keys, which is possibly another

--- a/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
+++ b/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
@@ -438,44 +438,42 @@
 	></button>
 {/if}
 
-{#if enabled}
-	{#if menu}
-		<ul
-			id="svelte-inspector-menu"
-			style:left="{Math.min(menu.x + 3, document.documentElement.clientWidth - w - 10)}px"
-			style:top="{document.documentElement.clientHeight < y + h + 40 ? y - h - 10 : y + 30}px"
-			bind:offsetWidth={w}
-			bind:offsetHeight={h}
-		>
-			{#each menu.chain as item, i (item.file + item.line + i)}
-				<li>
-					<button
-						type="button"
-						class="svelte-inspector-menu-row"
-						onclick={(e) => open_loc(item, e)}
-					>
-						<span class="svelte-inspector-tag">&lt;{item.tag}&gt;</span>
-						<span class="svelte-inspector-file">{item.file}:{item.line}</span>
-					</button>
-				</li>
-			{/each}
-		</ul>
-	{:else if active_el && file_loc}
-		{@const loc = active_el.__svelte_meta.loc}
-		<div
-			id="svelte-inspector-overlay"
-			style:left="{Math.min(x + 3, document.documentElement.clientWidth - w - 10)}px"
-			style:top="{document.documentElement.clientHeight < y + h + 40 ? y - h - 10 : y + 30}px"
-			bind:offsetWidth={w}
-			bind:offsetHeight={h}
-		>
-			<span class="svelte-inspector-tag">&lt;{active_el.tagName.toLowerCase()}&gt;</span>
-			<span class="svelte-inspector-file">{loc.file}:{loc.line + 1}</span>
-		</div>
-		<div id="svelte-inspector-announcer" aria-live="assertive" aria-atomic="true">
-			{active_el.tagName.toLowerCase()} in file {loc.file} on line {loc.line} column {loc.column}
-		</div>
-	{/if}
+{#if enabled && (menu || (active_el && file_loc))}
+	<div
+		id="svelte-inspector-overlay"
+		style:left="{Math.min(x + 3, document.documentElement.clientWidth - w - 10)}px"
+		style:top="{document.documentElement.clientHeight < y + h + 40 ? y - h - 10 : y + 30}px"
+		bind:offsetWidth={w}
+		bind:offsetHeight={h}
+	>
+		{#if menu}
+			<ul>
+				{#each menu.chain as item, i (item.file + item.line + i)}
+					<li>
+						<button
+							type="button"
+							class="svelte-inspector-menu-row"
+							onclick={(e) => open_loc(item, e)}
+						>
+							<span class="svelte-inspector-tag">&lt;{item.tag}&gt;</span>
+							<span class="svelte-inspector-file">{item.file}:{item.line}</span>
+						</button>
+					</li>
+				{/each}
+			</ul>
+		{:else}
+			{@const loc = active_el.__svelte_meta.loc}
+
+			<div class="svelte-inspector-menu-row">
+				<span class="svelte-inspector-tag">&lt;{active_el.tagName.toLowerCase()}&gt;</span>
+				<span class="svelte-inspector-file">{loc.file}:{loc.line + 1}</span>
+			</div>
+
+			<div id="svelte-inspector-announcer" aria-live="assertive" aria-atomic="true">
+				{active_el.tagName.toLowerCase()} in file {loc.file} on line {loc.line} column {loc.column}
+			</div>
+		{/if}
+	</div>
 {/if}
 
 <style>
@@ -489,11 +487,11 @@
 		direction: ltr;
 	}
 
-	#svelte-inspector-overlay,
-	#svelte-inspector-menu {
+	#svelte-inspector-overlay {
 		display: grid;
 		grid-template-columns: max-content 1fr;
-		gap: 8px;
+		column-gap: 8px;
+		row-gap: 4px;
 		position: fixed;
 		padding: 4px;
 		margin: 0;
@@ -505,11 +503,7 @@
 		z-index: 999999;
 		background-color: #161616;
 		color: #fff;
-	}
-
-	#svelte-inspector-overlay {
 		pointer-events: none;
-		padding: 8px 12px;
 	}
 
 	#svelte-inspector-toggle {
@@ -556,31 +550,33 @@
 		color: #ddd;
 	}
 
-	#svelte-inspector-menu {
-		position: fixed;
-		z-index: 1000000;
+	ul {
 		max-width: 480px;
 		list-style: none;
+		margin: 0;
+		padding: 0;
+		display: contents;
 
 		li {
 			display: contents;
 		}
+	}
 
-		.svelte-inspector-menu-row {
-			all: unset;
-			display: grid;
-			grid-column: 1 / 3;
-			grid-template-columns: subgrid;
-			box-sizing: border-box;
-			align-items: baseline;
-			width: 100%;
-			padding: 4px 8px;
-			color: #fff;
-			cursor: pointer;
+	.svelte-inspector-menu-row {
+		all: unset;
+		display: grid;
+		grid-column: 1 / 3;
+		grid-template-columns: subgrid;
+		box-sizing: border-box;
+		align-items: baseline;
+		width: 100%;
+		padding: 4px 8px;
+		color: #fff;
+		cursor: pointer;
+		pointer-events: all;
 
-			&:hover {
-				background-color: rgb(255 255 255 / 0.1);
-			}
+		&:hover {
+			background-color: rgb(255 255 255 / 0.1);
 		}
 	}
 </style>

--- a/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
+++ b/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
@@ -438,38 +438,44 @@
 	></button>
 {/if}
 
-{#if enabled && active_el && file_loc && !menu}
-	{@const loc = active_el.__svelte_meta.loc}
-	<div
-		id="svelte-inspector-overlay"
-		style:left="{Math.min(x + 3, document.documentElement.clientWidth - w - 10)}px"
-		style:top="{document.documentElement.clientHeight < y + h + 40 ? y - h - 10 : y + 30}px"
-		bind:offsetWidth={w}
-		bind:offsetHeight={h}
-	>
-		<span class="svelte-inspector-tag">&lt;{active_el.tagName.toLowerCase()}&gt;</span>
-		<span class="svelte-inspector-file">{loc.file}:{loc.line + 1}</span>
-	</div>
-	<div id="svelte-inspector-announcer" aria-live="assertive" aria-atomic="true">
-		{active_el.tagName.toLowerCase()} in file {loc.file} on line {loc.line} column {loc.column}
-	</div>
-{:else if enabled && menu}
-	<ul
-		id="svelte-inspector-menu"
-		style:left="{Math.min(menu.x + 3, document.documentElement.clientWidth - w - 10)}px"
-		style:top="{document.documentElement.clientHeight < y + h + 40 ? y - h - 10 : y + 30}px"
-		bind:offsetWidth={w}
-		bind:offsetHeight={h}
-	>
-		{#each menu.chain as item, i (item.file + item.line + i)}
-			<li>
-				<button type="button" class="svelte-inspector-menu-row" onclick={(e) => open_loc(item, e)}>
-					<span class="svelte-inspector-tag">&lt;{item.tag}&gt;</span>
-					<span class="svelte-inspector-file">{item.file}:{item.line}</span>
-				</button>
-			</li>
-		{/each}
-	</ul>
+{#if enabled}
+	{#if menu}
+		<ul
+			id="svelte-inspector-menu"
+			style:left="{Math.min(menu.x + 3, document.documentElement.clientWidth - w - 10)}px"
+			style:top="{document.documentElement.clientHeight < y + h + 40 ? y - h - 10 : y + 30}px"
+			bind:offsetWidth={w}
+			bind:offsetHeight={h}
+		>
+			{#each menu.chain as item, i (item.file + item.line + i)}
+				<li>
+					<button
+						type="button"
+						class="svelte-inspector-menu-row"
+						onclick={(e) => open_loc(item, e)}
+					>
+						<span class="svelte-inspector-tag">&lt;{item.tag}&gt;</span>
+						<span class="svelte-inspector-file">{item.file}:{item.line}</span>
+					</button>
+				</li>
+			{/each}
+		</ul>
+	{:else if active_el && file_loc}
+		{@const loc = active_el.__svelte_meta.loc}
+		<div
+			id="svelte-inspector-overlay"
+			style:left="{Math.min(x + 3, document.documentElement.clientWidth - w - 10)}px"
+			style:top="{document.documentElement.clientHeight < y + h + 40 ? y - h - 10 : y + 30}px"
+			bind:offsetWidth={w}
+			bind:offsetHeight={h}
+		>
+			<span class="svelte-inspector-tag">&lt;{active_el.tagName.toLowerCase()}&gt;</span>
+			<span class="svelte-inspector-file">{loc.file}:{loc.line + 1}</span>
+		</div>
+		<div id="svelte-inspector-announcer" aria-live="assertive" aria-atomic="true">
+			{active_el.tagName.toLowerCase()} in file {loc.file} on line {loc.line} column {loc.column}
+		</div>
+	{/if}
 {/if}
 
 <style>

--- a/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
+++ b/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
@@ -492,6 +492,7 @@
 		background-color: #fff;
 		color: #222;
 		cursor: auto;
+		user-select: none;
 	}
 
 	.svelte-inspector-grid {

--- a/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
+++ b/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
@@ -153,6 +153,7 @@
 		let entry = meta;
 		while ((entry = entry.parent)) {
 			if (entry.type !== 'component') continue;
+			if (/(^|\/)(node_modules|\.svelte-kit)\//.test(entry.file)) continue;
 
 			stack.push({
 				file: entry.file,

--- a/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
+++ b/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
@@ -464,7 +464,6 @@
 			document.documentElement.clientHeight - 12 - menu.chain.length * 28
 		)}px"
 	>
-		<div id="svelte-inspector-menu-head">wrapper chain · {menu.chain.length}</div>
 		{#each menu.chain as item, i (item.file + item.line + i)}
 			<button type="button" class="svelte-inspector-menu-row" onclick={(e) => open_loc(item, e)}>
 				<span class="svelte-inspector-menu-tag">&lt;{item.tag}&gt;</span>

--- a/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
+++ b/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
@@ -185,11 +185,6 @@
 		return chain;
 	}
 
-	function short_path(file) {
-		const parts = file.split('/');
-		return parts.slice(-2).join('/');
-	}
-
 	// Route a click by mode — the stock combo opens the innermost element
 	// (original behaviour), the chain combo opens the wrapper dropdown.
 	function on_contextmenu(e) {
@@ -456,7 +451,7 @@
 	</div>
 {/if}
 {#if enabled && menu}
-	<div
+	<ul
 		id="svelte-inspector-menu"
 		style:left="{Math.min(menu.x + 4, document.documentElement.clientWidth - 330)}px"
 		style:top="{Math.min(
@@ -465,13 +460,14 @@
 		)}px"
 	>
 		{#each menu.chain as item, i (item.file + item.line + i)}
-			<button type="button" class="svelte-inspector-menu-row" onclick={(e) => open_loc(item, e)}>
-				<span class="svelte-inspector-menu-tag">&lt;{item.tag}&gt;</span>
-				<span class="svelte-inspector-menu-file">{short_path(item.file)}</span>
-				<span class="svelte-inspector-menu-line">:{item.line}</span>
-			</button>
+			<li>
+				<button type="button" class="svelte-inspector-menu-row" onclick={(e) => open_loc(item, e)}>
+					<span class="svelte-inspector-menu-tag">&lt;{item.tag}&gt;</span>
+					<span class="svelte-inspector-menu-file">{item.file}:{item.line}</span>
+				</button>
+			</li>
 		{/each}
-	</div>
+	</ul>
 {/if}
 
 <style>
@@ -531,56 +527,52 @@
 		position: fixed;
 		z-index: 1000000;
 		min-width: 240px;
-		max-width: 320px;
+		max-width: 480px;
+		list-style: none;
 		padding: 4px;
 		background-color: #161616;
-		border: 1px solid rgba(255, 62, 0, 0.5);
-		border-radius: 8px;
-		box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+		border-radius: 2px;
+		filter: drop-shadow(2px 2px 4px rgb(0 0 0 / 0.1));
 		font-family: ui-monospace, 'SF Mono', Menlo, monospace;
 		font-size: 12px;
 		line-height: 1.4;
-	}
-	#svelte-inspector-menu-head {
-		padding: 4px 8px 6px;
-		color: #ff3e00;
-		text-transform: uppercase;
-		font-size: 10px;
-		letter-spacing: 0.04em;
-	}
-	.svelte-inspector-menu-row {
-		all: unset;
-		box-sizing: border-box;
-		display: flex;
-		align-items: baseline;
-		gap: 8px;
-		width: 100%;
-		padding: 5px 8px;
-		border-radius: 5px;
-		color: #fff;
-		cursor: pointer;
-	}
-	.svelte-inspector-menu-row:hover {
-		background-color: rgba(255, 62, 0, 0.18);
-	}
-	.svelte-inspector-menu-tag {
-		flex-shrink: 0;
-		max-width: 11rem;
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
-		font-weight: 600;
-	}
-	.svelte-inspector-menu-file {
-		flex: 1;
-		min-width: 0;
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
-		color: #aaa;
-	}
-	.svelte-inspector-menu-line {
-		flex-shrink: 0;
-		color: #ff8a5c;
+		display: grid;
+		grid-template-columns: max-content 1fr;
+
+		li {
+			display: contents;
+		}
+
+		.svelte-inspector-menu-row {
+			all: unset;
+			display: grid;
+			grid-column: 1 / 3;
+			grid-template-columns: subgrid;
+			box-sizing: border-box;
+			align-items: baseline;
+			gap: 8px;
+			width: 100%;
+			padding: 4px 8px;
+			color: #fff;
+			cursor: pointer;
+
+			&:hover {
+				background-color: rgb(255 255 255 / 0.1);
+			}
+
+			.svelte-inspector-menu-tag {
+				white-space: nowrap;
+				font-weight: 600;
+			}
+
+			.svelte-inspector-menu-file {
+				flex: 1;
+				min-width: 0;
+				overflow: hidden;
+				text-overflow: ellipsis;
+				white-space: nowrap;
+				color: #ddd;
+			}
+		}
 	}
 </style>

--- a/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
+++ b/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
@@ -35,7 +35,6 @@
 
 	let active_el = $state();
 
-	// Wrapper-chain dropdown: null when closed, else { x, y, chain }.
 	let menu = $state(null);
 
 	let hold_start_ts = $state();
@@ -148,25 +147,11 @@
 		}
 	}
 
-	// --- Wrapper-chain dropdown --------------------------------------------
-	// Stock inspector opens only the innermost element on click. This builds the
-	// component-instantiation chain so the click opens a dropdown of every
-	// wrapper, each pointing at the EXACT `<Component>` call site — not the leaf
-	// primitive, and not the nearest DOM ancestor.
-	//
-	// Source: Svelte dev attaches `el.__svelte_meta = { loc, parent }`. `loc` is
-	// the element's own tag location (0-based); `parent` is the dev_stack — a
-	// linked list of block/component entries. Each `type:'component'` entry holds
-	// `{ file, line, column, componentTag }` where file/line are the call site in
-	// the PARENT template (line 1-based, column 0-based; see the compiler's
-	// `getLocator(..., { offsetLine: 1 })`). Walking it points a click on a nested
-	// primitive at the `<Component>` that renders it, e.g. "<Button> Card.svelte:42".
-
-	function build_chain(target) {
+	function get_stack(target) {
 		const el = find_selectable_parent(target, true);
 		const meta = el?.__svelte_meta;
 
-		const chain = [
+		const stack = [
 			{
 				file: meta.loc.file,
 				line: meta.loc.line,
@@ -179,7 +164,7 @@
 		while ((entry = entry.parent)) {
 			if (entry.type !== 'component') continue;
 
-			chain.push({
+			stack.push({
 				file: entry.file,
 				line: entry.line,
 				column: entry.column + 1,
@@ -187,11 +172,9 @@
 			});
 		}
 
-		return chain;
+		return stack;
 	}
 
-	// Route a click by mode — the stock combo opens the innermost element
-	// (original behaviour), the chain combo opens the wrapper dropdown.
 	function on_contextmenu(e) {
 		if (e.target?.closest?.('#svelte-inspector-overlay')) {
 			return; // a menu row was clicked — let its own handler run
@@ -201,13 +184,10 @@
 	}
 
 	function open_menu(e) {
-		const chain = build_chain(active_el);
-		if (chain.length === 0) {
-			close_menu();
-			return;
-		}
+		if (!active_el) return;
+
 		stop(e);
-		menu = { x: e.clientX, y: e.clientY, chain };
+		menu = { x: e.clientX, y: e.clientY, stack: get_stack(active_el) };
 	}
 
 	function close_menu() {
@@ -422,11 +402,7 @@
 	});
 </script>
 
-<svelte:window
-	onclick={() => {
-		disable();
-	}}
-/>
+<svelte:window onclick={disable} />
 
 {#if show_toggle}
 	<button
@@ -467,7 +443,7 @@
 			<hr />
 
 			<ul class="svelte-inspector-grid">
-				{#each menu.chain as item, i (item.file + item.line + i)}
+				{#each menu.stack as item, i (item.file + item.line + i)}
 					<li>
 						<button
 							type="button"

--- a/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
+++ b/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
@@ -25,9 +25,7 @@
 			.trim()
 	)}`;
 
-	// location of code in file
-	let file_loc = $state();
-	// cursor pos and width for file_loc overlay positioning
+	// overlay positioning
 	let x = $state(),
 		y = $state(),
 		w = $state(),
@@ -120,12 +118,7 @@
 				el.classList.add('svelte-inspector-active-target');
 			}
 		}
-		if (el) {
-			const { file, line, column } = el.__svelte_meta.loc;
-			file_loc = `${file}:${line}:${column + 1}`;
-		} else {
-			file_loc = null;
-		}
+
 		active_el = el;
 		if (set_bubble_pos) {
 			const pos = el.getBoundingClientRect();
@@ -137,13 +130,9 @@
 	function open_editor(e) {
 		if (menu) return;
 
-		if (file_loc) {
+		if (active_el) {
 			stop(e);
-			fetch(`${options.__internal.base}/__open-in-editor?file=${encodeURIComponent(file_loc)}`);
-			has_opened = true;
-			if (options.holdMode && is_holding()) {
-				disable();
-			}
+			open_in_editor(active_el.__svelte_meta.loc);
 		}
 	}
 
@@ -155,7 +144,7 @@
 			{
 				file: meta.loc.file,
 				line: meta.loc.line,
-				column: meta.loc.column + 1,
+				column: meta.loc.column,
 				tag: el.tagName.toLowerCase()
 			}
 		];
@@ -167,7 +156,7 @@
 			stack.push({
 				file: entry.file,
 				line: entry.line,
-				column: entry.column + 1,
+				column: entry.column,
 				tag: entry.componentTag
 			});
 		}
@@ -196,9 +185,13 @@
 
 	function open_loc(item, e) {
 		stop(e);
+		open_in_editor(item);
+	}
+
+	function open_in_editor(loc) {
 		fetch(
 			`${options.__internal.base}/__open-in-editor?file=${encodeURIComponent(
-				`${item.file}:${item.line}:${item.column}`
+				`${loc.file}:${loc.line}:${loc.column + 1}`
 			)}`
 		);
 		has_opened = true;
@@ -267,7 +260,9 @@
 					stop(e);
 				}
 			} else if (is_open(e)) {
-				open_editor(e);
+				if (!menu) {
+					open_editor(e);
+				}
 			} else if (is_holding() || is_escape(e)) {
 				// is_holding() checks for unhandled additional key pressed
 				// while holding the toggle keys, which is possibly another
@@ -417,7 +412,7 @@
 	></button>
 {/if}
 
-{#if enabled && (menu || (active_el && file_loc))}
+{#if enabled && (menu || active_el)}
 	<div
 		id="svelte-inspector-overlay"
 		style:left="{Math.min(x + 3, document.documentElement.clientWidth - w - 10)}px"
@@ -467,7 +462,8 @@
 			</div>
 
 			<div id="svelte-inspector-announcer" aria-live="assertive" aria-atomic="true">
-				{active_el.tagName.toLowerCase()} in file {loc.file} on line {loc.line} column {loc.column}
+				{active_el.tagName.toLowerCase()} in file {loc.file} on line {loc.line} column {loc.column +
+					1}
 			</div>
 		{/if}
 	</div>

--- a/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
+++ b/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
@@ -195,7 +195,7 @@
 	}
 
 	function open_menu(e) {
-		const chain = build_chain(e.target);
+		const chain = build_chain(active_el);
 		if (chain.length === 0) {
 			close_menu();
 			return;

--- a/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
+++ b/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
@@ -168,7 +168,7 @@
 		if (!meta) return [];
 		const chain = [];
 		const add = (file, line, column, tag) => {
-			if (!file || file.includes('node_modules/')) return;
+			if (!file || file.includes('node_modules/') || file.includes('.svelte-kit')) return;
 			const last = chain[chain.length - 1];
 			if (last && last.file === file && last.line === line) return;
 			chain.push({ file, line, column, tag });

--- a/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
+++ b/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
@@ -396,7 +396,14 @@
 	});
 </script>
 
-<svelte:window onclick={disable} />
+<svelte:window
+	onclick={disable}
+	onkeydown={(e) => {
+		if (e.key === 'Escape') {
+			disable();
+		}
+	}}
+/>
 
 {#if show_toggle}
 	<button
@@ -486,7 +493,7 @@
 
 	#svelte-inspector-overlay {
 		position: fixed;
-		padding: 4px;
+		padding: 2px;
 		margin: 0;
 		border-radius: 2px;
 		filter: drop-shadow(2px 2px 4px rgb(0 0 0 / 0.1));
@@ -494,8 +501,8 @@
 		font-size: 12px;
 		line-height: 1.4;
 		z-index: 999999;
-		background-color: #161616;
-		color: #fff;
+		background-color: #fff;
+		color: #222;
 		cursor: auto;
 	}
 
@@ -503,7 +510,7 @@
 		display: grid;
 		grid-template-columns: max-content 1fr;
 		column-gap: 8px;
-		row-gap: 4px;
+		/* row-gap: 4px; */
 	}
 
 	#svelte-inspector-toggle {
@@ -546,7 +553,7 @@
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
-		color: #ddd;
+		color: #444;
 	}
 
 	ul {
@@ -568,15 +575,21 @@
 		pointer-events: all;
 		font: inherit;
 		align-items: center;
+		cursor: pointer;
 
 		&:focus-visible {
 			outline: 2px solid #ff3e00;
+		}
+
+		&:hover,
+		&:focus-visible {
+			background-color: rgb(0 0 0 / 0.05);
 		}
 	}
 
 	hr {
 		margin: 2px;
-		background: rgb(255 255 255 / 0.2);
+		background: rgb(0 0 0 / 0.05);
 		border: none;
 		height: 1px;
 		width: 100%;
@@ -606,7 +619,7 @@
 
 		&:hover,
 		&:focus-visible {
-			background-color: rgb(255 255 255 / 0.1);
+			background-color: rgb(0 0 0 / 0.05);
 		}
 	}
 </style>

--- a/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
+++ b/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
@@ -444,7 +444,7 @@
 		bind:offsetHeight={h}
 	>
 		{#if menu}
-			<button aria-label="close" class="svelte-inspector-button">
+			<button aria-label="close" class="svelte-inspector-button" {@attach (node) => node.focus()}>
 				<span>close</span>
 				<svg
 					xmlns="http://www.w3.org/2000/svg"
@@ -452,8 +452,6 @@
 					width="1em"
 					height="1em"
 					viewBox="0 0 24 24"
-					fill="none"
-					stroke="currentColor"
 					stroke-width="2"
 					stroke-linecap="round"
 					stroke-linejoin="round"><path d="M18 6 6 18" /><path d="m6 6 12 12" /></svg
@@ -504,6 +502,11 @@
 		direction: ltr;
 	}
 
+	*:not(svg *) {
+		all: unset;
+		box-sizing: border-box;
+	}
+
 	#svelte-inspector-overlay {
 		position: fixed;
 		padding: 4px;
@@ -527,7 +530,6 @@
 	}
 
 	#svelte-inspector-toggle {
-		all: unset;
 		border: 1px solid #ff3e00;
 		border-radius: 8px;
 		position: fixed;
@@ -592,10 +594,16 @@
 	}
 
 	hr {
-		margin: 2px 4px;
+		margin: 2px;
 		background: rgb(255 255 255 / 0.2);
 		border: none;
 		height: 1px;
+		width: 100%;
+		display: block;
+	}
+
+	svg path {
+		stroke: currentColor;
 	}
 
 	.svelte-inspector-button {
@@ -606,7 +614,6 @@
 	}
 
 	.svelte-inspector-menu-row {
-		all: unset;
 		display: grid;
 		grid-column: 1 / 3;
 		grid-template-columns: subgrid;
@@ -616,7 +623,8 @@
 		padding: 4px 8px;
 		cursor: pointer;
 
-		&:hover {
+		&:hover,
+		&:focus-visible {
 			background-color: rgb(255 255 255 / 0.1);
 		}
 	}

--- a/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
+++ b/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
@@ -6,10 +6,6 @@
 
 	import options from 'virtual:svelte-inspector-options';
 	const toggle_combo = options.toggleKeyCombo?.toLowerCase().split('-');
-	// A second toggle, separate from the stock one. The stock combo (alt-x) keeps
-	// its original behaviour (click opens the innermost element); this combo
-	// enables "chain mode" where a click opens the wrapper-chain dropdown instead.
-	const chain_combo = ['alt', 'c'];
 	const escape_keys = options.escapeKeys?.map((k) => k.toLowerCase());
 	const nav_keys = Object.values(options.navKeys).map((k) => k?.toLowerCase());
 	const open_key = options.openKey?.toLowerCase();
@@ -40,9 +36,6 @@
 
 	// Wrapper-chain dropdown: null when closed, else { x, y, chain }.
 	let menu = $state(null);
-	// True while the chain combo is the active mode — a click then opens the
-	// dropdown instead of the stock single-element open.
-	let chain_mode = $state(false);
 
 	let hold_start_ts = $state();
 
@@ -251,14 +244,6 @@
 		return toggle_combo?.every((k) => is_active(k, e));
 	}
 
-	function is_chain_combo(e) {
-		return chain_combo.every((k) => is_active(k, e));
-	}
-
-	function is_chain_toggle(e) {
-		return chain_combo.some((k) => is_active(k, e));
-	}
-
 	function is_escape(e) {
 		return escape_keys?.some((k) => is_active(k, e));
 	}
@@ -286,27 +271,13 @@
 	}
 
 	function keydown(e) {
-		if (e.repeat || e.key == null || (!enabled && !is_toggle(e) && !is_chain_toggle(e))) {
+		if (e.repeat || e.key == null || (!enabled && !is_toggle(e))) {
 			return;
 		}
 		if (is_combo(e)) {
-			chain_mode = false;
 			toggle();
 			if (options.holdMode && enabled) {
 				hold_start_ts = Date.now();
-			}
-		} else if (is_chain_combo(e)) {
-			// chain mode is a sticky toggle (no hold) so you can release the keys
-			// and still click rows in the dropdown.
-			stop(e);
-			if (enabled && chain_mode) {
-				disable();
-			} else {
-				chain_mode = true;
-				if (!enabled) {
-					enable();
-				}
-				hold_start_ts = null;
 			}
 		} else if (enabled) {
 			if (is_nav(e)) {
@@ -396,7 +367,6 @@
 		has_opened = false;
 		hold_start_ts = null;
 		menu = null;
-		chain_mode = false;
 		const b = document.body;
 		listeners(b, enabled);
 		if (options.customStyles) {

--- a/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
+++ b/packages/vite-plugin-svelte/src/plugins/inspector/runtime/Inspector.svelte
@@ -136,9 +136,7 @@
 	}
 
 	function open_editor(e) {
-		if (menu) {
-			return;
-		}
+		if (menu) return;
 
 		if (file_loc) {
 			stop(e);
@@ -189,7 +187,7 @@
 	// Route a click by mode — the stock combo opens the innermost element
 	// (original behaviour), the chain combo opens the wrapper dropdown.
 	function on_contextmenu(e) {
-		if (e.target?.closest?.('#svelte-inspector-menu')) {
+		if (e.target?.closest?.('#svelte-inspector-overlay')) {
 			return; // a menu row was clicked — let its own handler run
 		}
 		e.preventDefault();

--- a/packages/vite-plugin-svelte/src/public.d.ts
+++ b/packages/vite-plugin-svelte/src/public.d.ts
@@ -229,6 +229,13 @@ export interface InspectorOptions {
 	openKey?: string;
 
 	/**
+	 * define key to open the context menu for the currently selected dom node
+	 *
+	 * @default ' '
+	 */
+	openMenuKey?: string;
+
+	/**
 	 * define keys to close the inspector
 	 * @default ['Backspace', 'Escape']
 	 */

--- a/packages/vite-plugin-svelte/types/index.d.ts
+++ b/packages/vite-plugin-svelte/types/index.d.ts
@@ -229,6 +229,13 @@ declare module '@sveltejs/vite-plugin-svelte' {
 		openKey?: string;
 
 		/**
+		 * define key to open the context menu for the currently selected dom node
+		 *
+		 * @default ' '
+		 */
+		openMenuKey?: string;
+
+		/**
 		 * define keys to close the inspector
 		 * @default ['Backspace', 'Escape']
 		 */

--- a/packages/vite-plugin-svelte/types/index.d.ts.map
+++ b/packages/vite-plugin-svelte/types/index.d.ts.map
@@ -27,6 +27,6 @@
 		null,
 		null
 	],
-	"mappings": ";;;aAGYA,OAAOA;;WAETC,mBAAmBA;;;;;;;;;;;kBAWZC,aAAaA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;kBAgFbC,YAAYA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;WAiDnBC,mBAAmBA;;;;;;;;;;;;;;;;WAgBnBC,oBAAoBA;;;;;;;;;;;;;;;MAezBC,SAASA;;kBAEGC,qBAAqBA;;;;;;;;;;;;;;kBAcrBC,gBAAgBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;iBCzKjBC,MAAMA;iBCGNC,cAAcA;iBCARC,gBAAgBA",
+	"mappings": ";;;aAGYA,OAAOA;;WAETC,mBAAmBA;;;;;;;;;;;kBAWZC,aAAaA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;kBAgFbC,YAAYA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;WAiDnBC,mBAAmBA;;;;;;;;;;;;;;;;WAgBnBC,oBAAoBA;;;;;;;;;;;;;;;MAezBC,SAASA;;kBAEGC,qBAAqBA;;;;;;;;;;;;;;kBAcrBC,gBAAgBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;iBCzKjBC,MAAMA;iBCGNC,cAAcA;iBCARC,gBAAgBA",
 	"ignoreList": []
 }


### PR DESCRIPTION
Adds the component stack from #1362, but behind a (right-click) context menu rather than a new key combo. Also unifies the styles between the two modes, and gives them a much needed facelift