### PR TITLE
fix(inspector): activate under Vite+ on pnpm by matching the realpathed client path

### DIFF
--- a/.changeset/inspector-pnpm-client-path.md
+++ b/.changeset/inspector-pnpm-client-path.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+fix: inject the inspector into the client under Vite+ on pnpm, where the realpathed client module has no `vite/` segment before `dist/`

--- a/packages/vite-plugin-svelte/src/plugins/inspector/index.js
+++ b/packages/vite-plugin-svelte/src/plugins/inspector/index.js
@@ -117,11 +117,8 @@ export function svelteInspector(api) {
 		transform: {
 			// Vite+ projects install vite@npm:@voidzero-dev/vite-plus-core@latest which
 			// changes the path from `vite/dist/client/client.mjs` to `vite/dist/vite/client/client.mjs`
-			// so we need to also account for the additional `vite` subdirectory.
-			// Under pnpm the `vite` alias is a symlink that Node's ESM resolver realpaths,
-			// so the client resolves to `…/@voidzero-dev/vite-plus-core/dist/vite/client/client.mjs`
-			// with no `vite/` segment before `dist/` — hence the leading `vite/` is optional
-			filter: { id: /(?:vite\/)?dist\/(?:vite\/)?client\/client\.mjs(?:\?|$)/ },
+			// TODO: inject with transformIndexHtml when it works with SSR
+			filter: { id: /(?:vite\/dist|vite\/dist\/vite|vite-plus-core\/dist\/vite)\/client\/client\.mjs(?:\?|$)/ },
 			handler(code) {
 				if (disabled) {
 					return;

--- a/packages/vite-plugin-svelte/src/plugins/inspector/index.js
+++ b/packages/vite-plugin-svelte/src/plugins/inspector/index.js
@@ -118,7 +118,9 @@ export function svelteInspector(api) {
 			// Vite+ projects install vite@npm:@voidzero-dev/vite-plus-core@latest which
 			// changes the path from `vite/dist/client/client.mjs` to `vite/dist/vite/client/client.mjs`
 			// TODO: inject with transformIndexHtml when it works with SSR
-			filter: { id: /(?:vite\/dist|vite\/dist\/vite|vite-plus-core\/dist\/vite)\/client\/client\.mjs(?:\?|$)/ },
+			filter: {
+				id: /(?:vite\/dist|vite\/dist\/vite|vite-plus-core\/dist\/vite)\/client\/client\.mjs(?:\?|$)/
+			},
 			handler(code) {
 				if (disabled) {
 					return;

--- a/packages/vite-plugin-svelte/src/plugins/inspector/index.js
+++ b/packages/vite-plugin-svelte/src/plugins/inspector/index.js
@@ -117,8 +117,11 @@ export function svelteInspector(api) {
 		transform: {
 			// Vite+ projects install vite@npm:@voidzero-dev/vite-plus-core@latest which
 			// changes the path from `vite/dist/client/client.mjs` to `vite/dist/vite/client/client.mjs`
-			// so we need to also account for the additional `vite` subdirectory
-			filter: { id: /vite\/dist\/(?:vite\/)?client\/client\.mjs(?:\?|$)/ },
+			// so we need to also account for the additional `vite` subdirectory.
+			// Under pnpm the `vite` alias is a symlink that Node's ESM resolver realpaths,
+			// so the client resolves to `…/@voidzero-dev/vite-plus-core/dist/vite/client/client.mjs`
+			// with no `vite/` segment before `dist/` — hence the leading `vite/` is optional
+			filter: { id: /(?:vite\/)?dist\/(?:vite\/)?client\/client\.mjs(?:\?|$)/ },
 			handler(code) {
 				if (disabled) {
 					return;


### PR DESCRIPTION
Follow-up to #1355.

## Problem

#1355 fixed inspector activation under [Vite+](https://viteplus.dev), but the filter that was merged only covers installs where the `vite` alias directory name survives in the resolved client path:

```js
filter: { id: /vite\/dist\/(?:vite\/)?client\/client\.mjs(?:\?|$)/ }
```

That's the case with npm/yarn, where `vite@npm:@voidzero-dev/vite-plus-core` materializes a real `node_modules/vite` directory. Under **pnpm**, `node_modules/vite` is a **symlink**, and Node's ESM resolver resolves it to the realpath, so `VITE_PACKAGE_DIR` (derived from `import.meta.url`) — and therefore `CLIENT_ENTRY` — ends up as:

```
…/node_modules/.pnpm/@voidzero-dev+vite-plus-core@0.2.1_…/node_modules/@voidzero-dev/vite-plus-core/dist/vite/client/client.mjs
```

There is no `vite/dist/` substring in that path, so the merged filter never matches, the `load-inspector` import is never appended to the client, and the inspector doesn't activate — the same symptom #1355 set out to fix.

## Change

Make the leading `vite/` optional:

```js
filter: { id: /(?:vite\/)?dist\/(?:vite\/)?client\/client\.mjs(?:\?|$)/ }
```

This matches all three shapes:

| Path | before | after |
| --- | --- | --- |
| `…/vite/dist/client/client.mjs` (stock Vite) | ✅ | ✅ |
| `…/vite/dist/vite/client/client.mjs` (Vite+, npm/yarn alias dir) | ✅ | ✅ |
| `…/@voidzero-dev/vite-plus-core/dist/vite/client/client.mjs` (Vite+, pnpm realpath) | ❌ | ✅ |

## Verification

Tested in a pnpm monorepo running SvelteKit on Vite+:

- with unpatched `@sveltejs/vite-plugin-svelte@7.2.0`, the inspector never activates (Alt+X does nothing; `/@vite/client` contains no `load-inspector` import)
- with this change (applied via `pnpm patch`), the inspector activates and works as expected

Resolution check confirming the realpath:

```js
await import.meta.resolve('vite')
// file:///…/node_modules/.pnpm/@voidzero-dev+vite-plus-core@0.2.1_…/node_modules/@voidzero-dev/vite-plus-core/dist/vite/node/index.js
```

Environment:

| | |
| --- | --- |
| `@sveltejs/vite-plugin-svelte` | 7.2.0 |
| `vite-plus` / `@voidzero-dev/vite-plus-core` | 0.2.1 |
| pnpm | 11.10.0 |
| Node.js | 24.11.0 |
| `svelte` | 5.56.x |
| `@sveltejs/kit` | 2.61.x |
| OS | macOS (darwin 25.4.0) |
