### PR TITLE
fix: don't log inline config when encountering unexpected options

### DIFF
--- a/.changeset/common-bushes-kick.md
+++ b/.changeset/common-bushes-kick.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+fix: don't log inline config when encountering unexpected options

--- a/packages/vite-plugin-svelte/src/utils/options.js
+++ b/packages/vite-plugin-svelte/src/utils/options.js
@@ -60,8 +60,12 @@ export function validateInlineOptions(inlineOptions) {
 	const invalidKeys = Object.keys(inlineOptions || {}).filter(
 		(key) => !allowedInlineOptions.has(key)
 	);
-	if (invalidKeys.length) {
-		log.warn(`invalid plugin options "${invalidKeys.join(', ')}" in inline config`, inlineOptions);
+
+	const n = invalidKeys.length;
+	if (n > 0) {
+		log.warn(
+			`invalid plugin ${n === 1 ? 'option' : 'options'} ${invalidKeys.map((k) => `\`${k}\``).join(', ')} in inline config`
+		);
 	}
 }
 


### PR DESCRIPTION
Little surprised we don't throw on unexpected options. I think we probably should, though that would be a breaking change. In the meantime, logging the options themselves is silly — they're right there in your config. This PR changes it to just logging the message, and slightly improves the message