### PR TITLE
fix: stub out exported snippets during dependency scanning

### DIFF
--- a/.changeset/sunny-cities-cough.md
+++ b/.changeset/sunny-cities-cough.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+fix: support exported snippets during dependency scanning

--- a/packages/e2e-tests/scan-deps/__tests__/scan-deps.spec.ts
+++ b/packages/e2e-tests/scan-deps/__tests__/scan-deps.spec.ts
@@ -12,6 +12,8 @@ describe('vite import scan', () => {
 		expect(await getText('#svelte4single')).toBe('svelte4single');
 		expect(await getText('#svelte4none')).toBe('svelte4none');
 		expect(await getText('#svelte4space')).toBe('svelte4space');
+		expect(await getText('#svelte5named')).toBe('svelte5named');
 		expect(await getText('#svelte5snippet')).toBe('svelte5snippet');
+		expect(await getText('#svelte5snippet-alias')).toBe('svelte5snippet');
 	});
 });

--- a/packages/e2e-tests/scan-deps/__tests__/scan-deps.spec.ts
+++ b/packages/e2e-tests/scan-deps/__tests__/scan-deps.spec.ts
@@ -12,5 +12,6 @@ describe('vite import scan', () => {
 		expect(await getText('#svelte4single')).toBe('svelte4single');
 		expect(await getText('#svelte4none')).toBe('svelte4none');
 		expect(await getText('#svelte4space')).toBe('svelte4space');
+		expect(await getText('#svelte5snippet')).toBe('svelte5snippet');
 	});
 });

--- a/packages/e2e-tests/scan-deps/src/App.svelte
+++ b/packages/e2e-tests/scan-deps/src/App.svelte
@@ -1,5 +1,5 @@
 <script>
-	import { svelte5, svelte5snippet } from './Svelte5.svelte';
+	import { svelte5, svelte5named, svelte5snippet, svelte5snippetAlias } from './Svelte5.svelte';
 	import { svelte4double } from './Svelte4DoubleQuote.svelte';
 	import { svelte4single } from './Svelte4SingleQuote.svelte';
 	import { svelte4none } from './Svelte4NoQuote.svelte';
@@ -11,4 +11,6 @@
 <div id="svelte4single">{svelte4single}</div>
 <div id="svelte4none">{svelte4none}</div>
 <div id="svelte4space">{svelte4space}</div>
+<div id="svelte5named">{svelte5named}</div>
 <div id="svelte5snippet">{@render svelte5snippet()}</div>
+<div id="svelte5snippet-alias">{@render svelte5snippetAlias()}</div>

--- a/packages/e2e-tests/scan-deps/src/App.svelte
+++ b/packages/e2e-tests/scan-deps/src/App.svelte
@@ -1,5 +1,5 @@
 <script>
-	import { svelte5 } from './Svelte5.svelte';
+	import { svelte5, svelte5snippet } from './Svelte5.svelte';
 	import { svelte4double } from './Svelte4DoubleQuote.svelte';
 	import { svelte4single } from './Svelte4SingleQuote.svelte';
 	import { svelte4none } from './Svelte4NoQuote.svelte';
@@ -11,3 +11,4 @@
 <div id="svelte4single">{svelte4single}</div>
 <div id="svelte4none">{svelte4none}</div>
 <div id="svelte4space">{svelte4space}</div>
+<div id="svelte5snippet">{@render svelte5snippet()}</div>

--- a/packages/e2e-tests/scan-deps/src/Svelte5.svelte
+++ b/packages/e2e-tests/scan-deps/src/Svelte5.svelte
@@ -1,6 +1,7 @@
 <script module>
 	export const svelte5 = 'svelte5';
-	export { svelte5snippet };
+	const svelte5named = 'svelte5named';
+	export { svelte5named, svelte5snippet, svelte5snippet as svelte5snippetAlias };
 </script>
 
 {#snippet svelte5snippet()}

--- a/packages/e2e-tests/scan-deps/src/Svelte5.svelte
+++ b/packages/e2e-tests/scan-deps/src/Svelte5.svelte
@@ -1,3 +1,8 @@
 <script module>
 	export const svelte5 = 'svelte5';
+	export { svelte5snippet };
 </script>
+
+{#snippet svelte5snippet()}
+	svelte5snippet
+{/snippet}

--- a/packages/vite-plugin-svelte/src/plugins/setup-optimizer.js
+++ b/packages/vite-plugin-svelte/src/plugins/setup-optimizer.js
@@ -98,7 +98,21 @@ function rolldownOptimizerPlugin(api, consumer, components) {
 			delete plugin.buildStart;
 			delete plugin.transform;
 			delete plugin.buildEnd;
+			if (components) {
+				plugin.load = {
+					filter: { id: includeRe },
+					async handler(filename) {
+						try {
+							const code = await fs.readFile(filename.replace(/[?#].*$/s, ''), 'utf8');
+							return await compileFn(api.options, { filename, code }, generate, statsCollection);
+						} catch (e) {
+							throw toRollupError(e, api.options);
+						}
+					}
+				};
+			}
 		} else {
+			delete plugin.load;
 			plugin.transform = {
 				filter: { id: includeRe },
 				/**

--- a/packages/vite-plugin-svelte/src/plugins/setup-optimizer.js
+++ b/packages/vite-plugin-svelte/src/plugins/setup-optimizer.js
@@ -8,6 +8,7 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import * as svelte from 'svelte/compiler';
+import { parseSync } from 'vite';
 import { log } from '../utils/log.js';
 import { toRollupError } from '../utils/error.js';
 import { SVELTE_IMPORTS } from '../utils/constants.js';
@@ -19,6 +20,7 @@ import { isDepExcluded } from 'vitefu';
 
 const optimizeSveltePluginName = 'vite-plugin-svelte:optimize';
 const optimizeSvelteModulePluginName = 'vite-plugin-svelte:optimize-module';
+const viteDepScanVirtualModulePrefix = 'virtual-module:';
 
 /**
  * @param {PluginAPI} api
@@ -83,6 +85,8 @@ function rolldownOptimizerPlugin(api, consumer, components) {
 	const generate = consumer === 'server' ? 'server' : 'client';
 	/** @type {StatCollection | undefined} */
 	let statsCollection;
+	/** @type {Map<string, Promise<Set<string>>>} */
+	const topLevelSnippetNames = new Map();
 
 	/**@type {Rolldown.Plugin}*/
 	const plugin = {
@@ -96,23 +100,44 @@ function rolldownOptimizerPlugin(api, consumer, components) {
 		);
 		if (isScanner) {
 			delete plugin.buildStart;
-			delete plugin.transform;
 			delete plugin.buildEnd;
 			if (components) {
-				plugin.load = {
-					filter: { id: includeRe },
-					async handler(filename) {
-						try {
-							const code = await fs.readFile(filename.replace(/[?#].*$/s, ''), 'utf8');
-							return await compileFn(api.options, { filename, code }, generate, statsCollection);
-						} catch (e) {
-							throw toRollupError(e, api.options);
+				topLevelSnippetNames.clear();
+				plugin.transform = {
+					filter: { id: includeRe, moduleType: ['js'], code: /\bexport\b/ },
+					async handler(code, filename) {
+						const svelteFilename = getScannedSvelteFilename(filename);
+						if (!svelteFilename) return;
+
+						// Vite gives us only the extracted script, so this identifies exports but
+						// cannot tell whether an undeclared name is a template snippet
+						const localExports = getLocalNamedExports(code, filename);
+						if (localExports.length === 0) return;
+
+						let snippetNamesPromise = topLevelSnippetNames.get(svelteFilename);
+						if (!snippetNamesPromise) {
+							// Parse the full component only for named-export candidates, then cache its
+							// snippet names so each component is read once per scan
+							snippetNamesPromise = getTopLevelSnippetNames(svelteFilename);
+							topLevelSnippetNames.set(svelteFilename, snippetNamesPromise);
 						}
+
+						const snippetNames = await snippetNamesPromise;
+						const exportedSnippets = [
+							...new Set(localExports.filter((name) => snippetNames.has(name)))
+						];
+						if (exportedSnippets.length === 0) return;
+
+						// Stub confirmed snippets, stubbing every export could collide with normal bindings
+						return {
+							code: `${code}\nconst ${exportedSnippets.map((name) => `${name} = null`).join(', ')};`
+						};
 					}
 				};
+			} else {
+				delete plugin.transform;
 			}
 		} else {
-			delete plugin.load;
 			plugin.transform = {
 				filter: { id: includeRe },
 				/**
@@ -139,6 +164,54 @@ function rolldownOptimizerPlugin(api, consumer, components) {
 	};
 
 	return plugin;
+}
+
+/**
+ * @param {string} filename
+ * @returns {string | undefined}
+ */
+function getScannedSvelteFilename(filename) {
+	if (!filename.startsWith(viteDepScanVirtualModulePrefix)) return;
+	const queryIndex = filename.lastIndexOf('?id=');
+	if (queryIndex === -1) return;
+	return filename.slice(viteDepScanVirtualModulePrefix.length, queryIndex);
+}
+
+/**
+ * @param {string} code
+ * @param {string} filename
+ * @returns {string[]}
+ */
+function getLocalNamedExports(code, filename) {
+	const result = parseSync(filename, code, { lang: 'js' });
+	if (result.errors.length > 0) return [];
+
+	const names = [];
+	for (const node of result.program.body) {
+		if (node.type !== 'ExportNamedDeclaration' || node.source || node.declaration) continue;
+		for (const specifier of node.specifiers) {
+			if (specifier.local.type === 'Identifier') names.push(specifier.local.name);
+		}
+	}
+	return names;
+}
+
+/**
+ * @param {string} filename
+ * @returns {Promise<Set<string>>}
+ */
+async function getTopLevelSnippetNames(filename) {
+	try {
+		const code = await fs.readFile(filename, 'utf8');
+		const ast = svelte.parse(code, { filename, modern: true });
+		return new Set(
+			ast.fragment.nodes
+				.filter((node) => node.type === 'SnippetBlock')
+				.map((snippet) => snippet.expression.name)
+		);
+	} catch {
+		return new Set();
+	}
 }
 
 /**


### PR DESCRIPTION
Fixes #1356

~~Make vite-plugin-svelte compile the whole .svelte component during dependency scanning, so template-declared exports such as top-level snippets can be resolved.~~

Stub out exported snippets during depenendency scanning so that template-declared (non lang="ts") snippet exports can be resolved.