### PR TITLE
fix: configure api when plugin is used replaced with `applyToEnvironment`

### DIFF
--- a/.changeset/upset-melons-fix.md
+++ b/.changeset/upset-melons-fix.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+fix: configure api when plugin is used replaced with `applyToEnvironment`

--- a/packages/vite-plugin-svelte/__tests__/environment-api.spec.js
+++ b/packages/vite-plugin-svelte/__tests__/environment-api.spec.js
@@ -1,0 +1,36 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createServer, perEnvironmentPlugin } from 'vite';
+import { svelte } from '../src/index.js';
+
+describe('environment API', () => {
+	let root;
+	let server;
+
+	afterEach(async () => {
+		await server?.close();
+		if (root) await fs.rm(root, { recursive: true, force: true });
+	});
+
+	it.each([
+		['normally', () => svelte()],
+		['through perEnvironmentPlugin', () => [perEnvironmentPlugin('svelte', () => svelte())]]
+	])('initializes the plugin %s', async (_, createPlugins) => {
+		root = await fs.mkdtemp(path.join(path.dirname(fileURLToPath(import.meta.url)), '../.test-'));
+		await fs.writeFile(path.join(root, 'App.svelte'), '<h1>Hello</h1>');
+
+		server = await createServer({
+			root,
+			configFile: false,
+			logLevel: 'silent',
+			server: { port: 0 },
+			plugins: createPlugins()
+		});
+		await server.listen();
+
+		const result = await server.environments.client.transformRequest('/App.svelte');
+		expect(result?.code).toMatch(/svelte(?:_|\/)internal(?:_|\/)client/);
+	});
+});

--- a/packages/vite-plugin-svelte/src/index.js
+++ b/packages/vite-plugin-svelte/src/index.js
@@ -25,9 +25,18 @@ export function svelte(inlineOptions) {
 	if (process.env.DEBUG != null) {
 		log.setLevel('debug');
 	}
+	/** @type {Array<(config: import('vite').ResolvedConfig) => void>} */
+	const configResolvedCallbacks = [];
 	/** @type {PluginAPI} */
-	// @ts-expect-error initialize empty to guard against early use
-	const api = {}; // initialized by configure plugin, used in others
+	// @ts-expect-error resolved fields are initialized by the configure plugin
+	const api = {
+		onConfigResolved(callback) {
+			configResolvedCallbacks.push(callback);
+		},
+		runConfigResolved(config) {
+			for (const callback of configResolvedCallbacks) callback(config);
+		}
+	};
 	return [
 		{ name: 'vite-plugin-svelte' }, // marker for detection logic in other plugins that expect this name
 		configure(api, inlineOptions),

--- a/packages/vite-plugin-svelte/src/plugins/compile-module.js
+++ b/packages/vite-plugin-svelte/src/plugins/compile-module.js
@@ -33,13 +33,6 @@ export function compileModule(api) {
 	const plugin = {
 		name: 'vite-plugin-svelte:compile-module',
 		enforce: 'post',
-		async configResolved() {
-			options = api.options;
-			//@ts-expect-error transform defined below but filter not in type
-			plugin.transform.filter = buildModuleIdFilter(options);
-			idParser = buildModuleIdParser(options);
-			staticModuleCompileOptions = filterNonModuleCompilerOptions(options.compilerOptions);
-		},
 		transform: {
 			async handler(code, id) {
 				const ssr = this.environment.config.consumer === 'server';
@@ -97,6 +90,13 @@ export function compileModule(api) {
 			}
 		}
 	};
+	api.onConfigResolved(() => {
+		options = api.options;
+		//@ts-expect-error transform defined below but filter not in type
+		plugin.transform.filter = buildModuleIdFilter(options);
+		idParser = buildModuleIdParser(options);
+		staticModuleCompileOptions = filterNonModuleCompilerOptions(options.compilerOptions);
+	});
 	return plugin;
 }
 

--- a/packages/vite-plugin-svelte/src/plugins/compile.js
+++ b/packages/vite-plugin-svelte/src/plugins/compile.js
@@ -23,12 +23,6 @@ export function compile(api) {
 	/** @type {Plugin} */
 	const plugin = {
 		name: 'vite-plugin-svelte:compile',
-		configResolved() {
-			//@ts-expect-error defined below but filter not in type
-			plugin.transform.filter = api.filter;
-			options = api.options;
-			compileSvelte = api.compileSvelte;
-		},
 		transform: {
 			async handler(code, id) {
 				const ssr = this.environment.config.consumer === 'server';
@@ -66,5 +60,11 @@ export function compile(api) {
 			}
 		}
 	};
+	api.onConfigResolved(() => {
+		//@ts-expect-error defined below but filter not in type
+		plugin.transform.filter = api.filter;
+		options = api.options;
+		compileSvelte = api.compileSvelte;
+	});
 	return plugin;
 }

--- a/packages/vite-plugin-svelte/src/plugins/configure.js
+++ b/packages/vite-plugin-svelte/src/plugins/configure.js
@@ -30,6 +30,21 @@ export function configure(api, inlineOptions) {
 	 */
 	let preOptions;
 
+	/** @param {import('vite').ResolvedConfig} config */
+	function configureApi(config) {
+		const options = resolveOptions(preOptions, config);
+		api.options = options;
+		if (isDebugNamespaceEnabled('stats')) {
+			api.options.stats = new VitePluginSvelteStats();
+		}
+
+		api.filter = buildIdFilter(options);
+		api.idParser = buildIdParser(options);
+		api.compileSvelte = createCompileSvelte();
+		api.runConfigResolved(config);
+		log.debug('resolved options', api.options, 'config');
+	}
+
 	/** @type {Plugin} */
 	return {
 		name: 'vite-plugin-svelte:config',
@@ -56,16 +71,27 @@ export function configure(api, inlineOptions) {
 		configResolved: {
 			order: 'pre',
 			handler(config) {
-				const options = resolveOptions(preOptions, config);
-				api.options = options;
-				if (isDebugNamespaceEnabled('stats')) {
-					api.options.stats = new VitePluginSvelteStats();
-				}
+				configureApi(config);
+			}
+		},
 
-				api.filter = buildIdFilter(options);
-				api.idParser = buildIdParser(options);
-				api.compileSvelte = createCompileSvelte();
-				log.debug('resolved options', api.options, 'config');
+		buildStart: {
+			order: 'pre',
+			sequential: true,
+			async handler() {
+				if (api.options) return;
+				// Plugins returned by applyToEnvironment are created after Vite runs configResolved.
+				const config = this.environment.getTopLevelConfig();
+				preOptions = await preResolveOptions(
+					inlineOptions,
+					{ root: config.root },
+					{
+						command: config.command,
+						mode: config.mode,
+						isSsrBuild: config.command === 'build' && !!config.build.ssr
+					}
+				);
+				configureApi(config);
 			}
 		},
 

--- a/packages/vite-plugin-svelte/src/plugins/hot-update.js
+++ b/packages/vite-plugin-svelte/src/plugins/hot-update.js
@@ -31,24 +31,6 @@ export function hotUpdate(api) {
 	const plugin = {
 		name: 'vite-plugin-svelte:hot-update',
 		enforce: 'post',
-		configResolved() {
-			options = api.options;
-			idParser = api.idParser;
-
-			// @ts-expect-error
-			plugin.transform.filter = {
-				id: {
-					// reinclude virtual styles to get their output
-					include: [...api.filter.id.include, SVELTE_VIRTUAL_STYLE_ID_REGEX],
-					exclude: [
-						// ignore files in node_modules, we don't hot update them
-						/\/node_modules\//,
-						// remove style exclusion
-						...api.filter.id.exclude.filter((filter) => filter !== SVELTE_VIRTUAL_STYLE_ID_REGEX)
-					]
-				}
-			};
-		},
 
 		applyToEnvironment(env) {
 			// we only handle updates for client components
@@ -141,6 +123,24 @@ export function hotUpdate(api) {
 			}
 		}
 	};
+	api.onConfigResolved(() => {
+		options = api.options;
+		idParser = api.idParser;
+
+		// @ts-expect-error
+		plugin.transform.filter = {
+			id: {
+				// reinclude virtual styles to get their output
+				include: [...api.filter.id.include, SVELTE_VIRTUAL_STYLE_ID_REGEX],
+				exclude: [
+					// ignore files in node_modules, we don't hot update them
+					/\/node_modules\//,
+					// remove style exclusion
+					...api.filter.id.exclude.filter((filter) => filter !== SVELTE_VIRTUAL_STYLE_ID_REGEX)
+				]
+			}
+		};
+	});
 
 	return plugin;
 }

--- a/packages/vite-plugin-svelte/src/plugins/inspector/index.js
+++ b/packages/vite-plugin-svelte/src/plugins/inspector/index.js
@@ -37,7 +37,8 @@ export function svelteInspector(api) {
 	let inspectorOptions;
 	let disabled = false;
 
-	return {
+	/** @type {Plugin} */
+	const plugin = {
 		name: 'vite-plugin-svelte-inspector',
 		apply: 'serve',
 		enforce: 'pre',
@@ -46,35 +47,6 @@ export function svelteInspector(api) {
 			return !disabled && env.config.consumer === 'client';
 		},
 
-		configResolved(config) {
-			const environmentOptions = parseEnvironmentOptions(config);
-			if (environmentOptions === false) {
-				log.debug('environment options set to false, inspector disabled', null, 'inspector');
-				disabled = true;
-				return;
-			}
-			const configFileOptions = api.options?.inspector;
-
-			if (!configFileOptions && !environmentOptions) {
-				log.debug('no inspector options found, inspector disabled', null, 'inspector');
-				disabled = true;
-				return;
-			}
-
-			if (environmentOptions === true) {
-				inspectorOptions = defaultInspectorOptions;
-			} else {
-				inspectorOptions = {
-					...defaultInspectorOptions,
-					...(typeof configFileOptions === 'object' ? configFileOptions : {}),
-					...(environmentOptions || {})
-				};
-			}
-
-			inspectorOptions.__internal = {
-				base: config.base?.replace(/\/$/, '') || ''
-			};
-		},
 		resolveId: {
 			filter: {
 				id: /^virtual:svelte-inspector-/
@@ -127,4 +99,34 @@ export function svelteInspector(api) {
 			}
 		}
 	};
+	api.onConfigResolved((config) => {
+		const environmentOptions = parseEnvironmentOptions(config);
+		if (environmentOptions === false) {
+			log.debug('environment options set to false, inspector disabled', null, 'inspector');
+			disabled = true;
+			return;
+		}
+		const configFileOptions = api.options?.inspector;
+
+		if (!configFileOptions && !environmentOptions) {
+			log.debug('no inspector options found, inspector disabled', null, 'inspector');
+			disabled = true;
+			return;
+		}
+
+		if (environmentOptions === true) {
+			inspectorOptions = defaultInspectorOptions;
+		} else {
+			inspectorOptions = {
+				...defaultInspectorOptions,
+				...(typeof configFileOptions === 'object' ? configFileOptions : {}),
+				...(environmentOptions || {})
+			};
+		}
+
+		inspectorOptions.__internal = {
+			base: config.base?.replace(/\/$/, '') || ''
+		};
+	});
+	return plugin;
 }

--- a/packages/vite-plugin-svelte/src/plugins/load-compiled-css.js
+++ b/packages/vite-plugin-svelte/src/plugins/load-compiled-css.js
@@ -15,14 +15,9 @@ export function loadCompiledCss(api) {
 
 	/** @type{Map<string,any>} */
 	const buildWatchCssCache = new Map();
-	return {
+	/** @type {Plugin} */
+	const plugin = {
 		name: 'vite-plugin-svelte:load-compiled-css',
-
-		configResolved(c) {
-			const isDev = c.command === 'serve';
-			const isBuildWatch = !!c.build?.watch;
-			useLocalCache = isDev || isBuildWatch;
-		},
 
 		resolveId: {
 			filter, // same filter in load to ensure minimal work
@@ -76,4 +71,10 @@ export function loadCompiledCss(api) {
 			}
 		}
 	};
+	api.onConfigResolved((config) => {
+		const isDev = config.command === 'serve';
+		const isBuildWatch = !!config.build?.watch;
+		useLocalCache = isDev || isBuildWatch;
+	});
+	return plugin;
 }

--- a/packages/vite-plugin-svelte/src/plugins/load-custom.js
+++ b/packages/vite-plugin-svelte/src/plugins/load-custom.js
@@ -16,10 +16,6 @@ export function loadCustom(api) {
 	const plugin = {
 		name: 'vite-plugin-svelte:load-custom',
 		enforce: 'pre', // must come before vites own asset handling or custom extensions like .svg won't work
-		configResolved() {
-			//@ts-expect-error load defined below but filter not in type
-			plugin.load.filter = api.filter;
-		},
 
 		load: {
 			//filter: is set in configResolved
@@ -41,5 +37,9 @@ export function loadCustom(api) {
 			}
 		}
 	};
+	api.onConfigResolved(() => {
+		//@ts-expect-error load defined below but filter not in type
+		plugin.load.filter = api.filter;
+	});
 	return plugin;
 }

--- a/packages/vite-plugin-svelte/src/plugins/preprocess.js
+++ b/packages/vite-plugin-svelte/src/plugins/preprocess.js
@@ -37,24 +37,6 @@ export function preprocess(api) {
 	const plugin = {
 		name: 'vite-plugin-svelte:preprocess',
 		enforce: 'pre',
-		configResolved(c) {
-			options = api.options;
-			if (arraify(options.preprocess).length > 0) {
-				preprocessSvelte = createPreprocessSvelte(options, c);
-				// @ts-expect-error defined below but filter not in type
-				plugin.transform.filter = api.filter;
-			} else {
-				log.debug(
-					`disabling ${plugin.name} because no preprocessor is configured`,
-					undefined,
-					'preprocess'
-				);
-				// @ts-expect-error force set undefined to clear memory
-				preprocessSvelte = undefined;
-				// @ts-expect-error defined below but filter not in type
-				plugin.transform.filter = { id: /$./ }; // never match
-			}
-		},
 		configureServer(server) {
 			dependenciesCache = new DependenciesCache(server);
 		},
@@ -93,6 +75,24 @@ export function preprocess(api) {
 			}
 		}
 	};
+	api.onConfigResolved((config) => {
+		options = api.options;
+		if (arraify(options.preprocess).length > 0) {
+			preprocessSvelte = createPreprocessSvelte(options, config);
+			// @ts-expect-error defined below but filter not in type
+			plugin.transform.filter = api.filter;
+		} else {
+			log.debug(
+				`disabling ${plugin.name} because no preprocessor is configured`,
+				undefined,
+				'preprocess'
+			);
+			// @ts-expect-error force set undefined to clear memory
+			preprocessSvelte = undefined;
+			// @ts-expect-error defined below but filter not in type
+			plugin.transform.filter = { id: /$./ }; // never match
+		}
+	});
 	return plugin;
 }
 /**

--- a/packages/vite-plugin-svelte/src/plugins/setup-optimizer.js
+++ b/packages/vite-plugin-svelte/src/plugins/setup-optimizer.js
@@ -28,7 +28,8 @@ export function setupOptimizer(api) {
 	/** @type {ResolvedConfig} */
 	let viteConfig;
 
-	return {
+	/** @type {Plugin} */
+	const plugin = {
 		name: 'vite-plugin-svelte:setup-optimizer',
 		apply: 'serve',
 		configEnvironment(name, config) {
@@ -54,9 +55,6 @@ export function setupOptimizer(api) {
 
 			return { optimizeDeps };
 		},
-		configResolved(c) {
-			viteConfig = c;
-		},
 		async buildStart() {
 			if (!api.options.prebundleSvelteLibraries) return;
 			const changed = await svelteMetadataChanged(viteConfig.cacheDir, api.options);
@@ -67,6 +65,10 @@ export function setupOptimizer(api) {
 			}
 		}
 	};
+	api.onConfigResolved((config) => {
+		viteConfig = config;
+	});
+	return plugin;
 }
 
 /**

--- a/packages/vite-plugin-svelte/src/types/plugin-api.d.ts
+++ b/packages/vite-plugin-svelte/src/types/plugin-api.d.ts
@@ -1,10 +1,13 @@
 import type { ResolvedOptions } from './options.d.ts';
 import type { IdFilter, IdParser } from './id.d.ts';
 import type { CompileSvelte } from './compile.d.ts';
+import type { ResolvedConfig } from 'vite';
 
 export interface PluginAPI {
 	options: ResolvedOptions;
 	filter: IdFilter;
 	idParser: IdParser;
 	compileSvelte: CompileSvelte;
+	onConfigResolved: (callback: (config: ResolvedConfig) => void) => void;
+	runConfigResolved: (config: ResolvedConfig) => void;
 }


### PR DESCRIPTION
This PR fixes a problem when using the svelte plugin with `applyToEnvironment` or `perEnvironmentPlugin` (which is just a thin wrapper around `applyToEnvironment`).

The issue is that when there's multiple environment, and you use `applyToEnvironment` the `configResolved` hook is invoked before `applyToEnvironment` and since we assign to the `api` object only in `configResolved` the other plugins that try to use `api` fails.

The solution is to retry to load the config inside `buildStart` (which despite the name is also invoked in dev) unless the api has already been configured. There's a problem, tho: other plugins also relied on `configResolved`. I tried different solutions like always using `buildStart` instead of `configResolved` (this failed when not using `applyToEnvironment`), using a getter/setter for `options` but none felt better than what I have here which is adding a callback registry to the `api` object so that plugins can register there instead of using `configResolved`.

I tried and it seems to work well but please let me know if you have better ideas.