### PR TITLE
feat: pass environment to `dynamicCompileOptions`

### DIFF
--- a/.changeset/witty-bars-film.md
+++ b/.changeset/witty-bars-film.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': minor
+---
+
+feat: pass environment to `dynamicCompileOptions`

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -24,6 +24,7 @@ export default {
 				'.changeset/pre.json',
 				'**/vite.config.js.timestamp-*.mjs',
 				'packages/e2e-tests/dynamic-compile-options/src/components/A.svelte',
+				'packages/e2e-tests/dynamic-compile-options/src/components/Environment.svelte',
 				'packages/playground/big/src/pages/**', // lots of generated files
 				'packages/e2e-tests/scan-deps/src/Svelte*.svelte', // various syntax tests that require no format
 				'**/.vite-inspect/**',

--- a/docs/config.md
+++ b/docs/config.md
@@ -231,7 +231,7 @@ A [picomatch pattern](https://github.com/micromatch/picomatch), or array of patt
     filename: string; // The file to be compiled
     code: string; // The preprocessed Svelte code
     compileOptions: Partial<CompileOptions>; // The current compiler options
-    environment: Environment; // The current Vite environment, if available
+    environment: Environment; // The current Vite environment
   }) => Promise<Partial<CompileOptions> | void> | Partial<CompileOptions> | void;
   ```
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -231,6 +231,7 @@ A [picomatch pattern](https://github.com/micromatch/picomatch), or array of patt
     filename: string; // The file to be compiled
     code: string; // The preprocessed Svelte code
     compileOptions: Partial<CompileOptions>; // The current compiler options
+    environment?: Environment; // The current Vite environment, if available
   }) => Promise<Partial<CompileOptions> | void> | Partial<CompileOptions> | void;
   ```
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -231,7 +231,7 @@ A [picomatch pattern](https://github.com/micromatch/picomatch), or array of patt
     filename: string; // The file to be compiled
     code: string; // The preprocessed Svelte code
     compileOptions: Partial<CompileOptions>; // The current compiler options
-    environment?: Environment; // The current Vite environment, if available
+    environment: Environment; // The current Vite environment, if available
   }) => Promise<Partial<CompileOptions> | void> | Partial<CompileOptions> | void;
   ```
 
@@ -244,9 +244,9 @@ A [picomatch pattern](https://github.com/micromatch/picomatch), or array of patt
   export default defineConfig({
     plugins: [
       svelte({
-        dynamicCompileOptions({ filename, compileOptions }) {
+        dynamicCompileOptions({ filename, compileOptions, environment }) {
           // Dynamically set runes mode per Svelte file
-          if (forceRunesMode(filename) && !compileOptions.runes) {
+          if (environment.name === 'client' && forceRunesMode(filename) && !compileOptions.runes) {
             return { runes: true };
           }
         }

--- a/packages/e2e-tests/_test_dependencies/svelte-simple/index.js
+++ b/packages/e2e-tests/_test_dependencies/svelte-simple/index.js
@@ -1,2 +1,3 @@
 import Dependency from './src/components/Dependency.svelte';
+export { default as Environment } from './src/components/Environment.svelte';
 export default Dependency;

--- a/packages/e2e-tests/_test_dependencies/svelte-simple/src/components/Environment.svelte
+++ b/packages/e2e-tests/_test_dependencies/svelte-simple/src/components/Environment.svelte
@@ -1,0 +1,1 @@
+<div id="optimizer-environment">    optimizer environment</div>

--- a/packages/e2e-tests/dynamic-compile-options/__tests__/dynamic-compile-options.spec.ts
+++ b/packages/e2e-tests/dynamic-compile-options/__tests__/dynamic-compile-options.spec.ts
@@ -4,3 +4,7 @@ test('should respect dynamic compile option preserveWhitespace: true for A', asy
 	expect(await getText('#A')).toBe('    preserved leading whitespace');
 	expect(await getText('#B')).toBe('removed leading whitespace');
 });
+
+test('passes the current environment to dynamicCompileOptions', async () => {
+	expect(await getText('#environment')).toBe('    environment');
+});

--- a/packages/e2e-tests/dynamic-compile-options/src/App.svelte
+++ b/packages/e2e-tests/dynamic-compile-options/src/App.svelte
@@ -1,7 +1,9 @@
 <script>
 	import A from './components/A.svelte';
 	import B from './components/B.svelte';
+	import Environment from './components/Environment.svelte';
 </script>
 
 <A />
 <B />
+<Environment />

--- a/packages/e2e-tests/dynamic-compile-options/src/components/Environment.svelte
+++ b/packages/e2e-tests/dynamic-compile-options/src/components/Environment.svelte
@@ -1,0 +1,1 @@
+<div id="environment">    environment</div>

--- a/packages/e2e-tests/dynamic-compile-options/vite.config.js
+++ b/packages/e2e-tests/dynamic-compile-options/vite.config.js
@@ -5,8 +5,13 @@ export default defineConfig(() => {
 	return {
 		plugins: [
 			svelte({
-				dynamicCompileOptions({ filename }) {
+				dynamicCompileOptions({ filename, environment }) {
 					if (filename.endsWith('A.svelte')) {
+						return {
+							preserveWhitespace: true
+						};
+					}
+					if (filename.endsWith('Environment.svelte') && environment?.name === 'client') {
 						return {
 							preserveWhitespace: true
 						};

--- a/packages/e2e-tests/prebundle-svelte-deps/__tests__/prebundle-svelte-deps.spec.ts
+++ b/packages/e2e-tests/prebundle-svelte-deps/__tests__/prebundle-svelte-deps.spec.ts
@@ -25,6 +25,10 @@ async function expectPageToWork() {
 	expect(await getText('#module button:first-child')).toBe('count is 0');
 }
 
+test('passes the current environment while compiling a Svelte dependency', async () => {
+	expect(await getText('#optimizer-environment')).toBe('    optimizer environment');
+});
+
 if (!isBuild) {
 	test('page works with pre-bundling enabled', async () => {
 		await expectPageToWork();

--- a/packages/e2e-tests/prebundle-svelte-deps/src/App.svelte
+++ b/packages/e2e-tests/prebundle-svelte-deps/src/App.svelte
@@ -1,6 +1,6 @@
 <script>
 	import Hybrid from 'e2e-test-dep-svelte-hybrid';
-	import Simple from 'e2e-test-dep-svelte-simple';
+	import Simple, { Environment as OptimizerEnvironment } from 'e2e-test-dep-svelte-simple';
 	import { Dependency } from 'e2e-test-dep-svelte-exports-simple';
 	import { Message as Nested } from 'e2e-test-dep-svelte-nested';
 	import { setSomeContext } from 'e2e-test-dep-svelte-api-only';
@@ -16,6 +16,9 @@
 	</div>
 	<div id="simple">
 		<Simple />
+	</div>
+	<div>
+		<OptimizerEnvironment />
 	</div>
 	<div id="nested">
 		<Nested id="message" message="nested" />

--- a/packages/e2e-tests/prebundle-svelte-deps/vite.config.js
+++ b/packages/e2e-tests/prebundle-svelte-deps/vite.config.js
@@ -3,7 +3,17 @@ import { svelte } from '@sveltejs/vite-plugin-svelte';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-	plugins: [svelte()],
+	plugins: [
+		svelte({
+			dynamicCompileOptions({ filename, environment }) {
+				if (filename.endsWith('Environment.svelte') && environment?.name === 'client') {
+					return {
+						preserveWhitespace: true
+					};
+				}
+			}
+		})
+	],
 	optimizeDeps: {
 		exclude: [
 			// TODO this must be excluded because nested has an scss dep that prebundle can't handle!

--- a/packages/e2e-tests/vite-ssr-esm/logs/resolved-configs/vite.config.serve.json
+++ b/packages/e2e-tests/vite-ssr-esm/logs/resolved-configs/vite.config.serve.json
@@ -1,0 +1,983 @@
+{
+	"server": {
+		"port": 5173,
+		"strictPort": false,
+		"allowedHosts": [],
+		"open": false,
+		"cors": {
+			"origin": "/^https?:\\/\\/(?:(?:[^:]+\\.)?localhost|127\\.0\\.0\\.1|\\[::1\\])(?::\\d+)?$/",
+			"preflightContinue": true
+		},
+		"headers": {},
+		"warmup": {
+			"clientFiles": [],
+			"ssrFiles": []
+		},
+		"middlewareMode": false,
+		"fs": {
+			"strict": true,
+			"deny": [
+				".env",
+				".env.*",
+				"*.{crt,pem,key,p12,pfx,cer,der}",
+				".npmrc",
+				".yarnrc.yml",
+				"**/.git/**"
+			],
+			"allow": [
+				"/Users/paoloricciuti/Desktop/code/vite-plugin-svelte/packages/e2e-tests/vite-ssr-esm/src/lib",
+				"/Users/paoloricciuti/Desktop/code/vite-plugin-svelte/packages/e2e-tests/vite-ssr-esm/src/routes",
+				"/Users/paoloricciuti/Desktop/code/vite-plugin-svelte/packages/e2e-tests/vite-ssr-esm/.svelte-kit",
+				"/Users/paoloricciuti/Desktop/code/vite-plugin-svelte/packages/e2e-tests/preprocess-with-vite/src",
+				"/Users/paoloricciuti/Desktop/code/vite-plugin-svelte/packages/e2e-tests/preprocess-with-vite/node_modules",
+				"/Users/paoloricciuti/Desktop/code/vite-plugin-svelte/node_modules"
+			]
+		},
+		"preTransformRequests": true,
+		"perEnvironmentStartEndDuringDev": false,
+		"perEnvironmentWatchChangeDuringDev": false,
+		"forwardConsole": {
+			"enabled": false,
+			"unhandledErrors": false,
+			"logLevels": []
+		},
+		"watch": {
+			"usePolling": true,
+			"interval": 100,
+			"ignored": [
+				"/Users/paoloricciuti/Desktop/code/vite-plugin-svelte/packages/e2e-tests/vite-ssr-esm/.svelte-kit/!(generated)"
+			]
+		},
+		"ws": {},
+		"hmr": {}
+	},
+	"build": {
+		"target": ["chrome111", "edge111", "firefox114", "safari16.4", "ios16.4"],
+		"polyfillModulePreload": true,
+		"modulePreload": {
+			"polyfill": true
+		},
+		"outDir": "dist",
+		"assetsDir": "assets",
+		"assetsInlineLimit": 4096,
+		"sourcemap": true,
+		"terserOptions": {},
+		"chunkImportMap": false,
+		"rolldownOptions": {
+			"platform": "node",
+			"input": "/Users/paoloricciuti/Desktop/code/vite-plugin-svelte/node_modules/.pnpm/@sveltejs+kit@2.59.1_@sveltejs+vite-plugin-svelte@packages+vite-plugin-svelte_svelte@5._1056496848653c64063c2b6cdefa49f7/node_modules/@sveltejs/kit/src/runtime/client/entry.js"
+		},
+		"commonjsOptions": {
+			"include": ["/node_modules/"],
+			"extensions": [".js", ".cjs"]
+		},
+		"dynamicImportVarsOptions": {
+			"exclude": ["/node_modules/"]
+		},
+		"write": true,
+		"emptyOutDir": null,
+		"copyPublicDir": true,
+		"license": false,
+		"manifest": false,
+		"lib": false,
+		"ssrManifest": false,
+		"ssrEmitAssets": false,
+		"reportCompressedSize": true,
+		"chunkSizeWarningLimit": 500,
+		"watch": null,
+		"cssCodeSplit": true,
+		"minify": false,
+		"rollupOptions": {
+			"platform": "node",
+			"input": "/Users/paoloricciuti/Desktop/code/vite-plugin-svelte/node_modules/.pnpm/@sveltejs+kit@2.59.1_@sveltejs+vite-plugin-svelte@packages+vite-plugin-svelte_svelte@5._1056496848653c64063c2b6cdefa49f7/node_modules/@sveltejs/kit/src/runtime/client/entry.js"
+		},
+		"ssr": false,
+		"emitAssets": false,
+		"cssTarget": ["chrome111", "edge111", "firefox114", "safari16.4", "ios16.4"],
+		"cssMinify": false
+	},
+	"plugins": [
+		"vite:optimized-deps",
+		"vite:watch-package-data",
+		"vite:pre-alias",
+		"alias",
+		"transform-validation:1",
+		"vite-plugin-svelte:config",
+		"vite-plugin-svelte:load-custom",
+		"vite-plugin-svelte:preprocess",
+		"vite-plugin-svelte-inspector",
+		"vite-plugin-sveltekit-guard",
+		"vite:modulepreload-polyfill",
+		"vite:resolve-dev",
+		"vite:resolve-builtin:get-environment",
+		"vite:resolve-builtin",
+		"vite:html-inline-proxy",
+		"vite:css",
+		"builtin:oxc-runtime",
+		"vite:oxc",
+		"builtin:vite-json",
+		"vite:wasm-helper",
+		"vite:worker",
+		"vite:asset",
+		"transform-validation:2",
+		"vite-plugin-svelte",
+		"vite-plugin-svelte:setup-optimizer",
+		"vite-plugin-svelte:load-compiled-css",
+		"vite-plugin-svelte:compile",
+		"vite-plugin-sveltekit-setup",
+		"vite-plugin-sveltekit-virtual-modules",
+		"vite-plugin-sveltekit-compile",
+		"vite:define",
+		"vite:css-post",
+		"vite:build-html",
+		"vite:worker-import-meta-url",
+		"vite:asset-import-meta-url",
+		"vite:dynamic-import-vars",
+		"vite:import-glob",
+		"transform-validation:3",
+		"vite-plugin-svelte:compile-module",
+		"vite-plugin-svelte:hot-update",
+		"writeResolvedConfig",
+		"vite:client-inject",
+		"vite:css-analysis",
+		"vite:import-analysis"
+	],
+	"optimizeDeps": {
+		"include": [
+			"svelte-i18n",
+			"e2e-test-dep-svelte-api-only",
+			"svelte",
+			"svelte/animate",
+			"svelte/attachments",
+			"svelte/easing",
+			"svelte/internal",
+			"svelte/internal/client",
+			"svelte/internal/disclose-version",
+			"svelte/internal/flags/async",
+			"svelte/internal/flags/legacy",
+			"svelte/internal/flags/tracing",
+			"svelte/legacy",
+			"svelte/motion",
+			"svelte/reactivity",
+			"svelte/reactivity/window",
+			"svelte/store",
+			"svelte/transition",
+			"svelte/events",
+			"svelte > clsx"
+		],
+		"exclude": ["@sveltejs/kit", "$app", "$env"],
+		"needsInterop": [],
+		"rolldownOptions": {
+			"plugins": [
+				{
+					"name": "vite-plugin-svelte:optimize"
+				},
+				{
+					"name": "vite-plugin-svelte:optimize-module"
+				}
+			],
+			"resolve": {
+				"symlinks": true
+			},
+			"output": {
+				"topLevelVar": true
+			}
+		},
+		"extensions": [".svelte"],
+		"holdUntilCrawlEnd": true,
+		"force": false,
+		"ignoreOutdatedRequests": false,
+		"noDiscovery": false,
+		"entries": [
+			"/Users/paoloricciuti/Desktop/code/vite-plugin-svelte/packages/e2e-tests/vite-ssr-esm/src/routes/**/+*.{svelte,js,ts}",
+			"!/Users/paoloricciuti/Desktop/code/vite-plugin-svelte/packages/e2e-tests/vite-ssr-esm/src/routes/**/+*server.*"
+		],
+		"rollupOptions": {
+			"plugins": [
+				{
+					"name": "vite-plugin-svelte:optimize"
+				},
+				{
+					"name": "vite-plugin-svelte:optimize-module"
+				}
+			],
+			"resolve": {
+				"symlinks": true
+			},
+			"output": {
+				"topLevelVar": true
+			}
+		},
+		"esbuildOptions": {
+			"preserveSymlinks": false
+		}
+	},
+	"css": {
+		"transformer": "postcss",
+		"preprocessorMaxWorkers": true,
+		"devSourcemap": false,
+		"postcss": {
+			"plugins": [
+				{
+					"postcssPlugin": "noop"
+				}
+			]
+		}
+	},
+	"root": "/Users/paoloricciuti/Desktop/code/vite-plugin-svelte/packages/e2e-tests/vite-ssr-esm",
+	"configFile": "/Users/paoloricciuti/Desktop/code/vite-plugin-svelte/packages/e2e-tests/kit-node/vite.config.js",
+	"logLevel": "error",
+	"worker": {
+		"format": "iife",
+		"rollupOptions": {},
+		"rolldownOptions": {}
+	},
+	"resolve": {
+		"externalConditions": ["node", "module-sync"],
+		"extensions": [".mjs", ".js", ".mts", ".ts", ".jsx", ".tsx", ".json"],
+		"dedupe": [
+			"svelte",
+			"svelte/animate",
+			"svelte/attachments",
+			"svelte/easing",
+			"svelte/internal",
+			"svelte/internal/client",
+			"svelte/internal/disclose-version",
+			"svelte/internal/flags/async",
+			"svelte/internal/flags/legacy",
+			"svelte/internal/flags/tracing",
+			"svelte/internal/server",
+			"svelte/legacy",
+			"svelte/motion",
+			"svelte/reactivity",
+			"svelte/reactivity/window",
+			"svelte/server",
+			"svelte/store",
+			"svelte/transition",
+			"svelte/events"
+		],
+		"noExternal": [],
+		"external": [],
+		"preserveSymlinks": false,
+		"tsconfigPaths": false,
+		"alias": [
+			{
+				"find": "__SERVER__",
+				"replacement": "/Users/paoloricciuti/Desktop/code/vite-plugin-svelte/packages/e2e-tests/vite-ssr-esm/.svelte-kit/generated/server"
+			},
+			{
+				"find": "$app",
+				"replacement": "/Users/paoloricciuti/Desktop/code/vite-plugin-svelte/node_modules/.pnpm/@sveltejs+kit@2.59.1_@sveltejs+vite-plugin-svelte@packages+vite-plugin-svelte_svelte@5._1056496848653c64063c2b6cdefa49f7/node_modules/@sveltejs/kit/src/runtime/app"
+			},
+			{
+				"find": "$lib",
+				"replacement": "/Users/paoloricciuti/Desktop/code/vite-plugin-svelte/packages/e2e-tests/vite-ssr-esm/src/lib"
+			},
+			{
+				"find": "/^\\/?@vite\\/env/",
+				"replacement": "/@fs/Users/paoloricciuti/Desktop/code/vite-plugin-svelte/node_modules/.pnpm/vite@8.2.0_@types+node@22.20.1_sass@1.102.0_stylus@0.64.0_yaml@2.8.2/node_modules/vite/dist/client/env.mjs"
+			},
+			{
+				"find": "/^\\/?@vite\\/client/",
+				"replacement": "/@fs/Users/paoloricciuti/Desktop/code/vite-plugin-svelte/node_modules/.pnpm/vite@8.2.0_@types+node@22.20.1_sass@1.102.0_stylus@0.64.0_yaml@2.8.2/node_modules/vite/dist/client/client.mjs"
+			}
+		],
+		"mainFields": ["svelte", "browser", "module", "jsnext:main", "jsnext"],
+		"conditions": ["module", "browser", "development|production", "svelte"],
+		"builtins": []
+	},
+	"ssr": {
+		"target": "node",
+		"optimizeDeps": {
+			"esbuildOptions": {
+				"preserveSymlinks": false
+			},
+			"include": [
+				"svelte",
+				"svelte/animate",
+				"svelte/attachments",
+				"svelte/compiler",
+				"svelte/easing",
+				"svelte/internal",
+				"svelte/internal/client",
+				"svelte/internal/disclose-version",
+				"svelte/internal/flags/async",
+				"svelte/internal/flags/legacy",
+				"svelte/internal/flags/tracing",
+				"svelte/internal/server",
+				"svelte/legacy",
+				"svelte/motion",
+				"svelte/reactivity",
+				"svelte/reactivity/window",
+				"svelte/server",
+				"svelte/store",
+				"svelte/transition",
+				"svelte/events"
+			],
+			"exclude": [],
+			"needsInterop": [],
+			"rolldownOptions": {
+				"plugins": [
+					{
+						"name": "vite-plugin-svelte:optimize"
+					},
+					{
+						"name": "vite-plugin-svelte:optimize-module"
+					}
+				],
+				"resolve": {
+					"symlinks": true
+				},
+				"output": {
+					"topLevelVar": true
+				}
+			},
+			"extensions": [".svelte"],
+			"holdUntilCrawlEnd": true,
+			"force": false,
+			"ignoreOutdatedRequests": false,
+			"noDiscovery": true,
+			"rollupOptions": {
+				"plugins": [
+					{
+						"name": "vite-plugin-svelte:optimize"
+					},
+					{
+						"name": "vite-plugin-svelte:optimize-module"
+					}
+				],
+				"resolve": {
+					"symlinks": true
+				},
+				"output": {
+					"topLevelVar": true
+				}
+			}
+		},
+		"external": [
+			"cli-color",
+			"deepmerge",
+			"e2e-test-dep-cjs-and-esm",
+			"e2e-test-dep-cjs-only",
+			"e2e-test-dep-scss-only",
+			"estree-walker",
+			"intl-messageformat",
+			"sade",
+			"tiny-glob",
+			"cookie",
+			"set-cookie-parser"
+		],
+		"noExternal": [
+			"svelte",
+			"/^svelte\\//",
+			"esm-env",
+			"e2e-test-dep-svelte-api-only",
+			"e2e-test-dep-svelte-nested-workspace-devdep",
+			"e2e-test-dep-svelte-simple",
+			"svelte-i18n",
+			"esm-env",
+			"@sveltejs/kit/src/runtime"
+		],
+		"resolve": {
+			"conditions": ["module", "node", "development|production", "svelte"],
+			"externalConditions": ["node", "module-sync"]
+		}
+	},
+	"experimental": {
+		"importGlobRestoreExtension": false,
+		"hmrPartialAccept": true,
+		"bundledDev": false
+	},
+	"preview": {
+		"port": 4173,
+		"strictPort": false,
+		"allowedHosts": [],
+		"open": false,
+		"cors": {
+			"preflightContinue": true
+		},
+		"headers": {}
+	},
+	"define": {
+		"__SVELTEKIT_APP_DIR__": "\"_app\"",
+		"__SVELTEKIT_EMBEDDED__": "false",
+		"__SVELTEKIT_FORK_PRELOADS__": "false",
+		"__SVELTEKIT_PATHS_ASSETS__": "\"\"",
+		"__SVELTEKIT_PATHS_BASE__": "\"\"",
+		"__SVELTEKIT_PATHS_RELATIVE__": "true",
+		"__SVELTEKIT_CLIENT_ROUTING__": "true",
+		"__SVELTEKIT_HASH_ROUTING__": "false",
+		"__SVELTEKIT_SERVER_TRACING_ENABLED__": "false",
+		"__SVELTEKIT_EXPERIMENTAL_USE_TRANSFORM_ERROR__": "false",
+		"__SVELTEKIT_APP_VERSION_POLL_INTERVAL__": "0",
+		"__SVELTEKIT_PAYLOAD__": "globalThis.__sveltekit_dev",
+		"__SVELTEKIT_HAS_SERVER_LOAD__": "true",
+		"__SVELTEKIT_HAS_UNIVERSAL_LOAD__": "true"
+	},
+	"appType": "custom",
+	"base": "/",
+	"publicDir": "/Users/paoloricciuti/Desktop/code/vite-plugin-svelte/packages/e2e-tests/vite-ssr-esm/static",
+	"environments": {
+		"client": {
+			"define": {
+				"__SVELTEKIT_APP_DIR__": "\"_app\"",
+				"__SVELTEKIT_EMBEDDED__": "false",
+				"__SVELTEKIT_FORK_PRELOADS__": "false",
+				"__SVELTEKIT_PATHS_ASSETS__": "\"\"",
+				"__SVELTEKIT_PATHS_BASE__": "\"\"",
+				"__SVELTEKIT_PATHS_RELATIVE__": "true",
+				"__SVELTEKIT_CLIENT_ROUTING__": "true",
+				"__SVELTEKIT_HASH_ROUTING__": "false",
+				"__SVELTEKIT_SERVER_TRACING_ENABLED__": "false",
+				"__SVELTEKIT_EXPERIMENTAL_USE_TRANSFORM_ERROR__": "false",
+				"__SVELTEKIT_APP_VERSION_POLL_INTERVAL__": "0",
+				"__SVELTEKIT_PAYLOAD__": "globalThis.__sveltekit_dev",
+				"__SVELTEKIT_HAS_SERVER_LOAD__": "true",
+				"__SVELTEKIT_HAS_UNIVERSAL_LOAD__": "true"
+			},
+			"resolve": {
+				"externalConditions": ["node", "module-sync"],
+				"extensions": [".mjs", ".js", ".mts", ".ts", ".jsx", ".tsx", ".json"],
+				"dedupe": [
+					"svelte",
+					"svelte/animate",
+					"svelte/attachments",
+					"svelte/easing",
+					"svelte/internal",
+					"svelte/internal/client",
+					"svelte/internal/disclose-version",
+					"svelte/internal/flags/async",
+					"svelte/internal/flags/legacy",
+					"svelte/internal/flags/tracing",
+					"svelte/internal/server",
+					"svelte/legacy",
+					"svelte/motion",
+					"svelte/reactivity",
+					"svelte/reactivity/window",
+					"svelte/server",
+					"svelte/store",
+					"svelte/transition",
+					"svelte/events"
+				],
+				"noExternal": [],
+				"external": [],
+				"preserveSymlinks": false,
+				"tsconfigPaths": false,
+				"alias": [
+					{
+						"find": "__SERVER__",
+						"replacement": "/Users/paoloricciuti/Desktop/code/vite-plugin-svelte/packages/e2e-tests/vite-ssr-esm/.svelte-kit/generated/server"
+					},
+					{
+						"find": "$app",
+						"replacement": "/Users/paoloricciuti/Desktop/code/vite-plugin-svelte/node_modules/.pnpm/@sveltejs+kit@2.59.1_@sveltejs+vite-plugin-svelte@packages+vite-plugin-svelte_svelte@5._1056496848653c64063c2b6cdefa49f7/node_modules/@sveltejs/kit/src/runtime/app"
+					},
+					{
+						"find": "$lib",
+						"replacement": "/Users/paoloricciuti/Desktop/code/vite-plugin-svelte/packages/e2e-tests/vite-ssr-esm/src/lib"
+					},
+					{
+						"find": "/^\\/?@vite\\/env/",
+						"replacement": "/@fs/Users/paoloricciuti/Desktop/code/vite-plugin-svelte/node_modules/.pnpm/vite@8.2.0_@types+node@22.20.1_sass@1.102.0_stylus@0.64.0_yaml@2.8.2/node_modules/vite/dist/client/env.mjs"
+					},
+					{
+						"find": "/^\\/?@vite\\/client/",
+						"replacement": "/@fs/Users/paoloricciuti/Desktop/code/vite-plugin-svelte/node_modules/.pnpm/vite@8.2.0_@types+node@22.20.1_sass@1.102.0_stylus@0.64.0_yaml@2.8.2/node_modules/vite/dist/client/client.mjs"
+					}
+				],
+				"mainFields": ["svelte", "browser", "module", "jsnext:main", "jsnext"],
+				"conditions": ["module", "browser", "development|production", "svelte"],
+				"builtins": []
+			},
+			"keepProcessEnv": false,
+			"consumer": "client",
+			"optimizeDeps": {
+				"include": [
+					"svelte-i18n",
+					"e2e-test-dep-svelte-api-only",
+					"svelte",
+					"svelte/animate",
+					"svelte/attachments",
+					"svelte/easing",
+					"svelte/internal",
+					"svelte/internal/client",
+					"svelte/internal/disclose-version",
+					"svelte/internal/flags/async",
+					"svelte/internal/flags/legacy",
+					"svelte/internal/flags/tracing",
+					"svelte/legacy",
+					"svelte/motion",
+					"svelte/reactivity",
+					"svelte/reactivity/window",
+					"svelte/store",
+					"svelte/transition",
+					"svelte/events",
+					"svelte > clsx"
+				],
+				"exclude": ["@sveltejs/kit", "$app", "$env"],
+				"needsInterop": [],
+				"rolldownOptions": {
+					"plugins": [
+						{
+							"name": "vite-plugin-svelte:optimize"
+						},
+						{
+							"name": "vite-plugin-svelte:optimize-module"
+						}
+					],
+					"resolve": {
+						"symlinks": true
+					},
+					"output": {
+						"topLevelVar": true
+					}
+				},
+				"extensions": [".svelte"],
+				"holdUntilCrawlEnd": true,
+				"force": false,
+				"ignoreOutdatedRequests": false,
+				"noDiscovery": false,
+				"entries": [
+					"/Users/paoloricciuti/Desktop/code/vite-plugin-svelte/packages/e2e-tests/vite-ssr-esm/src/routes/**/+*.{svelte,js,ts}",
+					"!/Users/paoloricciuti/Desktop/code/vite-plugin-svelte/packages/e2e-tests/vite-ssr-esm/src/routes/**/+*server.*"
+				],
+				"rollupOptions": {
+					"plugins": [
+						{
+							"name": "vite-plugin-svelte:optimize"
+						},
+						{
+							"name": "vite-plugin-svelte:optimize-module"
+						}
+					],
+					"resolve": {
+						"symlinks": true
+					},
+					"output": {
+						"topLevelVar": true
+					}
+				},
+				"esbuildOptions": {
+					"preserveSymlinks": false
+				}
+			},
+			"dev": {
+				"warmup": [],
+				"sourcemap": {
+					"js": true
+				},
+				"preTransformRequests": true,
+				"recoverable": true,
+				"moduleRunnerTransform": false
+			},
+			"build": {
+				"target": ["chrome111", "edge111", "firefox114", "safari16.4", "ios16.4"],
+				"polyfillModulePreload": true,
+				"modulePreload": {
+					"polyfill": true
+				},
+				"outDir": "dist",
+				"assetsDir": "assets",
+				"assetsInlineLimit": 4096,
+				"sourcemap": true,
+				"terserOptions": {},
+				"chunkImportMap": false,
+				"rolldownOptions": {
+					"platform": "browser",
+					"input": "/Users/paoloricciuti/Desktop/code/vite-plugin-svelte/node_modules/.pnpm/@sveltejs+kit@2.59.1_@sveltejs+vite-plugin-svelte@packages+vite-plugin-svelte_svelte@5._1056496848653c64063c2b6cdefa49f7/node_modules/@sveltejs/kit/src/runtime/client/entry.js"
+				},
+				"commonjsOptions": {
+					"include": ["/node_modules/"],
+					"extensions": [".js", ".cjs"]
+				},
+				"dynamicImportVarsOptions": {
+					"exclude": ["/node_modules/"]
+				},
+				"write": true,
+				"emptyOutDir": null,
+				"copyPublicDir": true,
+				"license": false,
+				"manifest": false,
+				"lib": false,
+				"ssrManifest": false,
+				"ssrEmitAssets": false,
+				"reportCompressedSize": true,
+				"chunkSizeWarningLimit": 500,
+				"watch": null,
+				"cssCodeSplit": true,
+				"minify": false,
+				"rollupOptions": {
+					"platform": "browser",
+					"input": "/Users/paoloricciuti/Desktop/code/vite-plugin-svelte/node_modules/.pnpm/@sveltejs+kit@2.59.1_@sveltejs+vite-plugin-svelte@packages+vite-plugin-svelte_svelte@5._1056496848653c64063c2b6cdefa49f7/node_modules/@sveltejs/kit/src/runtime/client/entry.js"
+				},
+				"ssr": false,
+				"emitAssets": true,
+				"cssTarget": ["chrome111", "edge111", "firefox114", "safari16.4", "ios16.4"],
+				"cssMinify": false
+			},
+			"isBundled": false
+		},
+		"ssr": {
+			"define": {
+				"__SVELTEKIT_APP_DIR__": "\"_app\"",
+				"__SVELTEKIT_EMBEDDED__": "false",
+				"__SVELTEKIT_FORK_PRELOADS__": "false",
+				"__SVELTEKIT_PATHS_ASSETS__": "\"\"",
+				"__SVELTEKIT_PATHS_BASE__": "\"\"",
+				"__SVELTEKIT_PATHS_RELATIVE__": "true",
+				"__SVELTEKIT_CLIENT_ROUTING__": "true",
+				"__SVELTEKIT_HASH_ROUTING__": "false",
+				"__SVELTEKIT_SERVER_TRACING_ENABLED__": "false",
+				"__SVELTEKIT_EXPERIMENTAL_USE_TRANSFORM_ERROR__": "false",
+				"__SVELTEKIT_APP_VERSION_POLL_INTERVAL__": "0",
+				"__SVELTEKIT_PAYLOAD__": "globalThis.__sveltekit_dev",
+				"__SVELTEKIT_HAS_SERVER_LOAD__": "true",
+				"__SVELTEKIT_HAS_UNIVERSAL_LOAD__": "true"
+			},
+			"resolve": {
+				"externalConditions": ["node", "module-sync"],
+				"extensions": [".mjs", ".js", ".mts", ".ts", ".jsx", ".tsx", ".json"],
+				"dedupe": [
+					"svelte",
+					"svelte/animate",
+					"svelte/attachments",
+					"svelte/easing",
+					"svelte/internal",
+					"svelte/internal/client",
+					"svelte/internal/disclose-version",
+					"svelte/internal/flags/async",
+					"svelte/internal/flags/legacy",
+					"svelte/internal/flags/tracing",
+					"svelte/internal/server",
+					"svelte/legacy",
+					"svelte/motion",
+					"svelte/reactivity",
+					"svelte/reactivity/window",
+					"svelte/server",
+					"svelte/store",
+					"svelte/transition",
+					"svelte/events"
+				],
+				"noExternal": [
+					"svelte",
+					"/^svelte\\//",
+					"esm-env",
+					"e2e-test-dep-svelte-api-only",
+					"e2e-test-dep-svelte-nested-workspace-devdep",
+					"e2e-test-dep-svelte-simple",
+					"svelte-i18n",
+					"esm-env",
+					"@sveltejs/kit/src/runtime"
+				],
+				"external": [
+					"cli-color",
+					"deepmerge",
+					"e2e-test-dep-cjs-and-esm",
+					"e2e-test-dep-cjs-only",
+					"e2e-test-dep-scss-only",
+					"estree-walker",
+					"intl-messageformat",
+					"sade",
+					"tiny-glob",
+					"cookie",
+					"set-cookie-parser"
+				],
+				"preserveSymlinks": false,
+				"tsconfigPaths": false,
+				"alias": [
+					{
+						"find": "__SERVER__",
+						"replacement": "/Users/paoloricciuti/Desktop/code/vite-plugin-svelte/packages/e2e-tests/vite-ssr-esm/.svelte-kit/generated/server"
+					},
+					{
+						"find": "$app",
+						"replacement": "/Users/paoloricciuti/Desktop/code/vite-plugin-svelte/node_modules/.pnpm/@sveltejs+kit@2.59.1_@sveltejs+vite-plugin-svelte@packages+vite-plugin-svelte_svelte@5._1056496848653c64063c2b6cdefa49f7/node_modules/@sveltejs/kit/src/runtime/app"
+					},
+					{
+						"find": "$lib",
+						"replacement": "/Users/paoloricciuti/Desktop/code/vite-plugin-svelte/packages/e2e-tests/vite-ssr-esm/src/lib"
+					},
+					{
+						"find": "/^\\/?@vite\\/env/",
+						"replacement": "/@fs/Users/paoloricciuti/Desktop/code/vite-plugin-svelte/node_modules/.pnpm/vite@8.2.0_@types+node@22.20.1_sass@1.102.0_stylus@0.64.0_yaml@2.8.2/node_modules/vite/dist/client/env.mjs"
+					},
+					{
+						"find": "/^\\/?@vite\\/client/",
+						"replacement": "/@fs/Users/paoloricciuti/Desktop/code/vite-plugin-svelte/node_modules/.pnpm/vite@8.2.0_@types+node@22.20.1_sass@1.102.0_stylus@0.64.0_yaml@2.8.2/node_modules/vite/dist/client/client.mjs"
+					}
+				],
+				"mainFields": ["svelte", "module", "jsnext:main", "jsnext"],
+				"conditions": ["module", "node", "development|production", "svelte"],
+				"builtins": [
+					"_http_agent",
+					"_http_client",
+					"_http_common",
+					"_http_incoming",
+					"_http_outgoing",
+					"_http_server",
+					"_stream_duplex",
+					"_stream_passthrough",
+					"_stream_readable",
+					"_stream_transform",
+					"_stream_wrap",
+					"_stream_writable",
+					"_tls_common",
+					"_tls_wrap",
+					"assert",
+					"assert/strict",
+					"async_hooks",
+					"buffer",
+					"child_process",
+					"cluster",
+					"console",
+					"constants",
+					"crypto",
+					"dgram",
+					"diagnostics_channel",
+					"dns",
+					"dns/promises",
+					"domain",
+					"electron/js2c/browser_init",
+					"electron/js2c/isolated_bundle",
+					"electron/js2c/node_init",
+					"electron/js2c/preload_realm_bundle",
+					"electron/js2c/renderer_init",
+					"electron/js2c/sandbox_bundle",
+					"electron/js2c/utility_init",
+					"electron/js2c/worker_init",
+					"events",
+					"fs",
+					"fs/promises",
+					"http",
+					"http2",
+					"https",
+					"inspector",
+					"inspector/promises",
+					"module",
+					"net",
+					"original-fs",
+					"original-fs/promises",
+					"os",
+					"path",
+					"path/posix",
+					"path/win32",
+					"perf_hooks",
+					"process",
+					"punycode",
+					"querystring",
+					"readline",
+					"readline/promises",
+					"repl",
+					"stream",
+					"stream/consumers",
+					"stream/promises",
+					"stream/web",
+					"string_decoder",
+					"sys",
+					"timers",
+					"timers/promises",
+					"tls",
+					"trace_events",
+					"tty",
+					"url",
+					"util",
+					"util/types",
+					"v8",
+					"vm",
+					"wasi",
+					"worker_threads",
+					"zlib",
+					"/^node:/",
+					"/^bun:/"
+				]
+			},
+			"keepProcessEnv": true,
+			"consumer": "server",
+			"optimizeDeps": {
+				"include": [
+					"svelte",
+					"svelte/animate",
+					"svelte/attachments",
+					"svelte/compiler",
+					"svelte/easing",
+					"svelte/internal",
+					"svelte/internal/client",
+					"svelte/internal/disclose-version",
+					"svelte/internal/flags/async",
+					"svelte/internal/flags/legacy",
+					"svelte/internal/flags/tracing",
+					"svelte/internal/server",
+					"svelte/legacy",
+					"svelte/motion",
+					"svelte/reactivity",
+					"svelte/reactivity/window",
+					"svelte/server",
+					"svelte/store",
+					"svelte/transition",
+					"svelte/events"
+				],
+				"exclude": [],
+				"needsInterop": [],
+				"rolldownOptions": {
+					"plugins": [
+						{
+							"name": "vite-plugin-svelte:optimize"
+						},
+						{
+							"name": "vite-plugin-svelte:optimize-module"
+						}
+					],
+					"resolve": {
+						"symlinks": true
+					},
+					"output": {
+						"topLevelVar": true
+					}
+				},
+				"extensions": [".svelte"],
+				"holdUntilCrawlEnd": true,
+				"force": false,
+				"ignoreOutdatedRequests": false,
+				"noDiscovery": true,
+				"rollupOptions": {
+					"plugins": [
+						{
+							"name": "vite-plugin-svelte:optimize"
+						},
+						{
+							"name": "vite-plugin-svelte:optimize-module"
+						}
+					],
+					"resolve": {
+						"symlinks": true
+					},
+					"output": {
+						"topLevelVar": true
+					}
+				},
+				"esbuildOptions": {
+					"preserveSymlinks": false
+				}
+			},
+			"dev": {
+				"warmup": [],
+				"sourcemap": {
+					"js": true
+				},
+				"preTransformRequests": false,
+				"recoverable": false,
+				"moduleRunnerTransform": true
+			},
+			"build": {
+				"target": ["chrome111", "edge111", "firefox114", "safari16.4", "ios16.4"],
+				"polyfillModulePreload": true,
+				"modulePreload": {
+					"polyfill": true
+				},
+				"outDir": "dist",
+				"assetsDir": "assets",
+				"assetsInlineLimit": 4096,
+				"sourcemap": true,
+				"terserOptions": {},
+				"chunkImportMap": false,
+				"rolldownOptions": {
+					"platform": "node",
+					"input": "/Users/paoloricciuti/Desktop/code/vite-plugin-svelte/node_modules/.pnpm/@sveltejs+kit@2.59.1_@sveltejs+vite-plugin-svelte@packages+vite-plugin-svelte_svelte@5._1056496848653c64063c2b6cdefa49f7/node_modules/@sveltejs/kit/src/runtime/client/entry.js"
+				},
+				"commonjsOptions": {
+					"include": ["/node_modules/"],
+					"extensions": [".js", ".cjs"]
+				},
+				"dynamicImportVarsOptions": {
+					"exclude": ["/node_modules/"]
+				},
+				"write": true,
+				"emptyOutDir": null,
+				"copyPublicDir": true,
+				"license": false,
+				"manifest": false,
+				"lib": false,
+				"ssrManifest": false,
+				"ssrEmitAssets": false,
+				"reportCompressedSize": true,
+				"chunkSizeWarningLimit": 500,
+				"watch": null,
+				"cssCodeSplit": true,
+				"minify": false,
+				"rollupOptions": {
+					"platform": "node",
+					"input": "/Users/paoloricciuti/Desktop/code/vite-plugin-svelte/node_modules/.pnpm/@sveltejs+kit@2.59.1_@sveltejs+vite-plugin-svelte@packages+vite-plugin-svelte_svelte@5._1056496848653c64063c2b6cdefa49f7/node_modules/@sveltejs/kit/src/runtime/client/entry.js"
+				},
+				"ssr": true,
+				"emitAssets": false,
+				"cssTarget": ["chrome111", "edge111", "firefox114", "safari16.4", "ios16.4"],
+				"cssMinify": "lightningcss"
+			},
+			"isBundled": false
+		}
+	},
+	"configFileDependencies": [
+		"/Users/paoloricciuti/Desktop/code/vite-plugin-svelte/packages/e2e-tests/kit-node/vite.config.js"
+	],
+	"inlineConfig": {
+		"root": "/Users/paoloricciuti/Desktop/code/vite-plugin-svelte/packages/e2e-tests/kit-node",
+		"configFile": "/Users/paoloricciuti/Desktop/code/vite-plugin-svelte/packages/e2e-tests/kit-node/vite.config.js",
+		"logLevel": "error",
+		"build": {},
+		"worker": {},
+		"optimizeDeps": {}
+	},
+	"decodedBase": "/",
+	"rawBase": "/",
+	"cacheDir": "/Users/paoloricciuti/Desktop/code/vite-plugin-svelte/packages/e2e-tests/vite-ssr-esm/node_modules/.vite",
+	"command": "serve",
+	"mode": "development",
+	"isWorker": false,
+	"mainConfig": null,
+	"bundleChain": [],
+	"isProduction": false,
+	"json": {
+		"namedExports": true,
+		"stringify": "auto"
+	},
+	"esbuild": {
+		"jsxDev": true,
+		"charset": "utf8",
+		"legalComments": "none"
+	},
+	"oxc": {
+		"jsx": {
+			"development": true
+		}
+	},
+	"envDir": "/Users/paoloricciuti/Desktop/code/vite-plugin-svelte/packages/e2e-tests/vite-ssr-esm",
+	"env": {
+		"VITE_USER_NODE_ENV": "production",
+		"BASE_URL": "/",
+		"MODE": "development",
+		"DEV": true,
+		"PROD": false
+	},
+	"rawAssetsInclude": [],
+	"logger": {
+		"hasWarned": false
+	},
+	"packageCache": {},
+	"dev": {
+		"warmup": [],
+		"sourcemap": {
+			"js": true
+		},
+		"preTransformRequests": false,
+		"recoverable": false,
+		"moduleRunnerTransform": false
+	},
+	"devtools": {
+		"config": {
+			"host": "localhost"
+		},
+		"enabled": false
+	},
+	"webSocketToken": "N6BFpnldwZQ9",
+	"safeModulePaths": {}
+}

--- a/packages/vite-plugin-svelte/__tests__/compile.spec.js
+++ b/packages/vite-plugin-svelte/__tests__/compile.spec.js
@@ -1,5 +1,5 @@
 import process from 'node:process';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { createCompileSvelte } from '../src/utils/compile.js';
 /** @type {import('../../types/options.d.ts').ResolvedOptions} */
 const options = {
@@ -22,6 +22,32 @@ describe('createCompileSvelte', () => {
 	});
 
 	describe('compileSvelte', async () => {
+		it('passes the current environment to dynamicCompileOptions', async () => {
+			const dynamicCompileOptions = vi.fn();
+			const environment = /** @type {import('vite').Environment} */ (
+				/** @type {unknown} */ ({ name: 'client' })
+			);
+			const compileSvelte = createCompileSvelte(options);
+
+			await compileSvelte(
+				{
+					cssId: 'svelte-xxxxx',
+					query: {},
+					raw: false,
+					ssr: false,
+					timestamp: Date.now(),
+					id: 'id',
+					filename: '/some/File.svelte',
+					normalizedFilename: 'some/File.svelte'
+				},
+				'<div />',
+				{ dynamicCompileOptions },
+				environment
+			);
+
+			expect(dynamicCompileOptions).toHaveBeenCalledWith(expect.objectContaining({ environment }));
+		});
+
 		it('removes dangling pure annotations', async () => {
 			const code = `<script>
 				const x=1;

--- a/packages/vite-plugin-svelte/src/plugins/compile-module.js
+++ b/packages/vite-plugin-svelte/src/plugins/compile-module.js
@@ -58,7 +58,8 @@ export function compileModule(api) {
 				const dynamicCompileOptions = await options?.dynamicCompileOptions?.({
 					filename,
 					code,
-					compileOptions
+					compileOptions,
+					environment: this.environment
 				});
 				if (dynamicCompileOptions && log.debug.enabled) {
 					log.debug(

--- a/packages/vite-plugin-svelte/src/plugins/compile.js
+++ b/packages/vite-plugin-svelte/src/plugins/compile.js
@@ -42,6 +42,7 @@ export function compile(api) {
 						svelteRequest,
 						code,
 						options,
+						this.environment,
 						this.getCombinedSourcemap()
 					);
 				} catch (e) {

--- a/packages/vite-plugin-svelte/src/plugins/setup-optimizer.js
+++ b/packages/vite-plugin-svelte/src/plugins/setup-optimizer.js
@@ -43,8 +43,8 @@ export function setupOptimizer(api) {
 			// Add optimizer plugins to prebundle Svelte files.
 			optimizeDeps.rolldownOptions = {
 				plugins: [
-					rolldownOptimizerPlugin(api, consumer, true),
-					rolldownOptimizerPlugin(api, consumer, false)
+					rolldownOptimizerPlugin(api, name, consumer, true),
+					rolldownOptimizerPlugin(api, name, consumer, false)
 				]
 			};
 
@@ -71,13 +71,13 @@ export function setupOptimizer(api) {
 
 /**
  * @param {import('../types/plugin-api.d.ts').PluginAPI} api
+ * @param {string} environmentName
  * @param {'server'|'client'} consumer
  * @param {boolean} components
  * @return {Rolldown.Plugin}
  */
-function rolldownOptimizerPlugin(api, consumer, components) {
+function rolldownOptimizerPlugin(api, environmentName, consumer, components) {
 	const name = components ? optimizeSveltePluginName : optimizeSvelteModulePluginName;
-	const compileFn = components ? compileSvelte : compileSvelteModule;
 	const statsName = components ? 'prebundle library components' : 'prebundle library modules';
 	const includeRe = components ? /^[^?#]+\.svelte(?:[?#]|$)/ : /^[^?#]+\.svelte\.[jt]s(?:[?#]|$)/;
 	const generate = consumer === 'server' ? 'server' : 'client';
@@ -107,7 +107,22 @@ function rolldownOptimizerPlugin(api, consumer, components) {
 				 */
 				async handler(code, filename) {
 					try {
-						return await compileFn(api.options, { filename, code }, generate, statsCollection);
+						if (components) {
+							const environment = api.options.server?.environments[environmentName];
+							return await compileSvelte(
+								api.options,
+								{ filename, code },
+								generate,
+								environment,
+								statsCollection
+							);
+						}
+						return await compileSvelteModule(
+							api.options,
+							{ filename, code },
+							generate,
+							statsCollection
+						);
 					} catch (e) {
 						throw toRollupError(e, api.options);
 					}
@@ -131,10 +146,11 @@ function rolldownOptimizerPlugin(api, consumer, components) {
  * @param {ResolvedOptions} options
  * @param {{ filename: string, code: string }} input
  * @param {'client'|'server'} generate
+ * @param {import('vite').Environment | undefined} environment
  * @param {StatCollection} [statsCollection]
  * @returns {Promise<Code>}
  */
-async function compileSvelte(options, { filename, code }, generate, statsCollection) {
+async function compileSvelte(options, { filename, code }, generate, environment, statsCollection) {
 	let css = options.compilerOptions.css;
 	if (css !== 'injected') {
 		// TODO ideally we'd be able to externalize prebundled styles too, but for now always put them in the js
@@ -163,11 +179,15 @@ async function compileSvelte(options, { filename, code }, generate, statsCollect
 
 	const finalCode = preprocessed ? preprocessed.code : code;
 
-	const dynamicCompileOptions = await options?.dynamicCompileOptions?.({
-		filename,
-		code: finalCode,
-		compileOptions
-	});
+	let dynamicCompileOptions;
+	if (options.dynamicCompileOptions) {
+		dynamicCompileOptions = await options.dynamicCompileOptions({
+			filename,
+			code: finalCode,
+			compileOptions,
+			environment
+		});
+	}
 
 	if (dynamicCompileOptions && log.debug.enabled) {
 		log.debug(

--- a/packages/vite-plugin-svelte/src/plugins/setup-optimizer.js
+++ b/packages/vite-plugin-svelte/src/plugins/setup-optimizer.js
@@ -108,7 +108,11 @@ function rolldownOptimizerPlugin(api, environmentName, consumer, components) {
 				async handler(code, filename) {
 					try {
 						if (components) {
-							const environment = api.options.server?.environments[environmentName];
+							const environment =
+								/**
+								 * Given the order of plugin execution, we can be sure that the environment is already there.
+								 * @type {import("vite").Environment}
+								 */ (api.options.server?.environments[environmentName]);
 							return await compileSvelte(
 								api.options,
 								{ filename, code },
@@ -146,7 +150,7 @@ function rolldownOptimizerPlugin(api, environmentName, consumer, components) {
  * @param {ResolvedOptions} options
  * @param {{ filename: string, code: string }} input
  * @param {'client'|'server'} generate
- * @param {import('vite').Environment | undefined} environment
+ * @param {import('vite').Environment} environment
  * @param {StatCollection} [statsCollection]
  * @returns {Promise<Code>}
  */

--- a/packages/vite-plugin-svelte/src/public.d.ts
+++ b/packages/vite-plugin-svelte/src/public.d.ts
@@ -87,7 +87,7 @@ export interface PluginOptions {
 		filename: string;
 		code: string;
 		compileOptions: Partial<CompileOptions>;
-		environment?: Environment;
+		environment: Environment;
 	}) => Promise<Partial<CompileOptions> | void> | Partial<CompileOptions> | void;
 
 	/**

--- a/packages/vite-plugin-svelte/src/public.d.ts
+++ b/packages/vite-plugin-svelte/src/public.d.ts
@@ -1,4 +1,4 @@
-import type { InlineConfig, ResolvedConfig } from 'vite';
+import type { Environment, InlineConfig, ResolvedConfig } from 'vite';
 import type { CompileOptions, Warning, PreprocessorGroup } from 'svelte/compiler';
 
 export type Options = Omit<SvelteConfig, 'vitePlugin'> & PluginOptionsInline;
@@ -69,6 +69,7 @@ export interface PluginOptions {
 	 * `data.filename` - The file to be compiled
 	 * `data.code` - The preprocessed Svelte code
 	 * `data.compileOptions` - The current compiler options
+	 * `data.environment` - The current Vite environment, if available
 	 *
 	 * To change part of the compiler options, return an object with the changes you need.
 	 *
@@ -86,6 +87,7 @@ export interface PluginOptions {
 		filename: string;
 		code: string;
 		compileOptions: Partial<CompileOptions>;
+		environment?: Environment;
 	}) => Promise<Partial<CompileOptions> | void> | Partial<CompileOptions> | void;
 
 	/**

--- a/packages/vite-plugin-svelte/src/public.d.ts
+++ b/packages/vite-plugin-svelte/src/public.d.ts
@@ -69,7 +69,7 @@ export interface PluginOptions {
 	 * `data.filename` - The file to be compiled
 	 * `data.code` - The preprocessed Svelte code
 	 * `data.compileOptions` - The current compiler options
-	 * `data.environment` - The current Vite environment, if available
+	 * `data.environment` - The current Vite environment
 	 *
 	 * To change part of the compiler options, return an object with the changes you need.
 	 *

--- a/packages/vite-plugin-svelte/src/types/compile.d.ts
+++ b/packages/vite-plugin-svelte/src/types/compile.d.ts
@@ -1,12 +1,13 @@
 import type { Processed, CompileResult } from 'svelte/compiler';
 import type { SvelteRequest } from './id.d.ts';
 import type { ResolvedOptions } from './options.d.ts';
-import type { CustomPluginOptionsVite, Rollup } from 'vite';
+import type { CustomPluginOptionsVite, Environment, Rollup } from 'vite';
 
 export type CompileSvelte = (
 	svelteRequest: SvelteRequest,
 	code: string,
 	options: Partial<ResolvedOptions>,
+	environment: Environment,
 	sourcemap?: Rollup.SourceMap
 ) => Promise<CompileData>;
 

--- a/packages/vite-plugin-svelte/src/utils/compile.js
+++ b/packages/vite-plugin-svelte/src/utils/compile.js
@@ -21,7 +21,7 @@ export function createCompileSvelte() {
 	/** @type {StatCollection | undefined} */
 	let stats;
 	/** @type {CompileSvelte} */
-	return async function compileSvelte(svelteRequest, code, options, sourcemap) {
+	return async function compileSvelte(svelteRequest, code, options, environment, sourcemap) {
 		const { filename, normalizedFilename, cssId, ssr, raw } = svelteRequest;
 		const { emitCss = true } = options;
 		/** @type {Warning[]} */
@@ -72,7 +72,8 @@ export function createCompileSvelte() {
 		const dynamicCompileOptions = await options?.dynamicCompileOptions?.({
 			filename,
 			code: finalCode,
-			compileOptions
+			compileOptions,
+			environment
 		});
 		if (dynamicCompileOptions && log.debug.enabled) {
 			log.debug(

--- a/packages/vite-plugin-svelte/types/index.d.ts
+++ b/packages/vite-plugin-svelte/types/index.d.ts
@@ -1,5 +1,5 @@
 declare module '@sveltejs/vite-plugin-svelte' {
-	import type { InlineConfig, ResolvedConfig, Plugin, UserConfig } from 'vite';
+	import type { Environment, InlineConfig, ResolvedConfig, Plugin, UserConfig } from 'vite';
 	import type { CompileOptions, Warning, PreprocessorGroup } from 'svelte/compiler';
 	export type Options = Omit<SvelteConfig, 'vitePlugin'> & PluginOptionsInline;
 
@@ -69,6 +69,7 @@ declare module '@sveltejs/vite-plugin-svelte' {
 		 * `data.filename` - The file to be compiled
 		 * `data.code` - The preprocessed Svelte code
 		 * `data.compileOptions` - The current compiler options
+		 * `data.environment` - The current Vite environment, if available
 		 *
 		 * To change part of the compiler options, return an object with the changes you need.
 		 *
@@ -86,6 +87,7 @@ declare module '@sveltejs/vite-plugin-svelte' {
 			filename: string;
 			code: string;
 			compileOptions: Partial<CompileOptions>;
+			environment?: Environment;
 		}) => Promise<Partial<CompileOptions> | void> | Partial<CompileOptions> | void;
 
 		/**

--- a/packages/vite-plugin-svelte/types/index.d.ts
+++ b/packages/vite-plugin-svelte/types/index.d.ts
@@ -87,7 +87,7 @@ declare module '@sveltejs/vite-plugin-svelte' {
 			filename: string;
 			code: string;
 			compileOptions: Partial<CompileOptions>;
-			environment?: Environment;
+			environment: Environment;
 		}) => Promise<Partial<CompileOptions> | void> | Partial<CompileOptions> | void;
 
 		/**

--- a/packages/vite-plugin-svelte/types/index.d.ts
+++ b/packages/vite-plugin-svelte/types/index.d.ts
@@ -69,7 +69,7 @@ declare module '@sveltejs/vite-plugin-svelte' {
 		 * `data.filename` - The file to be compiled
 		 * `data.code` - The preprocessed Svelte code
 		 * `data.compileOptions` - The current compiler options
-		 * `data.environment` - The current Vite environment, if available
+		 * `data.environment` - The current Vite environment
 		 *
 		 * To change part of the compiler options, return an object with the changes you need.
 		 *

--- a/packages/vite-plugin-svelte/types/index.d.ts.map
+++ b/packages/vite-plugin-svelte/types/index.d.ts.map
@@ -27,6 +27,6 @@
 		null,
 		null
 	],
-	"mappings": ";;;aAGYA,OAAOA;;WAETC,mBAAmBA;;;;;;;;;;;kBAWZC,aAAaA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;kBAgFbC,YAAYA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;WAiDnBC,mBAAmBA;;;;;;;;;;;;;;;;WAgBnBC,oBAAoBA;;;;;;;;;;;;;;;MAezBC,SAASA;;kBAEGC,qBAAqBA;;;;;;;;;;;;;;kBAcrBC,gBAAgBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;iBCzKjBC,MAAMA;iBCGNC,cAAcA;iBCARC,gBAAgBA",
+	"mappings": ";;;aAGYA,OAAOA;;WAETC,mBAAmBA;;;;;;;;;;;kBAWZC,aAAaA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;kBAkFbC,YAAYA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;WAiDnBC,mBAAmBA;;;;;;;;;;;;;;;;WAgBnBC,oBAAoBA;;;;;;;;;;;;;;;MAezBC,SAASA;;kBAEGC,qBAAqBA;;;;;;;;;;;;;;kBAcrBC,gBAAgBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;iBC3KjBC,MAAMA;iBCGNC,cAAcA;iBCARC,gBAAgBA",
 	"ignoreList": []
 }


### PR DESCRIPTION
We closed #1318 but the suggestion we gave to use `perEnvironmentPlugin` didn't work because of the current vite setup that doesn't invoke (or invoke too late) `resolveConfig`.

I've [opened a bug in vite](https://github.com/vitejs/vite/issues/23176) to see if it's solvable, but in the meantime we can pass the environment to dynamic compile option to solve it.