### PR TITLE
chore: ignore unrelated security advisory

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,6 +31,7 @@ auditConfig:
     - 'GHSA-wf6x-7x77-mvgw' # we aren't using mergeDeep from immutable with public inputs
     - 'GHSA-48c2-rrv3-qjmp' # we don't consume public yaml files
     - 'GHSA-f886-m6hf-6m8v' # belongs to an optional peer dependency of Vite
+    - 'GHSA-2v37-7h3g-55p8' # belongs to an optional peer dependency of Vitefu
 
 overrides:
   # $ prefixed package names take their version from root package.json - this is like catalogs but without them


### PR DESCRIPTION
This PR gets our CI check passing again by ignoring an advisory for a really old version of Vite that VPS doesn't support but is listed in Vitefu's optional peer dep range
```
❯ pnpm audit --prod
┌─────────────────────┬────────────────────────────────────────────────────────┐
│ high                │ nanoid: custom generators can loop indefinitely when   │
│                     │ size is zero                                           │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Package             │ nanoid                                                 │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Vulnerable versions │ <3.3.17                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Patched versions    │ >=3.3.17                                               │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Paths               │ packages__vite-plugin-                                 │
│                     │ svelte>vitefu>vite>postcss>nanoid                      │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ More info           │ https://github.com/advisories/GHSA-2v37-7h3g-55p8      │
└─────────────────────┴────────────────────────────────────────────────────────┘
```