### PR TITLE
Fix/windows preprocess dependency path normalization

### DIFF
--- a/.changeset/quick-pandas-relax.md
+++ b/.changeset/quick-pandas-relax.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+fix: normalize paths consistently in `DependenciesCache` so style preprocessor dependencies (e.g. postcss `@import`/global-data files) correctly trigger HMR on Windows

--- a/packages/e2e-tests/hmr-postcss-mixins/__tests__/hmr-postcss-mixins.spec.ts
+++ b/packages/e2e-tests/hmr-postcss-mixins/__tests__/hmr-postcss-mixins.spec.ts
@@ -1,0 +1,25 @@
+import { isBuild, getText, getColor, editFile, browserLogs } from '~utils';
+
+test('should render App', async () => {
+	expect(await getText('#label')).toBe('postcss mixin case');
+	expect(await getColor('#label')).toBe('blue');
+});
+
+test('should not have failed requests', async () => {
+	browserLogs.forEach((msg) => {
+		expect(msg).not.toMatch('404');
+	});
+});
+
+if (!isBuild) {
+	describe('hmr', () => {
+		test('should apply updates when editing mixins.pcss, a dependency injected via @csstools/postcss-global-data', async () => {
+			expect(await getColor('#label')).toBe('blue');
+			editFile('src/mixins.pcss', (c) => c.replace('color: blue', 'color: magenta'));
+			// a single edit here can result in more than one HMR message reaching the browser (one for the style
+			// module, one a full component reload), so poll for the settled result rather than waiting for just the
+			// first message and asserting immediately
+			await expect.poll(() => getColor('#label')).toBe('magenta');
+		});
+	});
+}

--- a/packages/e2e-tests/hmr-postcss-mixins/index.html
+++ b/packages/e2e-tests/hmr-postcss-mixins/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Svelte App</title>
+	</head>
+	<body>
+		<script type="module" src="/src/main.js"></script>
+	</body>
+</html>

--- a/packages/e2e-tests/hmr-postcss-mixins/package.json
+++ b/packages/e2e-tests/hmr-postcss-mixins/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "e2e-tests-hmr-postcss-mixins",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "@csstools/postcss-global-data": "^4.0.0",
+    "@csstools/postcss-mixins": "^1.0.0",
+    "@sveltejs/vite-plugin-svelte": "workspace:^",
+    "svelte": "^5.45.4",
+    "vite": "catalog:"
+  },
+  "type": "module"
+}

--- a/packages/e2e-tests/hmr-postcss-mixins/src/App.svelte
+++ b/packages/e2e-tests/hmr-postcss-mixins/src/App.svelte
@@ -1,0 +1,7 @@
+<h1 id="label">postcss mixin case</h1>
+
+<style lang="postcss">
+	#label {
+		@apply --label-color;
+	}
+</style>

--- a/packages/e2e-tests/hmr-postcss-mixins/src/main.js
+++ b/packages/e2e-tests/hmr-postcss-mixins/src/main.js
@@ -1,0 +1,4 @@
+import App from './App.svelte';
+import { mount } from 'svelte';
+
+mount(App, { target: document.body });

--- a/packages/e2e-tests/hmr-postcss-mixins/src/mixins.pcss
+++ b/packages/e2e-tests/hmr-postcss-mixins/src/mixins.pcss
@@ -1,0 +1,3 @@
+@mixin --label-color() {
+	color: blue;
+}

--- a/packages/e2e-tests/hmr-postcss-mixins/svelte.config.js
+++ b/packages/e2e-tests/hmr-postcss-mixins/svelte.config.js
@@ -1,0 +1,7 @@
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+
+export default {
+	// Consult https://svelte.dev/docs/kit/integrations#vitePreprocess
+	// for more information about preprocessors
+	preprocess: vitePreprocess()
+};

--- a/packages/e2e-tests/hmr-postcss-mixins/vite.config.js
+++ b/packages/e2e-tests/hmr-postcss-mixins/vite.config.js
@@ -1,0 +1,28 @@
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+import { defineConfig } from 'vite';
+import globalData from '@csstools/postcss-global-data';
+import mixins from '@csstools/postcss-mixins';
+
+export default defineConfig(() => {
+	return {
+		plugins: [svelte()],
+		css: {
+			postcss: {
+				plugins: [globalData({ files: ['src/mixins.pcss'] }), mixins()]
+			}
+		},
+		build: {
+			// make build faster by skipping transforms and minification
+			target: 'esnext',
+			minify: false
+		},
+		server: {
+			watch: {
+				// During tests we edit the files too fast and sometimes chokidar
+				// misses change events, so enforce polling for consistency
+				usePolling: true,
+				interval: 100
+			}
+		}
+	};
+});

--- a/packages/vite-plugin-svelte/src/plugins/preprocess.js
+++ b/packages/vite-plugin-svelte/src/plugins/preprocess.js
@@ -12,6 +12,7 @@ import { log } from '../utils/log.js';
 import { arraify } from '../utils/options.js';
 import fs from 'node:fs';
 import path from 'node:path';
+import { normalizePath } from 'vite';
 
 /**
  * @param {PluginAPI} api
@@ -150,7 +151,7 @@ class DependenciesCache {
 		this.#server = server;
 		/** @type {(filename: string) => void} */
 		const emitChangeEventOnDependants = (filename) => {
-			const dependants = this.#dependants.get(filename);
+			const dependants = this.#dependants.get(normalizePath(filename));
 			dependants?.forEach((dependant) => {
 				if (fs.existsSync(dependant)) {
 					log.debug(
@@ -201,14 +202,16 @@ class DependenciesCache {
 		this.#dependencies.set(id, dependencies);
 		const removed = prevDependencies.filter((d) => !dependencies.includes(d));
 		const added = dependencies.filter((d) => !prevDependencies.includes(d));
-		added.forEach((d) => {
+		added.forEach((rawDep) => {
+			const d = normalizePath(rawDep);
 			this.#ensureWatchedFile(d);
 			if (!this.#dependants.has(d)) {
 				this.#dependants.set(d, new Set());
 			}
 			/** @type {Set<string>} */ (this.#dependants.get(d)).add(svelteRequest.filename);
 		});
-		removed.forEach((d) => {
+		removed.forEach((rawDep) => {
+			const d = normalizePath(rawDep);
 			/** @type {Set<string>} */ (this.#dependants.get(d)).delete(svelteRequest.filename);
 		});
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -403,6 +403,24 @@ importers:
         specifier: ^8.0.9
         version: 8.2.1(@types/node@22.20.1)(sass@1.102.0)(stylus@0.64.0)(yaml@2.9.0)
 
+  packages/e2e-tests/hmr-postcss-mixins:
+    devDependencies:
+      '@csstools/postcss-global-data':
+        specifier: ^4.0.0
+        version: 4.0.0(postcss@8.5.26)
+      '@csstools/postcss-mixins':
+        specifier: ^1.0.0
+        version: 1.0.0(postcss@8.5.26)
+      '@sveltejs/vite-plugin-svelte':
+        specifier: workspace:^
+        version: link:../../vite-plugin-svelte
+      svelte:
+        specifier: ^5.46.4
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
+      vite:
+        specifier: ^8.0.9
+        version: 8.2.1(@types/node@22.20.1)(sass@1.102.0)(stylus@0.64.0)(yaml@2.9.0)
+
   packages/e2e-tests/import-queries:
     devDependencies:
       '@sveltejs/vite-plugin-svelte':
@@ -834,9 +852,31 @@ packages:
     peerDependencies:
       '@csstools/css-tokenizer': ^3.0.4
 
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
   '@csstools/css-tokenizer@3.0.4':
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/postcss-global-data@4.0.0':
+    resolution: {integrity: sha512-mPKrL3Tzt8k1V+hTkU8XTH6JKRekB97oKHv/MekC9nfmRa+gMf1swlHRt8YK722sYN4xOipl17FZst99jsScLA==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      postcss: ^8.4
+
+  '@csstools/postcss-mixins@1.0.0':
+    resolution: {integrity: sha512-rz6qjT2w9L3k65jGc2dX+3oGiSrYQ70EZPDrINSmSVoVys7lLBFH0tvEa8DW2sr9cbRVD/W+1sy8+7bfu0JUfg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      postcss: ^8.4
 
   '@esbuild/aix-ppc64@0.19.12':
     resolution: {integrity: sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==}
@@ -3527,8 +3567,24 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
     optional: true
 
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
   '@csstools/css-tokenizer@3.0.4':
     optional: true
+
+  '@csstools/css-tokenizer@4.0.0': {}
+
+  '@csstools/postcss-global-data@4.0.0(postcss@8.5.26)':
+    dependencies:
+      postcss: 8.5.26
+
+  '@csstools/postcss-mixins@1.0.0(postcss@8.5.26)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+      postcss: 8.5.26
 
   '@esbuild/aix-ppc64@0.19.12':
     optional: true


### PR DESCRIPTION
This is my proposed fix/a result of my investigation into the issue behind #1394 

It's broken into the smaller single commit that normalizes the paths, which fixes the issue in manual testing, and a second commit with an e2e test that covers this particular case, but I'm not sure if that's too focused/granular. I was uncertain about including it but figured I might as well for completeness' sake.

Apologies in advance if I've missed a part of this process, I'm not super familiar with the PR process for open source type stuff.