### PR TITLE
fix: support exported snippets during dependency scanning

### DIFF
--- a/.changeset/tidy-snippets-scan.md
+++ b/.changeset/tidy-snippets-scan.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+fix dependency scanning for exported snippets in untyped module scripts

--- a/packages/e2e-tests/scan-deps/__tests__/scan-deps.spec.ts
+++ b/packages/e2e-tests/scan-deps/__tests__/scan-deps.spec.ts
@@ -12,5 +12,6 @@ describe('vite import scan', () => {
 		expect(await getText('#svelte4single')).toBe('svelte4single');
 		expect(await getText('#svelte4none')).toBe('svelte4none');
 		expect(await getText('#svelte4space')).toBe('svelte4space');
+		expect(await getText('#svelte5snippet')).toBe('svelte5snippet');
 	});
 });

--- a/packages/e2e-tests/scan-deps/src/App.svelte
+++ b/packages/e2e-tests/scan-deps/src/App.svelte
@@ -1,5 +1,5 @@
 <script>
-	import { svelte5 } from './Svelte5.svelte';
+	import { svelte5, svelte5snippet } from './Svelte5.svelte';
 	import { svelte4double } from './Svelte4DoubleQuote.svelte';
 	import { svelte4single } from './Svelte4SingleQuote.svelte';
 	import { svelte4none } from './Svelte4NoQuote.svelte';
@@ -11,3 +11,4 @@
 <div id="svelte4single">{svelte4single}</div>
 <div id="svelte4none">{svelte4none}</div>
 <div id="svelte4space">{svelte4space}</div>
+<div id="svelte5snippet">{@render svelte5snippet()}</div>

--- a/packages/e2e-tests/scan-deps/src/Svelte5.svelte
+++ b/packages/e2e-tests/scan-deps/src/Svelte5.svelte
@@ -1,3 +1,8 @@
 <script module>
 	export const svelte5 = 'svelte5';
+	export { svelte5snippet };
 </script>
+
+{#snippet svelte5snippet()}
+	svelte5snippet
+{/snippet}

--- a/packages/vite-plugin-svelte/src/plugins/setup-optimizer.js
+++ b/packages/vite-plugin-svelte/src/plugins/setup-optimizer.js
@@ -96,6 +96,7 @@ function rolldownOptimizerPlugin(api, environmentName, consumer, components) {
 		);
 		if (isScanner) {
 			delete plugin.buildStart;
+			delete plugin.transform;
 			delete plugin.buildEnd;
 			if (components) {
 				plugin.transform = {
@@ -104,8 +105,6 @@ function rolldownOptimizerPlugin(api, environmentName, consumer, components) {
 						return { code, moduleType: 'ts' };
 					}
 				};
-			} else {
-				delete plugin.transform;
 			}
 		} else {
 			plugin.transform = {

--- a/packages/vite-plugin-svelte/src/plugins/setup-optimizer.js
+++ b/packages/vite-plugin-svelte/src/plugins/setup-optimizer.js
@@ -98,6 +98,10 @@ function rolldownOptimizerPlugin(api, environmentName, consumer, components) {
 			delete plugin.buildStart;
 			delete plugin.transform;
 			delete plugin.buildEnd;
+			// treat all Svelte file script blocks as TypeScript for the sake of dependency
+			// scanning so that it doesn't treat exported snippets as a missing reference
+			// since they are only defined in the template. This is a lot cheaper than
+			// compiling every Svelte file
 			if (components) {
 				plugin.transform = {
 					filter: { id: includeRe },

--- a/packages/vite-plugin-svelte/src/plugins/setup-optimizer.js
+++ b/packages/vite-plugin-svelte/src/plugins/setup-optimizer.js
@@ -99,7 +99,7 @@ function rolldownOptimizerPlugin(api, environmentName, consumer, components) {
 			delete plugin.buildEnd;
 			if (components) {
 				plugin.transform = {
-					filter: { id: /^virtual-module:[^?#]+\.svelte(?:[?#]|$)/ },
+					filter: { id: includeRe },
 					handler(code) {
 						return { code, moduleType: 'ts' };
 					}

--- a/packages/vite-plugin-svelte/src/plugins/setup-optimizer.js
+++ b/packages/vite-plugin-svelte/src/plugins/setup-optimizer.js
@@ -96,8 +96,17 @@ function rolldownOptimizerPlugin(api, environmentName, consumer, components) {
 		);
 		if (isScanner) {
 			delete plugin.buildStart;
-			delete plugin.transform;
 			delete plugin.buildEnd;
+			if (components) {
+				plugin.transform = {
+					filter: { id: /^virtual-module:[^?#]+\.svelte(?:[?#]|$)/ },
+					handler(code) {
+						return { code, moduleType: 'ts' };
+					}
+				};
+			} else {
+				delete plugin.transform;
+			}
 		} else {
 			plugin.transform = {
 				filter: { id: includeRe },


### PR DESCRIPTION
Vite's dependency scanner rejects exported top-level snippets from untyped `<script module>` blocks because their bindings exist in the Svelte template, not the extracted script.

This PR tries to treat Svelte script blocks as TypeScript during scanning, matching the working `lang="ts"` behavior without compiling every component.

Fixes #1356