### PR TITLE
fix: correctly apply child HMR after parent update

### DIFF
--- a/.changeset/quiet-cats-update.md
+++ b/.changeset/quiet-cats-update.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+fix: correctly apply HMR to child components after updating its parent

--- a/packages/e2e-tests/hmr/__tests__/hmr.spec.ts
+++ b/packages/e2e-tests/hmr/__tests__/hmr.spec.ts
@@ -126,6 +126,18 @@ if (!isBuild) {
 			expect(await getText('#hmr-test-3 .counter')).toBe('0');
 		});
 
+		test('should update a child component after updating its parent', async () => {
+			await updateHmrTest((content) =>
+				content.replace(
+					"const label = 'hmr-test-updated'",
+					"const label = 'hmr-test-updated-again'"
+				)
+			);
+			expect(await getText('#hmr-test-1 .label')).toBe('hmr-test-updated-again');
+			expect(await getText('#hmr-test-2 .label')).toBe('hmr-test-updated-again');
+			expect(await getText('#hmr-test-3 .label')).toBe('hmr-test-updated-again');
+		});
+
 		test('should preserve state of store when editing hmr-stores.js', async () => {
 			// change state
 			await (await getEl('#hmr-test-2 .increment')).click();

--- a/packages/vite-plugin-svelte/src/plugins/hot-update.js
+++ b/packages/vite-plugin-svelte/src/plugins/hot-update.js
@@ -102,6 +102,20 @@ export function hotUpdate(api) {
 					const affectedModules = [];
 					const prevResults = svelteModules.map((m) => transformResultCache.get(m.id));
 
+					// Svelte components self-accept updates at their stable URLs. If a
+					// child was updated earlier, Vite would otherwise timestamp its import
+					// while eagerly transforming the parent, creating a second browser
+					// module instance. Keep subsequent transforms on the stable URL until
+					// the child itself receives another update timestamp.
+					for (const mod of svelteModules) {
+						for (const imported of mod.importedModules) {
+							const importedRequest = imported.id && idParser(imported.id, false);
+							if (importedRequest && !importedRequest.query.type) {
+								imported.lastHMRTimestamp = 0;
+							}
+						}
+					}
+
 					/** @type {Set<string>} */
 					const seen = new Set();
 					/** @param {string} url */

--- a/packages/vite-plugin-svelte/src/plugins/hot-update.js
+++ b/packages/vite-plugin-svelte/src/plugins/hot-update.js
@@ -90,6 +90,20 @@ export function hotUpdate(api) {
 					const nonSvelteModules = [];
 					for (const mod of modules) {
 						if (transformResultCache.has(mod.id)) {
+							// If an imported Svelte module was updated before this, it would be
+							// imported on the browser with that timestamp. This can cause
+							// subsequent edits to the imported module to never be reflected
+							// in the browser. Therefore, we strip the timestamp to ensure that
+							// the HMR update imports the module without a stale timestamp query
+							if (this.environment.name === 'client') {
+								for (const imported of mod.importedModules) {
+									const importedRequest = imported.id && idParser(imported.id, false);
+									if (importedRequest && !importedRequest.query.type) {
+										imported.lastHMRTimestamp = 0;
+									}
+								}
+							}
+
 							svelteModules.push(mod);
 						} else {
 							nonSvelteModules.push(mod);
@@ -101,20 +115,6 @@ export function hotUpdate(api) {
 					}
 					const affectedModules = [];
 					const prevResults = svelteModules.map((m) => transformResultCache.get(m.id));
-
-					// If an imported Svelte module was updated earlier, the browser would
-					// have already created a module instance. Updating its timestamp again
-					// from a parent update would create a second instance. We need to avoid
-					// this since future updates to the imported module will only update the
-					// first instance
-					for (const mod of svelteModules) {
-						for (const imported of mod.importedModules) {
-							const importedRequest = imported.id && idParser(imported.id, false);
-							if (importedRequest && !importedRequest.query.type) {
-								imported.lastHMRTimestamp = 0;
-							}
-						}
-					}
 
 					/** @type {Set<string>} */
 					const seen = new Set();

--- a/packages/vite-plugin-svelte/src/plugins/hot-update.js
+++ b/packages/vite-plugin-svelte/src/plugins/hot-update.js
@@ -102,11 +102,11 @@ export function hotUpdate(api) {
 					const affectedModules = [];
 					const prevResults = svelteModules.map((m) => transformResultCache.get(m.id));
 
-					// Svelte components self-accept updates at their stable URLs. If a
-					// child was updated earlier, Vite would otherwise timestamp its import
-					// while eagerly transforming the parent, creating a second browser
-					// module instance. Keep subsequent transforms on the stable URL until
-					// the child itself receives another update timestamp.
+					// If an imported Svelte module was updated earlier, the browser would
+					// have already created a module instance. Updating its timestamp again
+					// from a parent update would create a second instance. We need to avoid
+					// this since future updates to the imported module will only update the
+					// first instance
 					for (const mod of svelteModules) {
 						for (const imported of mod.importedModules) {
 							const importedRequest = imported.id && idParser(imported.id, false);


### PR DESCRIPTION
Fixes #1320

This PR strips the timestamp from imported Svelte modules so that the parent module doesn't continue to import a stale version of it in the browser after the imported one has been edited.