### PR TITLE
fix: don't forward the bundler's combined sourcemap to svelte.compile

### DIFF
--- a/.changeset/sourcemap-double-chaining.md
+++ b/.changeset/sourcemap-double-chaining.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/vite-plugin-svelte': patch
+---
+
+fix: no longer forward the bundler's combined sourcemap to `svelte.compile`. The transform hook previously passed `this.getCombinedSourcemap()` as svelte's `sourcemap` option; svelte composed it into its own map, and Vite/Rollup then chained the same upstream transforms again after the hook returned. This double composition interpreted source coordinates (already pointing at the original file) as generated coordinates of the upstream map, so mapping segments were dropped: stack traces and devtools locations for code transformed by plugins running before svelte (e.g. plugins using MagicString) fell back to the start of the script block instead of the real location. The compile hook now only forwards the sourcemap produced by the plugin's own preprocess hook, which is the external-preprocessor map svelte needs to chain preprocessor sources (such as scss) into its css sourcemap; all other transform maps are left for the bundler to chain exactly once

--- a/packages/e2e-tests/sourcemap-pretransform/__tests__/sourcemap-pretransform.spec.ts
+++ b/packages/e2e-tests/sourcemap-pretransform/__tests__/sourcemap-pretransform.spec.ts
@@ -1,0 +1,139 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { getText, isBuild, page, testDir } from '~utils';
+import { expect } from 'vitest';
+
+// minimal sourcemap VLQ decoder (no third-party dependency needed).
+// returns decoded lines; each segment is absolute:
+// [generatedColumn, sourceIndex?, originalLine?, originalColumn?, nameIndex?]
+const B64 = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+const CHAR_TO_INT: Record<string, number> = {};
+for (let i = 0; i < B64.length; i++) {
+	CHAR_TO_INT[B64[i]] = i;
+}
+
+function decodeMappings(mappings: string): number[][][] {
+	const lines: number[][][] = [];
+	let line: number[][] = [];
+	let segment: number[] = [];
+	const state = [0, 0, 0, 0, 0];
+	let i = 0;
+
+	const pushSegment = () => {
+		if (segment.length === 0) return;
+		state[0] += segment[0];
+		const absolute: number[] = [state[0]];
+		if (segment.length >= 4) {
+			state[1] += segment[1];
+			state[2] += segment[2];
+			state[3] += segment[3];
+			absolute.push(state[1], state[2], state[3]);
+			if (segment.length === 5) {
+				state[4] += segment[4];
+				absolute.push(state[4]);
+			}
+		}
+		line.push(absolute);
+		segment = [];
+	};
+
+	while (i < mappings.length) {
+		const ch = mappings[i];
+		if (ch === ';') {
+			pushSegment();
+			lines.push(line);
+			line = [];
+			state[0] = 0;
+			i++;
+			continue;
+		}
+		if (ch === ',') {
+			pushSegment();
+			i++;
+			continue;
+		}
+		let shift = 0;
+		let value = 0;
+		let digit: number;
+		do {
+			digit = CHAR_TO_INT[mappings[i++]];
+			value += (digit & 31) << shift;
+			shift += 5;
+		} while (digit & 32);
+		const negative = value & 1;
+		segment.push(negative ? -(value >> 1) : value >> 1);
+	}
+	pushSegment();
+	lines.push(line);
+	return lines;
+}
+
+test('should render the component', async () => {
+	expect(await getText('body')).toContain('Hello, see devtools');
+});
+
+if (!isBuild) {
+	// https://github.com/sveltejs/svelte/issues/18778
+	// a plugin that transforms .svelte code before the svelte plugin must not
+	// break sourcemap chaining: the generated location of `console.error` must
+	// map back to its real position in the original App.svelte source.
+	test('pre-transform sourcemaps chain back to the original svelte source', async () => {
+		// expected original position, read from the untouched source fixture
+		const source = fs.readFileSync(path.resolve(testDir, 'src/App.svelte'), 'utf8');
+		const sourceLines = source.split('\n');
+		const expectedLine = sourceLines.findIndex((line) => line.includes("console.error('helo')"));
+		const expectedColumn = sourceLines[expectedLine].indexOf('console.error');
+		expect(expectedLine).toBeGreaterThanOrEqual(0);
+
+		const text = await page.evaluate(async () => {
+			// runs in the browser, not in node
+			// eslint-disable-next-line n/no-unsupported-features/node-builtins
+			const res = await fetch('/src/App.svelte');
+			if (!res.ok) {
+				throw new Error(`failed to load App.svelte: ${res.status}`);
+			}
+			return res.text();
+		});
+
+		const mapMatch = text.match(/sourceMappingURL=data:application\/json;base64,([A-Za-z0-9+/=]+)/);
+		expect(mapMatch, 'module should contain an inline sourcemap').toBeTruthy();
+		const map = JSON.parse(Buffer.from(mapMatch![1], 'base64').toString('utf8'));
+
+		const generatedLines = text.split('\n');
+		const errorLineIndex = generatedLines.findIndex(
+			(line) => line.includes('console.error') && line.includes('helo')
+		);
+		expect(errorLineIndex).toBeGreaterThanOrEqual(0);
+
+		const decoded = decodeMappings(map.mappings);
+		const segments = decoded[errorLineIndex] ?? [];
+		const mappedSegments = segments.filter((segment) => segment.length >= 4);
+
+		expect(
+			mappedSegments.length,
+			'the generated console.error line must not lose its sourcemap segments'
+		).toBeGreaterThan(0);
+
+		// svelte maps script statements to the start of the source line
+		// (column 0), so assert the mapped line is the console.error line and
+		// that the mapped column lies on that line before the statement
+		const matching = mappedSegments.find(
+			(segment) =>
+				segment[2] === expectedLine &&
+				segment[3] >= 0 &&
+				segment[3] <= expectedColumn &&
+				// if sourcesContent is present, verify the mapped source line is
+				// really the console.error line
+				(map.sourcesContent?.[segment[1]]
+					? map.sourcesContent[segment[1]].split('\n')[segment[2]]?.includes('console.error')
+					: true)
+		);
+		expect(
+			matching,
+			`console.error should map back to the console.error line (line ${expectedLine + 1}) of App.svelte`
+		).toBeTruthy();
+
+		const sourceName = map.sources[matching![1]];
+		expect(sourceName).toMatch(/App\.svelte(\?|$)/);
+	});
+}

--- a/packages/e2e-tests/sourcemap-pretransform/index.html
+++ b/packages/e2e-tests/sourcemap-pretransform/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
+
+		<title>Svelte app</title>
+
+		<script type="module" src="/src/main.js"></script>
+	</head>
+
+	<body></body>
+</html>

--- a/packages/e2e-tests/sourcemap-pretransform/package.json
+++ b/packages/e2e-tests/sourcemap-pretransform/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "e2e-tests-sourcemap-pretransform",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "@sveltejs/vite-plugin-svelte": "workspace:^",
+    "magic-string": "^1.0.0",
+    "svelte": "^5.45.4",
+    "vite": "catalog:"
+  }
+}

--- a/packages/e2e-tests/sourcemap-pretransform/src/App.svelte
+++ b/packages/e2e-tests/sourcemap-pretransform/src/App.svelte
@@ -1,0 +1,7 @@
+<script>
+	let x = 1;
+
+	console.error('helo');
+</script>
+
+Hello, see devtools

--- a/packages/e2e-tests/sourcemap-pretransform/src/main.js
+++ b/packages/e2e-tests/sourcemap-pretransform/src/main.js
@@ -1,0 +1,3 @@
+import App from './App.svelte';
+import { mount } from 'svelte';
+mount(App, { target: document.body });

--- a/packages/e2e-tests/sourcemap-pretransform/vite.config.js
+++ b/packages/e2e-tests/sourcemap-pretransform/vite.config.js
@@ -1,0 +1,29 @@
+import { defineConfig } from 'vite';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+import MagicString from 'magic-string';
+
+// a plugin that transforms `.svelte` code before the svelte plugin runs and
+// returns its own sourcemap, just like third-party plugins in the wild do
+function pretransformPlugin() {
+	return {
+		name: 'pretransform',
+		transform(code, id) {
+			if (!id.includes('App.svelte')) {
+				return null;
+			}
+			const ms = new MagicString(code);
+			// inject a line at the very start of the script block
+			const insertAt = code.indexOf('<script>') + '<script>'.length;
+			ms.appendRight(insertAt, 'let injected = 42;\n');
+			return {
+				code: ms.toString(),
+				map: ms.generateMap()
+			};
+		}
+	};
+}
+
+// https://vite.dev/config/
+export default defineConfig({
+	plugins: [pretransformPlugin(), svelte({})]
+});

--- a/packages/vite-plugin-svelte/src/index.js
+++ b/packages/vite-plugin-svelte/src/index.js
@@ -27,7 +27,10 @@ export function svelte(inlineOptions) {
 	}
 	/** @type {PluginAPI} */
 	// @ts-expect-error initialize empty to guard against early use
-	const api = {}; // initialized by configure plugin, used in others
+	const api = {
+		// maps of code produced by our own preprocess hook, keyed by svelte request id
+		preprocessedMaps: new Map()
+	}; // rest is initialized by configure plugin, used in others
 	return [
 		{ name: 'vite-plugin-svelte' }, // marker for detection logic in other plugins that expect this name
 		configure(api, inlineOptions),

--- a/packages/vite-plugin-svelte/src/plugins/compile.js
+++ b/packages/vite-plugin-svelte/src/plugins/compile.js
@@ -38,12 +38,17 @@ export function compile(api) {
 				}
 				let compileData;
 				try {
+					// Only forward the map from our own preprocess hook to svelte. Never
+					// use this.getCombinedSourcemap(): it also contains maps of transforms
+					// from other plugins, which the bundler already chains again after this
+					// hook returns. Forwarding them makes svelte compose them a second
+					// time, dropping mapping segments (sveltejs/svelte#18778).
 					compileData = await compileSvelte(
 						svelteRequest,
 						code,
 						options,
 						this.environment,
-						this.getCombinedSourcemap()
+						api.preprocessedMaps.get(svelteRequest.id)
 					);
 				} catch (e) {
 					throw toRollupError(e, options);

--- a/packages/vite-plugin-svelte/src/plugins/preprocess.js
+++ b/packages/vite-plugin-svelte/src/plugins/preprocess.js
@@ -85,6 +85,17 @@ export function preprocess(api) {
 					if (preprocessed.map) {
 						// @ts-expect-error type differs but should work
 						result.map = preprocessed.map;
+						// hand our own preprocess map to the compile hook so it can forward
+						// it to svelte.compile as the external-preprocessor map (svelte
+						// needs it to chain preprocessor sources like scss into css.map)
+						api.preprocessedMaps.set(
+							svelteRequest.id,
+							/** @type {import('vite').Rollup.SourceMap} */ (
+								/** @type {unknown} */ (preprocessed.map)
+							)
+						);
+					} else {
+						api.preprocessedMaps.delete(svelteRequest.id);
 					}
 					return result;
 				} catch (e) {

--- a/packages/vite-plugin-svelte/src/types/compile.d.ts
+++ b/packages/vite-plugin-svelte/src/types/compile.d.ts
@@ -8,7 +8,7 @@ export type CompileSvelte = (
 	code: string,
 	options: Partial<ResolvedOptions>,
 	environment: Environment,
-	sourcemap?: Rollup.SourceMap
+	preprocessorMap?: Rollup.SourceMap
 ) => Promise<CompileData>;
 
 export type PreprocessSvelte = (

--- a/packages/vite-plugin-svelte/src/types/plugin-api.d.ts
+++ b/packages/vite-plugin-svelte/src/types/plugin-api.d.ts
@@ -1,10 +1,17 @@
 import type { ResolvedOptions } from './options.d.ts';
 import type { IdFilter, IdParser } from './id.d.ts';
 import type { CompileSvelte } from './compile.d.ts';
+import type { Rollup } from 'vite';
 
 export interface PluginAPI {
 	options: ResolvedOptions;
 	filter: IdFilter;
 	idParser: IdParser;
 	compileSvelte: CompileSvelte;
+	/**
+	 * Sourcemaps returned by our own preprocess hook, keyed by svelte request id.
+	 * The compile hook forwards them to `svelte.compile` as the external-preprocessor
+	 * map (needed for `css.map` chaining, e.g. scss sources).
+	 */
+	preprocessedMaps: Map<string, Rollup.SourceMap>;
 }

--- a/packages/vite-plugin-svelte/src/utils/compile.js
+++ b/packages/vite-plugin-svelte/src/utils/compile.js
@@ -21,7 +21,7 @@ export function createCompileSvelte() {
 	/** @type {StatCollection | undefined} */
 	let stats;
 	/** @type {CompileSvelte} */
-	return async function compileSvelte(svelteRequest, code, options, environment, sourcemap) {
+	return async function compileSvelte(svelteRequest, code, options, environment, preprocessorMap) {
 		const { filename, normalizedFilename, cssId, ssr, raw } = svelteRequest;
 		const { emitCss = true } = options;
 		/** @type {Warning[]} */
@@ -88,8 +88,15 @@ export function createCompileSvelte() {
 					...dynamicCompileOptions
 				}
 			: compileOptions;
-		if (sourcemap) {
-			finalCompileOptions.sourcemap = sourcemap;
+		// Forward only the external-preprocessor map from our own preprocess hook.
+		// It maps the code svelte is compiling back to the original source, and svelte
+		// needs it to chain preprocessor sources (e.g. scss) into css.map. Never pass
+		// the bundler's combined sourcemap here: it also contains maps from unrelated
+		// transforms, which Vite/Rollup chain again after this hook returns. Composing
+		// them in svelte too double-composes the maps and drops mapping segments
+		// (sveltejs/svelte#18778).
+		if (preprocessorMap) {
+			finalCompileOptions.sourcemap = preprocessorMap;
 		}
 		const endStat = stats?.start(filename);
 		/** @type {CompileResult} */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -625,6 +625,21 @@ importers:
         specifier: ^8.0.9
         version: 8.2.2(@types/node@22.20.1)(sass@1.103.1)(stylus@0.64.0)(yaml@2.9.0)
 
+  packages/e2e-tests/sourcemap-pretransform:
+    devDependencies:
+      '@sveltejs/vite-plugin-svelte':
+        specifier: workspace:^
+        version: link:../../vite-plugin-svelte
+      magic-string:
+        specifier: ^1.0.0
+        version: 1.2.2
+      svelte:
+        specifier: ^5.46.4
+        version: 5.56.10(@typescript-eslint/types@8.68.0)
+      vite:
+        specifier: ^8.0.9
+        version: 8.2.2(@types/node@22.20.1)(sass@1.103.1)(stylus@0.64.0)(yaml@2.9.0)
+
   packages/e2e-tests/svelte-preprocess:
     devDependencies:
       '@sveltejs/vite-plugin-svelte':


### PR DESCRIPTION
### The problem

If another Vite plugin transforms `.svelte` files before `@sveltejs/vite-plugin-svelte` and returns a sourcemap (e.g. a MagicString-based plugin that injects code), the final sourcemap in the browser loses mappings for those transformed files. `console.error` calls and other statements show up in DevTools at the top of the `<script>` block instead of their real line numbers.

Reported in sveltejs/svelte#18778.

### Why it happens

The compile transform hook was passing `this.getCombinedSourcemap()` into `svelte.compile` as the `sourcemap` option. So the chain looked like:

1. upstream transform produces map M1 (original → injected)
2. svelte gets M1 as input, produces M2 (injected → compiled) with M1 already chained in — the result maps compiled → original
3. Vite then chains M2 with M1 **again** after the hook returns, because it does the same chaining for every transform

The second merge tries to look up "compiled → original" source coordinates *as if they were generated coordinates of M1*. They're not — they're already in the original domain — so `traceSegment` returns null and those segments get dropped. The end result is that generated lines that should have mappings have none.

### What this change does

- The compile hook no longer forwards the bundler's combined sourcemap to Svelte.
- Instead, it only forwards the map produced by **our own preprocess hook** (stored in `api.preprocessedMaps` keyed by request id). Svelte still needs this external-preprocessor map to chain preprocessor sources (like scss files) into `css.map`.
- All other transform maps are left for the bundler to chain exactly once, which is what the standard transform hook contract expects.

The `compile-module` hook already followed this pattern (it never passed a combined map in), so this brings the `compile` hook in line.

### Testing

- Added a new e2e test in `packages/e2e-tests/sourcemap-pretransform`: a pre-svelte MagicString transform injects a line into `App.svelte`, and we decode the inline sourcemap of the served module to verify the generated `console.error` line maps back to the correct original source line.
  - Fails without the fix (0 mapped segments on the console.error line)
  - Passes with the fix
- Existing `css-dev-sourcemap` e2e still passes (scss preprocessor sources still chain correctly into css.map), both in serve and build mode.
- All 38 unit tests pass.
- Full serve e2e suite: 101 tests pass / 2 pre-existing skips, 0 regressions.
- `check:types`, `eslint`, `prettier` all clean.

### Changeset

Added as `.changeset/sourcemap-double-chaining.md` (patch for `@sveltejs/vite-plugin-svelte`).
